### PR TITLE
Add marketplace checks and expand plugin manifest (v1.4)

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -11,7 +11,8 @@ Personal Claude Code configuration repository (dotfiles-style). Stores hooks, co
 ```
 hooks/       # Custom hooks (shell commands triggered by Claude Code events)
 commands/    # Custom slash commands
-scripts/     # Standalone utility scripts
+scripts/     # Standalone utility scripts + configure-claude installer
+config/      # Global settings manifest (plugins, MCP servers, statusLine)
 plugins/     # Claude Code plugins
 skills/      # Custom skills
 agents/      # Custom agent configurations
@@ -19,7 +20,7 @@ agents/      # Custom agent configurations
 
 ## Versioning
 
-Current version: **1.2**
+Current version: **1.4**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -27,6 +28,8 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
+- **1.3** — Added `configure-claude.js` installer script, `config/global-settings.json` manifest; skill now invokes the script directly
 - **1.2** — Added `configure-claude` skill: installs hooks and scripts into any project's `.claude/` directory
 - **1.1** — Added hooks system: hooks.json config, 6 hook scripts (session lifecycle, console.log checks, compact suggestions), lib utilities (utils, package-manager, session-aliases, session-manager)
 - **1.0** — Initial setup: repo structure, CLAUDE.md, README.md

--- a/claude/README.md
+++ b/claude/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.2**
+**Version: 1.4**
 
 ## Getting started
 
@@ -11,7 +11,8 @@ Clone this repo and symlink or copy the relevant directories into your project's
 ```
 hooks/       # Shell commands triggered by Claude Code events
 commands/    # Custom slash commands
-scripts/     # Standalone utility scripts
+scripts/     # Standalone utility scripts + configure-claude installer
+config/      # Global settings manifest (plugins, MCP servers, statusLine)
 plugins/     # Claude Code plugins
 skills/      # Custom skills
 agents/      # Custom agent configurations
@@ -19,6 +20,8 @@ agents/      # Custom agent configurations
 
 ## Changelog
 
+- **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
+- **1.3** — Added `configure-claude.js` installer script + `config/global-settings.json` manifest
 - **1.2** — Added `configure-claude` skill for installing configs into projects
 - **1.1** — Added hooks system: hooks.json config, hook scripts, lib utilities
 - **1.0** — Initial setup: repo structure, CLAUDE.md, README.md

--- a/claude/config/global-settings.json
+++ b/claude/config/global-settings.json
@@ -25,5 +25,44 @@
     "type": "command",
     "command": "npx -y ccstatusline@latest",
     "padding": 0
+  },
+  "ccstatusline": {
+    "version": 3,
+    "lines": [
+      [
+        { "id": "1", "type": "model", "color": "cyan" },
+        { "id": "2", "type": "separator" },
+        { "id": "3", "type": "context-length", "color": "brightBlack" },
+        { "id": "754ddbe7-60dd-4e85-a59d-9fd8724c651f", "type": "separator" },
+        { "id": "13205302-b48a-4630-a8b8-22f23ffd38c1", "type": "tokens-input" },
+        { "id": "4", "type": "separator" },
+        { "id": "5", "type": "tokens-output", "color": "magenta" },
+        { "id": "6", "type": "separator" },
+        { "id": "7", "type": "context-percentage", "color": "yellow" }
+      ],
+      [
+        { "id": "93d28a9e-293d-431b-aad2-dedb9065dd50", "type": "git-branch" },
+        { "id": "048d4592-7c85-4cf9-ab9a-25fd1035772f", "type": "separator" },
+        { "id": "9e80beb0-996c-4b5f-96a4-351b557286dc", "type": "git-changes" },
+        { "id": "17800866-3a68-401a-b09d-1357392a4358", "type": "separator" },
+        { "id": "652f7038-3f15-44a1-93fb-4dac65fb4e26", "type": "git-worktree" }
+      ],
+      [
+        { "id": "6e2eed20-3334-4d1f-965c-0e1e786a0224", "type": "current-working-dir" }
+      ]
+    ],
+    "flexMode": "full",
+    "compactThreshold": 60,
+    "colorLevel": 2,
+    "inheritSeparatorColors": false,
+    "globalBold": false,
+    "powerline": {
+      "enabled": false,
+      "separators": [""],
+      "separatorInvertBackground": [false],
+      "startCaps": [],
+      "endCaps": [],
+      "autoAlign": false
+    }
   }
 }

--- a/claude/config/global-settings.json
+++ b/claude/config/global-settings.json
@@ -1,0 +1,29 @@
+{
+  "marketplaces": [
+    { "name": "claude-plugins-official", "repo": "anthropics/claude-plugins-official" },
+    { "name": "claude-code-plugins", "repo": "anthropics/claude-code" },
+    { "name": "superpowers-marketplace", "repo": "obra/superpowers-marketplace" }
+  ],
+  "plugins": [
+    "commit-commands@claude-plugins-official",
+    "superpowers@claude-plugins-official",
+    "claude-md-management@claude-plugins-official",
+    "hookify@claude-plugins-official",
+    "typescript-lsp@claude-plugins-official",
+    "pyright-lsp@claude-plugins-official",
+    "code-simplifier@claude-plugins-official",
+    "code-review@claude-plugins-official",
+    "pr-review-toolkit@claude-plugins-official",
+    "security-guidance@claude-plugins-official",
+    "frontend-design@claude-plugins-official",
+    "feature-dev@claude-plugins-official"
+  ],
+  "mcpServers": [
+    "sequential-thinking"
+  ],
+  "statusLine": {
+    "type": "command",
+    "command": "npx -y ccstatusline@latest",
+    "padding": 0
+  }
+}

--- a/claude/scripts/configure-claude.js
+++ b/claude/scripts/configure-claude.js
@@ -46,7 +46,7 @@ function readJsonSync(filePath) {
 function resolveHookPaths(obj, claudeConfigDir) {
   const json = JSON.stringify(obj);
   const safeDir = claudeConfigDir.replace(/\\/g, '\\\\');
-  return JSON.parse(json.replace(/\$\{CLAUDE_CONFIG_DIR\}/g, safeDir));
+  return JSON.parse(json.replace(/\$\{CLAUDE_CONFIG_DIR\}/g, () => safeDir));
 }
 
 function installCcstatuslineConfig(manifest) {
@@ -196,7 +196,12 @@ function checkGlobalSettings(manifest, projectSettingsPath) {
 
   // Check MCP servers
   if (manifest.mcpServers) {
-    const enabledMcp = globalLocal?.enabledMcpServers || [];
+    const rawMcp = globalLocal?.enabledMcpServers;
+    const enabledMcp = Array.isArray(rawMcp)
+      ? rawMcp
+      : (rawMcp && typeof rawMcp === 'object')
+        ? Object.keys(rawMcp).filter(k => rawMcp[k])
+        : [];
     for (const server of manifest.mcpServers) {
       if (enabledMcp.includes(server)) {
         console.log(`  ✓ MCP server: ${server}`);

--- a/claude/scripts/configure-claude.js
+++ b/claude/scripts/configure-claude.js
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+/**
+ * configure-claude.js
+ *
+ * Installs Claude Code hooks, scripts, and config into a target project's .claude/ directory.
+ * Also checks global ~/.claude/settings.json against the expected manifest.
+ *
+ * Usage: node configure-claude.js [target-directory]
+ *   target-directory defaults to cwd
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_REPO = path.resolve(__dirname, '..');
+const HOOKS_JSON = path.join(CONFIG_REPO, 'hooks', 'hooks.json');
+const GLOBAL_MANIFEST = path.join(CONFIG_REPO, 'config', 'global-settings.json');
+const SCRIPTS_HOOKS = path.join(CONFIG_REPO, 'scripts', 'hooks');
+const SCRIPTS_LIB = path.join(CONFIG_REPO, 'scripts', 'lib');
+const HOME_SETTINGS = path.join(require('os').homedir(), '.claude', 'settings.json');
+const HOME_SETTINGS_LOCAL = path.join(require('os').homedir(), '.claude', 'settings.local.json');
+const KNOWN_MARKETPLACES = path.join(require('os').homedir(), '.claude', 'plugins', 'known_marketplaces.json');
+
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function readJsonSync(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function resolveHookPaths(obj, claudeConfigDir) {
+  const json = JSON.stringify(obj);
+  return JSON.parse(json.replace(/\$\{CLAUDE_CONFIG_DIR\}/g, claudeConfigDir));
+}
+
+function main() {
+  const targetDir = path.resolve(process.argv[2] || process.cwd());
+  const claudeDir = path.join(targetDir, '.claude');
+  const settingsPath = path.join(claudeDir, 'settings.json');
+
+  console.log(`\nConfiguring Claude Code for: ${targetDir}\n`);
+
+  // 1. Create .claude/ directory
+  fs.mkdirSync(claudeDir, { recursive: true });
+  console.log(`  ✓ Ensured ${claudeDir} exists`);
+
+  // 2. Copy scripts/hooks/ and scripts/lib/
+  const destHooks = path.join(claudeDir, 'scripts', 'hooks');
+  const destLib = path.join(claudeDir, 'scripts', 'lib');
+
+  copyDirSync(SCRIPTS_HOOKS, destHooks);
+  console.log(`  ✓ Copied hook scripts → ${destHooks}`);
+
+  copyDirSync(SCRIPTS_LIB, destLib);
+  console.log(`  ✓ Copied lib scripts  → ${destLib}`);
+
+  // 3. Read hooks.json from config repo
+  const hooksConfig = readJsonSync(HOOKS_JSON);
+  if (!hooksConfig) {
+    console.error('  ✗ Could not read hooks.json from config repo');
+    process.exit(1);
+  }
+
+  // 4. Resolve ${CLAUDE_CONFIG_DIR} to target's .claude path
+  const resolvedHooks = resolveHookPaths(hooksConfig.hooks, claudeDir);
+
+  // 5. Merge hooks into target settings.json
+  const existingSettings = readJsonSync(settingsPath) || {};
+  const merged = {
+    ...existingSettings,
+    $schema: hooksConfig.$schema || existingSettings.$schema,
+    hooks: resolvedHooks,
+  };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+  console.log(`  ✓ Merged hooks into ${settingsPath}`);
+
+  // Verify no unresolved placeholders remain
+  const written = fs.readFileSync(settingsPath, 'utf8');
+  if (written.includes('${CLAUDE_CONFIG_DIR}')) {
+    console.error('  ✗ WARNING: Unresolved ${CLAUDE_CONFIG_DIR} found in settings.json');
+  } else {
+    console.log('  ✓ All hook paths resolved (no ${CLAUDE_CONFIG_DIR} remaining)');
+  }
+
+  // 6. Check global settings against manifest
+  console.log('\n--- Global settings check ---\n');
+  const manifest = readJsonSync(GLOBAL_MANIFEST);
+  if (!manifest) {
+    console.log('  ⚠ Could not read global manifest, skipping global check');
+  } else {
+    checkGlobalSettings(manifest);
+  }
+
+  console.log('\nDone!\n');
+}
+
+function checkGlobalSettings(manifest) {
+  const globalSettings = readJsonSync(HOME_SETTINGS);
+  const globalLocal = readJsonSync(HOME_SETTINGS_LOCAL);
+  let allGood = true;
+
+  // Check marketplaces (prerequisite for plugins)
+  if (manifest.marketplaces) {
+    const knownMarketplaces = readJsonSync(KNOWN_MARKETPLACES) || {};
+    const knownNames = Object.keys(knownMarketplaces);
+    for (const marketplace of manifest.marketplaces) {
+      if (knownNames.includes(marketplace.name)) {
+        console.log(`  ✓ Marketplace: ${marketplace.name}`);
+      } else {
+        console.log(`  ✗ Marketplace missing: ${marketplace.name}`);
+        console.log(`    → Install via: /plugin marketplace add ${marketplace.repo}`);
+        allGood = false;
+      }
+    }
+  }
+
+  // Check plugins
+  if (manifest.plugins) {
+    const enabledPlugins = globalSettings?.enabledPlugins || {};
+    for (const plugin of manifest.plugins) {
+      if (enabledPlugins[plugin]) {
+        console.log(`  ✓ Plugin: ${plugin}`);
+      } else {
+        console.log(`  ✗ Plugin missing: ${plugin}`);
+        console.log(`    → Enable via Claude Code settings or add to ~/.claude/settings.json`);
+        allGood = false;
+      }
+    }
+  }
+
+  // Check MCP servers
+  if (manifest.mcpServers) {
+    const enabledMcp = globalLocal?.enabledMcpjsonServers || [];
+    for (const server of manifest.mcpServers) {
+      if (enabledMcp.includes(server)) {
+        console.log(`  ✓ MCP server: ${server}`);
+      } else {
+        console.log(`  ✗ MCP server missing: ${server}`);
+        console.log(`    → Add "${server}" to enabledMcpjsonServers in ~/.claude/settings.local.json`);
+        allGood = false;
+      }
+    }
+  }
+
+  // Check statusLine
+  if (manifest.statusLine) {
+    const currentStatus = globalSettings?.statusLine;
+    if (currentStatus && currentStatus.command === manifest.statusLine.command) {
+      console.log(`  ✓ StatusLine: ${manifest.statusLine.command}`);
+    } else {
+      console.log(`  ✗ StatusLine not configured: ${manifest.statusLine.command}`);
+      console.log(`    → Add statusLine config to ~/.claude/settings.json`);
+      allGood = false;
+    }
+  }
+
+  if (allGood) {
+    console.log('\n  All global settings match the manifest.');
+  }
+}
+
+main();

--- a/claude/skills/configure-claude.md
+++ b/claude/skills/configure-claude.md
@@ -1,12 +1,12 @@
 # configure-claude
 
-Install all Claude Code configs from this repository into the current project's `.claude/` directory.
+Install all Claude Code configs from this repository into a project's `.claude/` directory.
 
 ## What it does
 
-1. Copies `hooks/hooks.json` into the target project's `.claude/settings.json` (merging the hooks key if settings already exist)
-2. Copies `scripts/hooks/` and `scripts/lib/` into the target project's `.claude/scripts/` directory
-3. Rewrites `${CLAUDE_CONFIG_DIR}` references in hooks.json to use the actual installed path
+1. Copies `scripts/hooks/` and `scripts/lib/` into the target project's `.claude/scripts/`
+2. Reads `hooks/hooks.json`, resolves `${CLAUDE_CONFIG_DIR}` paths, and merges the `hooks` key into the target's `.claude/settings.json` (preserving existing keys)
+3. Checks `~/.claude/settings.json` against `config/global-settings.json` and warns about any missing plugins, MCP servers, or statusLine config
 
 ## Usage
 
@@ -16,20 +16,11 @@ Run `/configure-claude` from any project to install this config into that projec
 
 When this skill is invoked:
 
-1. Determine the target project directory. If the current working directory is this config repo itself, ask the user which project to configure. Otherwise, use the current working directory.
+1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/claude`), ask the user which project to configure. Otherwise, use the current working directory.
 
-2. Ensure the target has a `.claude/` directory (create if needed).
-
-3. Copy the scripts:
+2. Run the installer script:
    ```bash
-   cp -r <config-repo>/scripts/hooks/ <target>/.claude/scripts/hooks/
-   cp -r <config-repo>/scripts/lib/ <target>/.claude/scripts/lib/
+   node /Users/callumke/Projects/claude/scripts/configure-claude.js <target-directory>
    ```
 
-4. Read the target's `.claude/settings.json` if it exists. Merge the `hooks` key from `<config-repo>/hooks/hooks.json` into it. If no settings.json exists, create one from hooks.json.
-
-5. In the merged settings.json, replace all occurrences of `${CLAUDE_CONFIG_DIR}` with the actual path: `<target>/.claude` — so script references resolve correctly.
-
-6. Report what was installed and any files that were overwritten.
-
-**Important**: Do not overwrite existing non-hook keys in the target's settings.json. Only merge the `hooks` key.
+3. Review the output and report what was installed to the user, including any global settings warnings.


### PR DESCRIPTION
## Summary
- Added marketplace prerequisite checks to `configure-claude.js` — reads `~/.claude/plugins/known_marketplaces.json` and warns about missing marketplaces with install instructions before checking plugins
- Expanded `config/global-settings.json` with `marketplaces` array (3 marketplaces) and 8 new recommended plugins (typescript-lsp, pyright-lsp, code-simplifier, code-review, pr-review-toolkit, security-guidance, frontend-design, feature-dev)
- Updated skill instructions to use the installer script directly; bumped version to 1.4

## Test plan
- [x] Run `node scripts/configure-claude.js /tmp/test-project` — should show ✓ for all 3 marketplaces and list missing plugins
- [ ] Rename `~/.claude/plugins/known_marketplaces.json` and re-run — should show ✗ warnings with `/plugin marketplace add` instructions
- [ ] Verify new plugins are available in `claude-plugins-official` marketplace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer to automate Claude environment setup, merge configs, run marketplace/plugin/server validation, and optionally install status-line UI settings.
* **Documentation**
  * README and setup guides updated to describe installer-driven workflow, validation warnings, and updated examples for configuration review.
* **Version**
  * Release bumped to 1.4 with changelog entries for marketplace checks and installer additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->