### PR TITLE
Add mono-repo support + spec-driven development (v1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,28 @@ skills/      # Custom skills
 agents/      # Custom agent configurations
 ```
 
+## Key file locations
+
+- `~/.claude/settings.json` — global settings; `enabledPlugins` is `{ "name@marketplace": true }`
+- `~/.claude/settings.local.json` — local settings; `enabledMcpjsonServers` is an array of names
+- `~/.claude/plugins/known_marketplaces.json` — object keyed by marketplace name (not an array)
+- `~/.config/ccstatusline/settings.json` — ccstatusline layout config
+- `config/global-settings.json` — this repo's manifest of expected global state
+
+## Gotchas
+
+- `known_marketplaces.json` is an object keyed by name, not an array — use `Object.keys()` to get names
+- Plugins can be enabled at global (`~/.claude/settings.json`) OR project scope (`.claude/settings.json`) — check both
+- `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths
+- `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`
+- Git repo lives at `Projects/claude/`, NOT at parent `Projects/` — was migrated in this session
+
+## Testing configure-claude.js
+
+- `node scripts/configure-claude.js /tmp/test-project` — full integration test against temp dir
+- `--install-ccstatusline` flag for standalone ccstatusline install
+- Always `rm -rf /tmp/test-project` after testing
+
 ## Versioning
 
 Current version: **1.4**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,11 @@ Personal Claude Code configuration repository (dotfiles-style). Stores hooks, co
 hooks/       # Custom hooks (shell commands triggered by Claude Code events)
 commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
-config/      # Global settings manifest (plugins, MCP servers, statusLine)
+config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
-skills/      # Custom skills
-agents/      # Custom agent configurations
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
+agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater)
+templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
 
 ## Key file locations
@@ -25,6 +26,7 @@ agents/      # Custom agent configurations
 - `~/.claude/plugins/known_marketplaces.json` — object keyed by marketplace name (not an array)
 - `~/.config/ccstatusline/settings.json` — ccstatusline layout config
 - `config/global-settings.json` — this repo's manifest of expected global state
+- `config/profiles.json` — profile detection signals and profile→plugin/skill/agent mappings
 
 ## Gotchas
 
@@ -42,7 +44,7 @@ agents/      # Custom agent configurations
 
 ## Versioning
 
-Current version: **1.4**
+Current version: **1.5**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -50,6 +52,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.5** — Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
 - **1.3** — Added `configure-claude.js` installer script, `config/global-settings.json` manifest; skill now invokes the script directly
 - **1.2** — Added `configure-claude` skill: installs hooks and scripts into any project's `.claude/` directory

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.4**
+**Version: 1.5**
 
 ## Getting started
 
@@ -12,14 +12,42 @@ Clone this repo and symlink or copy the relevant directories into your project's
 hooks/       # Shell commands triggered by Claude Code events
 commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
-config/      # Global settings manifest (plugins, MCP servers, statusLine)
+config/      # Global settings manifest + profiles.json
 plugins/     # Claude Code plugins
-skills/      # Custom skills
-agents/      # Custom agent configurations
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
+agents/      # Agent definitions (@context-loader, @doc-updater)
+templates/   # Spec, doc, and changelog templates
 ```
+
+## Mono-repo Support
+
+The installer auto-detects project type via `config/profiles.json`:
+- **Signals** — file existence, package.json deps/fields, subdirectory presence
+- **Profiles** — `base`, `typescript`, `python`, `frontend`, `backend`, `monorepo-root`
+- Each profile specifies which plugins, skills, agents, and templates to install
+- Mono-repos get per-workspace installation with workspace-specific profiles
+
+```bash
+# Install into a mono-repo with backend/ and frontend/
+node scripts/configure-claude.js /path/to/monorepo
+```
+
+## Agents
+
+- **`@context-loader`** — Reads all spec state, git history, and produces a prioritized briefing for the session
+- **`@doc-updater`** — Detects changed workspaces, fans out parallel sub-agents to update docs, then updates root tracking files
+
+## Spec-driven Development
+
+When installed with the `monorepo-root` profile, the installer creates:
+- `.claude/specs/` — templates for requirements, design, and tasks
+- `SPECLOG.md` — tracks spec status across the project
+- `CHANGELOG.md` — keep-a-changelog format
+- `docs/` — documentation folder at root and each workspace
 
 ## Changelog
 
+- **1.5** — Mono-repo support + spec-driven development: profile-based installer, agents, templates, spec-aware hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
 - **1.3** — Added `configure-claude.js` installer script + `config/global-settings.json` manifest
 - **1.2** — Added `configure-claude` skill for installing configs into projects

--- a/agents/context-loader.md
+++ b/agents/context-loader.md
@@ -1,0 +1,77 @@
+---
+name: context-loader
+description: "Use this agent when starting a new session on a spec-driven project, or when you need to understand current project state and what to work on next."
+model: sonnet
+color: cyan
+tools: ["Read", "Glob", "Grep", "Bash"]
+---
+
+# Context Loader Agent
+
+You are a project context loader for spec-driven development projects. Your job is to read all project state and produce a prioritized briefing so the developer knows exactly where things stand and what to work on next.
+
+## Process
+
+### 1. Find Project Root
+
+Locate the project root by finding `.claude/specs/`, `SPECLOG.md`, and `CHANGELOG.md`. These should be at the mono-repo root (or single project root).
+
+### 2. Read All Spec State
+
+For each spec directory under `.claude/specs/`:
+- Read `requirements.md` — understand what the spec is about
+- Read `design.md` — understand architectural decisions
+- Read `tasks.md` — identify incomplete tasks (`- [ ]`), completed tasks (`- [x]`), and blocked tasks
+
+### 3. Read SPECLOG.md
+
+Parse the spec tracking table to understand:
+- Which specs are in-progress, planned, or completed
+- Who owns each spec
+- When each was last updated
+
+### 4. Read Recent Git History
+
+Run `git log --oneline -20` to understand recent work. Correlate commits with specs and tasks.
+
+### 5. Read CHANGELOG.md
+
+Check the `[Unreleased]` section for items already tracked. Identify any gaps between git history and changelog.
+
+### 6. Produce Prioritized Briefing
+
+Output a structured summary in this format:
+
+```
+## Project Briefing
+
+### Completed
+- [spec/task summaries that are done]
+
+### In Progress
+- [spec/task summaries with remaining work counts]
+
+### Next Up
+- [prioritized list of what to work on, based on task dependencies and spec status]
+
+### Blockers
+- [anything blocked, with reasons]
+
+### Recent Activity
+- [last 5-10 commits summarized]
+```
+
+### 7. Pre-load Relevant Source Files
+
+Based on the current in-progress spec's tasks, identify the most relevant source files. Read them so they're in Claude's context for the session. Focus on:
+- Files mentioned in task descriptions
+- Files related to the architectural components in design.md
+- Recently modified files from git log
+
+## Guidelines
+
+- Be concise but thorough — this briefing sets the tone for the entire session
+- Prioritize actionable information over background context
+- If multiple specs are in progress, recommend which to focus on first
+- Flag any inconsistencies (e.g., tasks marked complete but code not matching)
+- Don't modify any files — this agent is read-only

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -14,14 +14,14 @@ You are a documentation updater for spec-driven development projects. Your job i
 
 ### 1. Detect Changed Workspaces
 
-Run `git diff --name-only HEAD` to identify which directories have changes. Categorize into:
+Run `git diff --name-only HEAD~1..HEAD` to identify recently committed changes, and `git diff --name-only --staged` plus `git diff --name-only` for any uncommitted work. Combine all results and categorize into:
 - Root-level changes
 - Workspace changes (e.g., `backend/`, `frontend/`)
 
 ### 2. Fan Out Parallel Sub-agents
 
 For each changed workspace, spawn a Task sub-agent that:
-- Reads the workspace's source code changes (`git diff HEAD -- <workspace>/`)
+- Reads the workspace's source code changes (`git diff HEAD~1..HEAD -- <workspace>/` and `git diff HEAD -- <workspace>/`)
 - Updates the workspace's `docs/` folder:
   - API documentation (if endpoints changed)
   - Setup/configuration guides (if dependencies or config changed)

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -1,0 +1,86 @@
+---
+name: doc-updater
+description: "Use this agent when ending a session or after completing work on a spec. Detects which workspaces changed, fans out parallel sub-agents for each, then updates root documentation."
+model: sonnet
+color: green
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"]
+---
+
+# Doc Updater Agent
+
+You are a documentation updater for spec-driven development projects. Your job is to detect what changed, update documentation at every level, and ensure spec tracking files are current.
+
+## Process
+
+### 1. Detect Changed Workspaces
+
+Run `git diff --name-only HEAD` to identify which directories have changes. Categorize into:
+- Root-level changes
+- Workspace changes (e.g., `backend/`, `frontend/`)
+
+### 2. Fan Out Parallel Sub-agents
+
+For each changed workspace, spawn a Task sub-agent that:
+- Reads the workspace's source code changes (`git diff HEAD -- <workspace>/`)
+- Updates the workspace's `docs/` folder:
+  - API documentation (if endpoints changed)
+  - Setup/configuration guides (if dependencies or config changed)
+  - Feature documentation (if new features added)
+- Updates the workspace's `README.md` if it exists and changes warrant it
+- Returns a summary of what was updated
+
+Use `subagent_type: "general-purpose"` for each workspace sub-agent. Run them in parallel.
+
+### 3. Wait and Collect
+
+Wait for all sub-agent results. Collect summaries of what each updated.
+
+### 4. Update Root Documentation
+
+After workspace docs are done, update root-level files:
+
+#### Update spec tasks.md files
+- Read `git log --oneline` since last session
+- For each in-progress spec, check if any tasks can be marked complete based on commits
+- Mark completed tasks with `[x]` and add completion date
+
+#### Update SPECLOG.md
+- Read each spec's `tasks.md` to determine current status
+- If all tasks complete → status "Complete"
+- If any tasks incomplete → status "In Progress"
+- Update the "Last Updated" column
+
+#### Update CHANGELOG.md
+- Review `git log` for changes not yet in `[Unreleased]`
+- Categorize changes: Added, Changed, Fixed
+- Add items under the appropriate heading
+
+#### Update root docs/ and README.md
+- Update root `docs/` folder with any cross-cutting documentation changes
+- Update root `README.md` if project structure or setup instructions changed
+
+### 5. Report Summary
+
+Output a consolidated list:
+```
+## Documentation Update Summary
+
+### Files Modified
+- path/to/file.md — reason for update
+
+### Spec Status Changes
+- spec-name: old-status → new-status
+
+### Changelog Additions
+- Added: description
+- Fixed: description
+```
+
+## Guidelines
+
+- Only update documentation that is actually stale — don't rewrite docs that are already accurate
+- When updating CHANGELOG.md, match the existing writing style
+- For task completion detection, be conservative — only mark tasks done if the git log clearly shows the work was completed
+- Preserve any manual edits users have made to docs
+- If a workspace has no `docs/` folder, create one with the template structure
+- Don't modify source code — this agent only touches documentation and tracking files

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -43,7 +43,7 @@
       "plugins": ["frontend-design@claude-plugins-official"]
     },
     "backend": {
-      "extends": "typescript",
+      "extends": "base",
       "plugins": []
     },
     "monorepo-root": {

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -1,0 +1,56 @@
+{
+  "signals": {
+    "typescript": { "files": ["tsconfig.json"] },
+    "python": { "files": ["requirements.txt", "pyproject.toml", "setup.py", "Pipfile"] },
+    "frontend": {
+      "packageDeps": ["react", "vue", "svelte", "next", "nuxt", "angular"],
+      "files": ["next.config.js", "next.config.ts", "vite.config.ts", "vite.config.js"]
+    },
+    "backend": {
+      "packageDeps": ["express", "fastify", "hono", "@nestjs/core", "django", "flask", "fastapi"]
+    },
+    "monorepo": {
+      "dirs": ["backend", "frontend"],
+      "packageFields": ["workspaces"]
+    }
+  },
+  "profiles": {
+    "base": {
+      "plugins": [
+        "commit-commands@claude-plugins-official",
+        "superpowers@claude-plugins-official",
+        "claude-md-management@claude-plugins-official",
+        "hookify@claude-plugins-official",
+        "code-simplifier@claude-plugins-official",
+        "code-review@claude-plugins-official",
+        "pr-review-toolkit@claude-plugins-official",
+        "security-guidance@claude-plugins-official",
+        "feature-dev@claude-plugins-official"
+      ],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview"],
+      "agents": []
+    },
+    "typescript": {
+      "extends": "base",
+      "plugins": ["typescript-lsp@claude-plugins-official"]
+    },
+    "python": {
+      "extends": "base",
+      "plugins": ["pyright-lsp@claude-plugins-official"]
+    },
+    "frontend": {
+      "extends": "typescript",
+      "plugins": ["frontend-design@claude-plugins-official"]
+    },
+    "backend": {
+      "extends": "typescript",
+      "plugins": []
+    },
+    "monorepo-root": {
+      "extends": "base",
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs"],
+      "agents": ["context-loader", "doc-updater"],
+      "templates": ["specs"]
+    }
+  }
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -33,11 +33,11 @@
         "description": "Reminder before git push to review changes"
       },
       {
-        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"README\\\\.md|CLAUDE\\\\.md|AGENTS\\\\.md|CONTRIBUTING\\\\.md\")",
+        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"README\\\\.md|CLAUDE\\\\.md|AGENTS\\\\.md|CONTRIBUTING\\\\.md|SPECLOG\\\\.md|CHANGELOG\\\\.md|\\\\.claude/specs/\")",
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING)\\.md$/.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
+            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|SPECLOG|CHANGELOG)\\.md$/.test(p)&&!/\\.claude\\/specs\\//.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
           }
         ],
         "description": "Block creation of random .md files - keeps docs consolidated"
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/suggest-compact.js\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/skills/strategic-compact/scripts/suggest-compact.js\""
           }
         ],
         "description": "Suggest manual compaction at logical intervals"

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -108,26 +108,26 @@ function matchesSignal(targetDir, signal) {
     }
   }
 
-  // Check package.json fields
+  // Check package.json fields (must be non-empty)
   if (signal.packageFields) {
     const pkg = readJsonSync(path.join(targetDir, 'package.json'));
     if (pkg) {
       for (const field of signal.packageFields) {
-        if (pkg[field]) return true;
+        const val = pkg[field];
+        if (val == null) continue;
+        if (Array.isArray(val) && val.length > 0) return true;
+        if (typeof val === 'string' && val.trim().length > 0) return true;
+        if (typeof val === 'object' && !Array.isArray(val) && Object.keys(val).length > 0) return true;
       }
     }
   }
 
-  // Check subdirectory existence
+  // Check subdirectory existence (any match triggers)
   if (signal.dirs) {
-    let allExist = true;
     for (const dir of signal.dirs) {
-      if (!fs.existsSync(path.join(targetDir, dir)) || !fs.statSync(path.join(targetDir, dir)).isDirectory()) {
-        allExist = false;
-        break;
-      }
+      const dirPath = path.join(targetDir, dir);
+      if (fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) return true;
     }
-    if (signal.dirs.length > 0 && allExist) return true;
   }
 
   return false;

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -4,7 +4,8 @@
  * configure-claude.js
  *
  * Installs Claude Code hooks, scripts, and config into a target project's .claude/ directory.
- * Also checks global ~/.claude/settings.json against the expected manifest.
+ * Auto-detects project type (typescript, python, frontend, backend, monorepo) and installs
+ * only relevant plugins, skills, agents, and templates per profile.
  *
  * Usage: node configure-claude.js [target-directory]
  *   target-directory defaults to cwd
@@ -16,8 +17,12 @@ const path = require('path');
 const CONFIG_REPO = path.resolve(__dirname, '..');
 const HOOKS_JSON = path.join(CONFIG_REPO, 'hooks', 'hooks.json');
 const GLOBAL_MANIFEST = path.join(CONFIG_REPO, 'config', 'global-settings.json');
+const PROFILES_JSON = path.join(CONFIG_REPO, 'config', 'profiles.json');
 const SCRIPTS_HOOKS = path.join(CONFIG_REPO, 'scripts', 'hooks');
 const SCRIPTS_LIB = path.join(CONFIG_REPO, 'scripts', 'lib');
+const SKILLS_DIR = path.join(CONFIG_REPO, 'skills');
+const AGENTS_DIR = path.join(CONFIG_REPO, 'agents');
+const TEMPLATES_DIR = path.join(CONFIG_REPO, 'templates');
 const HOME_SETTINGS = path.join(require('os').homedir(), '.claude', 'settings.json');
 const HOME_SETTINGS_LOCAL = path.join(require('os').homedir(), '.claude', 'settings.local.json');
 const KNOWN_MARKETPLACES = path.join(require('os').homedir(), '.claude', 'plugins', 'known_marketplaces.json');
@@ -35,6 +40,23 @@ function copyDirSync(src, dest) {
   }
 }
 
+/**
+ * Copy a directory, but only if destination files don't already exist.
+ * Preserves existing files (never overwrites).
+ */
+function copyDirSyncNoOverwrite(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirSyncNoOverwrite(srcPath, destPath);
+    } else if (!fs.existsSync(destPath)) {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
 function readJsonSync(filePath) {
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -47,6 +69,249 @@ function resolveHookPaths(obj, claudeConfigDir) {
   const json = JSON.stringify(obj);
   const safeDir = claudeConfigDir.replace(/\\/g, '\\\\');
   return JSON.parse(json.replace(/\$\{CLAUDE_CONFIG_DIR\}/g, () => safeDir));
+}
+
+// --- Profile detection ---
+
+function detectProfiles(targetDir) {
+  const profilesConfig = readJsonSync(PROFILES_JSON);
+  if (!profilesConfig) return ['base'];
+
+  const signals = profilesConfig.signals;
+  const matched = [];
+
+  for (const [name, signal] of Object.entries(signals)) {
+    if (matchesSignal(targetDir, signal)) {
+      matched.push(name);
+    }
+  }
+
+  return matched.length > 0 ? matched : ['base'];
+}
+
+function matchesSignal(targetDir, signal) {
+  // Check file existence
+  if (signal.files) {
+    for (const file of signal.files) {
+      if (fs.existsSync(path.join(targetDir, file))) return true;
+    }
+  }
+
+  // Check package.json dependencies
+  if (signal.packageDeps) {
+    const pkg = readJsonSync(path.join(targetDir, 'package.json'));
+    if (pkg) {
+      const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+      for (const dep of signal.packageDeps) {
+        if (allDeps[dep]) return true;
+      }
+    }
+  }
+
+  // Check package.json fields
+  if (signal.packageFields) {
+    const pkg = readJsonSync(path.join(targetDir, 'package.json'));
+    if (pkg) {
+      for (const field of signal.packageFields) {
+        if (pkg[field]) return true;
+      }
+    }
+  }
+
+  // Check subdirectory existence
+  if (signal.dirs) {
+    let allExist = true;
+    for (const dir of signal.dirs) {
+      if (!fs.existsSync(path.join(targetDir, dir)) || !fs.statSync(path.join(targetDir, dir)).isDirectory()) {
+        allExist = false;
+        break;
+      }
+    }
+    if (signal.dirs.length > 0 && allExist) return true;
+  }
+
+  return false;
+}
+
+function resolveProfile(profileNames, profilesConfig) {
+  const profiles = profilesConfig.profiles;
+  const resolved = { plugins: new Set(), skills: new Set(), agents: new Set(), templates: new Set() };
+
+  for (const name of profileNames) {
+    mergeProfile(name, profiles, resolved, new Set());
+  }
+
+  return {
+    plugins: [...resolved.plugins],
+    skills: [...resolved.skills],
+    agents: [...resolved.agents],
+    templates: [...resolved.templates],
+  };
+}
+
+function mergeProfile(name, profiles, resolved, visited) {
+  if (visited.has(name)) return;
+  visited.add(name);
+
+  const profile = profiles[name];
+  if (!profile) return;
+
+  // Resolve parent first
+  if (profile.extends) {
+    mergeProfile(profile.extends, profiles, resolved, visited);
+  }
+
+  if (profile.plugins) profile.plugins.forEach(p => resolved.plugins.add(p));
+  if (profile.skills) profile.skills.forEach(s => resolved.skills.add(s));
+  if (profile.agents) profile.agents.forEach(a => resolved.agents.add(a));
+  if (profile.templates) profile.templates.forEach(t => resolved.templates.add(t));
+}
+
+function findWorkspaces(targetDir) {
+  const workspaces = [];
+
+  // Check for backend/ and frontend/ subdirs
+  for (const name of ['backend', 'frontend']) {
+    const wsPath = path.join(targetDir, name);
+    if (fs.existsSync(wsPath) && fs.statSync(wsPath).isDirectory()) {
+      workspaces.push({ name, path: wsPath });
+    }
+  }
+
+  // Also check package.json workspaces field for additional dirs
+  const pkg = readJsonSync(path.join(targetDir, 'package.json'));
+  if (pkg?.workspaces) {
+    const wsPatterns = Array.isArray(pkg.workspaces) ? pkg.workspaces : pkg.workspaces.packages || [];
+    for (const pattern of wsPatterns) {
+      // Simple glob: strip trailing /* or /**
+      const dir = pattern.replace(/\/\*+$/, '');
+      const wsPath = path.join(targetDir, dir);
+      if (fs.existsSync(wsPath) && fs.statSync(wsPath).isDirectory()) {
+        if (!workspaces.find(w => w.path === wsPath)) {
+          workspaces.push({ name: dir, path: wsPath });
+        }
+      }
+    }
+  }
+
+  return workspaces;
+}
+
+// --- Installation ---
+
+function installForProfile(targetDir, resolvedProfile, label) {
+  const claudeDir = path.join(targetDir, '.claude');
+  const settingsPath = path.join(claudeDir, 'settings.json');
+
+  console.log(`\n--- Installing: ${label} (${targetDir}) ---\n`);
+
+  // 1. Create .claude/ directory
+  fs.mkdirSync(claudeDir, { recursive: true });
+  console.log(`  ✓ Ensured ${claudeDir} exists`);
+
+  // 2. Copy scripts/hooks/ and scripts/lib/
+  const destHooks = path.join(claudeDir, 'scripts', 'hooks');
+  const destLib = path.join(claudeDir, 'scripts', 'lib');
+
+  copyDirSync(SCRIPTS_HOOKS, destHooks);
+  console.log(`  ✓ Copied hook scripts → ${destHooks}`);
+
+  copyDirSync(SCRIPTS_LIB, destLib);
+  console.log(`  ✓ Copied lib scripts  → ${destLib}`);
+
+  // 3. Copy skills (only those in resolved profile)
+  const destSkills = path.join(claudeDir, 'skills');
+  let skillCount = 0;
+  for (const skillName of resolvedProfile.skills) {
+    const srcSkill = path.join(SKILLS_DIR, skillName);
+    if (fs.existsSync(srcSkill) && fs.statSync(srcSkill).isDirectory()) {
+      copyDirSync(srcSkill, path.join(destSkills, skillName));
+      skillCount++;
+    }
+  }
+  console.log(`  ✓ Copied ${skillCount} skill(s) → ${destSkills}`);
+
+  // 4. Copy agents (only those in resolved profile)
+  if (resolvedProfile.agents.length > 0) {
+    const destAgents = path.join(claudeDir, 'agents');
+    fs.mkdirSync(destAgents, { recursive: true });
+    let agentCount = 0;
+    for (const agentName of resolvedProfile.agents) {
+      const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
+      if (fs.existsSync(srcAgent)) {
+        fs.copyFileSync(srcAgent, path.join(destAgents, `${agentName}.md`));
+        agentCount++;
+      }
+    }
+    console.log(`  ✓ Copied ${agentCount} agent(s) → ${destAgents}`);
+  }
+
+  // 5. Copy templates (never overwrite existing)
+  if (resolvedProfile.templates.includes('specs')) {
+    // Copy spec templates → .claude/specs/
+    const destSpecs = path.join(claudeDir, 'specs');
+    copyDirSyncNoOverwrite(path.join(TEMPLATES_DIR, 'specs'), destSpecs);
+    console.log(`  ✓ Copied spec templates → ${destSpecs} (no overwrite)`);
+
+    // Copy SPECLOG.md and CHANGELOG.md → project root
+    for (const file of ['SPECLOG.md', 'CHANGELOG.md']) {
+      const destFile = path.join(targetDir, file);
+      if (!fs.existsSync(destFile)) {
+        fs.copyFileSync(path.join(TEMPLATES_DIR, file), destFile);
+        console.log(`  ✓ Created ${file}`);
+      } else {
+        console.log(`  ✓ ${file} already exists (skipped)`);
+      }
+    }
+
+    // Copy docs/ template → project root docs/
+    const destDocs = path.join(targetDir, 'docs');
+    if (!fs.existsSync(destDocs)) {
+      copyDirSyncNoOverwrite(path.join(TEMPLATES_DIR, 'docs'), destDocs);
+      console.log(`  ✓ Created docs/ folder`);
+    } else {
+      console.log(`  ✓ docs/ already exists (skipped)`);
+    }
+  }
+
+  // 6. Read hooks.json from config repo
+  const hooksConfig = readJsonSync(HOOKS_JSON);
+  if (!hooksConfig) {
+    console.error('  ✗ Could not read hooks.json from config repo');
+    process.exit(1);
+  }
+
+  if (!hooksConfig.hooks) {
+    console.error('  ✗ hooks.json is missing "hooks" key');
+    process.exit(1);
+  }
+  const resolvedHooks = resolveHookPaths(hooksConfig.hooks, claudeDir);
+
+  // 7. Merge hooks and plugins into target settings.json
+  const existingSettings = readJsonSync(settingsPath) || {};
+  const pluginsToEnable = {};
+  for (const plugin of resolvedProfile.plugins) {
+    pluginsToEnable[plugin] = true;
+  }
+
+  const merged = {
+    ...existingSettings,
+    ...(hooksConfig.$schema ? { $schema: hooksConfig.$schema } : {}),
+    hooks: resolvedHooks,
+    enabledPlugins: { ...existingSettings.enabledPlugins, ...pluginsToEnable },
+  };
+
+  fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
+  console.log(`  ✓ Merged hooks into ${settingsPath}`);
+  console.log(`  ✓ Enabled ${resolvedProfile.plugins.length} plugin(s) in project settings`);
+
+  // Verify no unresolved placeholders remain
+  const written = fs.readFileSync(settingsPath, 'utf8');
+  if (written.includes('${CLAUDE_CONFIG_DIR}')) {
+    console.error('  ✗ WARNING: Unresolved ${CLAUDE_CONFIG_DIR} found in settings.json');
+  } else {
+    console.log('  ✓ All hook paths resolved (no ${CLAUDE_CONFIG_DIR} remaining)');
+  }
 }
 
 function installCcstatuslineConfig(manifest) {
@@ -78,75 +343,59 @@ function main() {
   }
 
   const targetDir = path.resolve(process.argv.filter(a => !a.startsWith('--'))[2] || process.cwd());
-  const claudeDir = path.join(targetDir, '.claude');
-  const settingsPath = path.join(claudeDir, 'settings.json');
+  const profilesConfig = readJsonSync(PROFILES_JSON);
+
+  if (!profilesConfig) {
+    console.error('  ✗ Could not read profiles.json');
+    process.exit(1);
+  }
 
   console.log(`\nConfiguring Claude Code for: ${targetDir}\n`);
 
-  // 1. Create .claude/ directory
-  fs.mkdirSync(claudeDir, { recursive: true });
-  console.log(`  ✓ Ensured ${claudeDir} exists`);
+  // Detect profiles
+  const detectedProfiles = detectProfiles(targetDir);
+  console.log(`  Detected profiles: ${detectedProfiles.join(', ')}`);
 
-  // 2. Copy scripts/hooks/ and scripts/lib/
-  const destHooks = path.join(claudeDir, 'scripts', 'hooks');
-  const destLib = path.join(claudeDir, 'scripts', 'lib');
+  const isMonorepo = detectedProfiles.includes('monorepo');
 
-  copyDirSync(SCRIPTS_HOOKS, destHooks);
-  console.log(`  ✓ Copied hook scripts → ${destHooks}`);
+  if (isMonorepo) {
+    // Install root with monorepo-root profile
+    const rootProfileNames = detectedProfiles.filter(p => p !== 'monorepo').concat('monorepo-root');
+    const rootResolved = resolveProfile(rootProfileNames, profilesConfig);
+    installForProfile(targetDir, rootResolved, `monorepo root [${rootProfileNames.join(', ')}]`);
 
-  copyDirSync(SCRIPTS_LIB, destLib);
-  console.log(`  ✓ Copied lib scripts  → ${destLib}`);
+    // Create docs/ in each workspace (if templates include specs)
+    const workspaces = findWorkspaces(targetDir);
 
-  // 3. Read hooks.json from config repo
-  const hooksConfig = readJsonSync(HOOKS_JSON);
-  if (!hooksConfig) {
-    console.error('  ✗ Could not read hooks.json from config repo');
-    process.exit(1);
-  }
+    // Install each workspace with its own detected profile
+    for (const ws of workspaces) {
+      const wsProfiles = detectProfiles(ws.path);
+      console.log(`\n  Workspace "${ws.name}" profiles: ${wsProfiles.join(', ')}`);
+      const wsResolved = resolveProfile(wsProfiles, profilesConfig);
+      installForProfile(ws.path, wsResolved, `workspace: ${ws.name} [${wsProfiles.join(', ')}]`);
 
-  // 4. Resolve ${CLAUDE_CONFIG_DIR} to target's .claude path
-  if (!hooksConfig.hooks) {
-    console.error('  ✗ hooks.json is missing "hooks" key');
-    process.exit(1);
-  }
-  const resolvedHooks = resolveHookPaths(hooksConfig.hooks, claudeDir);
-
-  // 5. Merge hooks and plugins into target settings.json
-  const existingSettings = readJsonSync(settingsPath) || {};
-  const manifest = readJsonSync(GLOBAL_MANIFEST);
-  const pluginsToEnable = {};
-  if (manifest?.plugins) {
-    for (const plugin of manifest.plugins) {
-      pluginsToEnable[plugin] = true;
+      // Create docs/ in workspace if root has specs template
+      if (rootResolved.templates.includes('specs')) {
+        const wsDocs = path.join(ws.path, 'docs');
+        if (!fs.existsSync(wsDocs)) {
+          copyDirSyncNoOverwrite(path.join(TEMPLATES_DIR, 'docs'), wsDocs);
+          console.log(`  ✓ Created ${ws.name}/docs/ folder`);
+        }
+      }
     }
-  }
-  const merged = {
-    ...existingSettings,
-    ...(hooksConfig.$schema ? { $schema: hooksConfig.$schema } : {}),
-    hooks: resolvedHooks,
-    enabledPlugins: { ...existingSettings.enabledPlugins, ...pluginsToEnable },
-  };
-
-  fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
-  console.log(`  ✓ Merged hooks into ${settingsPath}`);
-  if (manifest?.plugins) {
-    console.log(`  ✓ Enabled ${manifest.plugins.length} plugins in project settings`);
-  }
-
-  // Verify no unresolved placeholders remain
-  const written = fs.readFileSync(settingsPath, 'utf8');
-  if (written.includes('${CLAUDE_CONFIG_DIR}')) {
-    console.error('  ✗ WARNING: Unresolved ${CLAUDE_CONFIG_DIR} found in settings.json');
   } else {
-    console.log('  ✓ All hook paths resolved (no ${CLAUDE_CONFIG_DIR} remaining)');
+    // Single project installation
+    const resolved = resolveProfile(detectedProfiles, profilesConfig);
+    installForProfile(targetDir, resolved, detectedProfiles.join(', '));
   }
 
-  // 6. Check global settings against manifest
+  // Global settings check
+  const manifest = readJsonSync(GLOBAL_MANIFEST);
   console.log('\n--- Global settings check ---\n');
   if (!manifest) {
     console.log('  ⚠ Could not read global manifest, skipping global check');
   } else {
-    checkGlobalSettings(manifest, settingsPath);
+    checkGlobalSettings(manifest, path.join(targetDir, '.claude', 'settings.json'));
   }
 
   console.log('\nDone!\n');

--- a/scripts/hooks/check-console-log.js
+++ b/scripts/hooks/check-console-log.js
@@ -9,7 +9,7 @@
  * debug statements before committing.
  */
 
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 
 let data = '';
@@ -22,19 +22,19 @@ process.stdin.on('data', chunk => {
 process.stdin.on('end', () => {
   try {
     // Check if we're in a git repository
-    try {
-      execSync('git rev-parse --git-dir', { stdio: 'pipe' });
-    } catch {
+    const gitCheck = spawnSync('git', ['rev-parse', '--git-dir'], { stdio: 'pipe' });
+    if (gitCheck.status !== 0) {
       // Not in a git repo, just pass through the data
       console.log(data);
       process.exit(0);
     }
 
     // Get list of modified files
-    const files = execSync('git diff --name-only HEAD', {
+    const diffResult = spawnSync('git', ['diff', '--name-only', 'HEAD'], {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe']
-    })
+    });
+    const files = (diffResult.stdout || '')
       .split('\n')
       .filter(f => /\.(ts|tsx|js|jsx)$/.test(f) && fs.existsSync(f));
 

--- a/scripts/hooks/session-end.js
+++ b/scripts/hooks/session-end.js
@@ -18,6 +18,8 @@ const {
   ensureDir,
   writeFile,
   replaceInFile,
+  findSpecsDir,
+  getGitModifiedFiles,
   log
 } = require('../lib/utils');
 
@@ -73,6 +75,20 @@ async function main() {
 
     writeFile(sessionFile, template);
     log(`[SessionEnd] Created session file: ${sessionFile}`);
+  }
+
+  // Spec change detection
+  const specResult = findSpecsDir(process.cwd());
+  if (specResult) {
+    const modifiedFiles = getGitModifiedFiles([
+      '\\.claude/specs/',
+      'SPECLOG\\.md',
+      'CHANGELOG\\.md'
+    ]);
+    if (modifiedFiles.length > 0) {
+      log(`[SessionEnd] Spec files modified: ${modifiedFiles.join(', ')}`);
+      log('[SessionEnd] Consider running @doc-updater to update documentation');
+    }
   }
 
   process.exit(0);

--- a/scripts/lib/utils.js
+++ b/scripts/lib/utils.js
@@ -299,10 +299,13 @@ function runCommand(cmd, options = {}) {
       stdio: ['pipe', 'pipe', 'pipe'],
       ...options
     });
+    if (result.error) {
+      return { success: false, output: result.error.message.trim() };
+    }
     if (result.status === 0) {
       return { success: true, output: (result.stdout || '').trim() };
     }
-    return { success: false, output: (result.stderr || result.error?.message || '').trim() };
+    return { success: false, output: (result.stderr || '').trim() };
   } catch (err) {
     return { success: false, output: err.message };
   }

--- a/skills/configure-claude/SKILL.md
+++ b/skills/configure-claude/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: configure-claude
+description: Install Claude Code hooks, scripts, plugins, and config into a project. Use when setting up a new project or syncing config to an existing one.
+disable-model-invocation: true
+allowed-tools: Bash(node *), Read, Glob
+---
+
+Install all Claude Code configs from this repository into a project's `.claude/` directory.
+
+## What it does
+
+1. Copies `scripts/hooks/` and `scripts/lib/` into the target project's `.claude/scripts/`
+2. Reads `hooks/hooks.json`, resolves `${CLAUDE_CONFIG_DIR}` paths, and merges the `hooks` key into the target's `.claude/settings.json` (preserving existing keys)
+3. Enables all manifest plugins in the project's `.claude/settings.json`
+4. Checks global settings against `config/global-settings.json` and warns about missing marketplaces, plugins, MCP servers, or statusLine config
+
+## Instructions
+
+When this skill is invoked:
+
+1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/claude`), ask the user which project to configure. Otherwise, use the current working directory.
+
+2. Run the installer script:
+   ```bash
+   node /Users/callumke/Projects/claude/scripts/configure-claude.js <target-directory>
+   ```
+
+3. Review the output and report what was installed to the user, including any global settings warnings.
+
+4. If ccstatusline config is missing or outdated, offer to install it:
+   ```bash
+   node /Users/callumke/Projects/claude/scripts/configure-claude.js --install-ccstatusline
+   ```

--- a/skills/spec-interview/SKILL.md
+++ b/skills/spec-interview/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: spec-interview
+description: Conduct an in-depth interview about a spec document to surface edge cases, tradeoffs, and non-obvious decisions, then write the final spec. Use when a SPEC.md exists and needs to be fleshed out.
+disable-model-invocation: true
+argument-hint: [spec-file-path]
+---
+
+Conduct an in-depth interview about a spec document, then write the final spec.
+
+## Instructions
+
+When this skill is invoked:
+
+1. **Find the spec file.** If `$ARGUMENTS` is provided, use that as the file path. Otherwise, look for files matching `**/SPEC.md`, `**/spec.md`, or similar in the current project. If multiple are found or none exist, use AskUserQuestion to ask which file to use or where to create one. Read the file contents thoroughly.
+
+2. **Interview the user.** Conduct a deep, multi-round interview using AskUserQuestion. The goal is to surface non-obvious decisions, edge cases, and tradeoffs that the spec doesn't address or is ambiguous about.
+
+   Interview guidelines:
+   - **Do NOT ask obvious questions** that the spec already answers clearly. Read the spec carefully first.
+   - **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, performance budgets, accessibility considerations, and integration boundaries.
+   - **Be specific.** Reference concrete parts of the spec. Instead of "how should errors work?", ask "when the payment webhook fails mid-checkout and the user has already seen the success screen, what should happen?"
+   - **Go deep on answers.** Follow up on interesting responses. If the user says "we'll use a queue", ask about retry policy, dead letters, ordering guarantees, idempotency.
+   - **Cover multiple dimensions per round.** Use multi-question AskUserQuestion calls (up to 4 questions) to keep the interview moving efficiently.
+   - **Provide informed options.** When asking about tradeoffs, present concrete options with pros/cons rather than open-ended questions.
+
+3. **Continue until complete.** Keep interviewing across multiple rounds. A thorough interview typically needs 4-8 rounds depending on spec complexity. You are done when:
+   - All major architectural decisions are resolved
+   - Edge cases and error flows are addressed
+   - The user confirms they have nothing else to add
+
+4. **Write the final spec.** Once the interview is complete, rewrite the spec file incorporating all decisions from the interview. The final spec should:
+   - Preserve the original structure and intent
+   - Integrate all interview answers as concrete decisions (not as Q&A)
+   - Add new sections for topics that emerged during the interview
+   - Be written as a definitive spec, not a discussion document
+   - Flag any remaining open questions that weren't resolved

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: strategic-compact
+description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
+user-invocable: false
+---
+
+# Strategic Compact
+
+Hook-driven system that suggests manual `/compact` at strategic intervals rather than relying on auto-compact which fires at arbitrary points mid-task.
+
+## How it works
+
+A PreToolUse hook on Edit/Write runs `scripts/suggest-compact.js` which:
+
+1. **Tracks tool call count** per session via a temp file keyed by `CLAUDE_SESSION_ID`
+2. **Suggests `/compact` at threshold** (default 50 tool calls) — signals you're likely transitioning from exploration to execution
+3. **Suggests again every 25 calls** after threshold — periodic checkpoints for stale context
+
+## Why manual over auto-compact
+
+- Auto-compact happens at arbitrary points, often mid-task
+- Strategic compacting preserves context through logical phases
+- Compact after exploration, before execution
+- Compact after completing a milestone, before starting the next
+
+## Configuration
+
+Set `COMPACT_THRESHOLD` environment variable to override the default 50-call threshold.
+
+## Files
+
+- `scripts/suggest-compact.js` — the hook implementation
+- Registered in `hooks/hooks.json` as a PreToolUse hook on Edit/Write
+- Works with `scripts/hooks/pre-compact.js` which saves state before compaction

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -10,7 +10,7 @@ Hook-driven system that suggests manual `/compact` at strategic intervals rather
 
 ## How it works
 
-A PreToolUse hook on Edit/Write runs `scripts/suggest-compact.js` which:
+A PreToolUse hook on Edit/Write runs `skills/strategic-compact/scripts/suggest-compact.js` which:
 
 1. **Tracks tool call count** per session via a temp file keyed by `CLAUDE_SESSION_ID`
 2. **Suggests `/compact` at threshold** (default 50 tool calls) — signals you're likely transitioning from exploration to execution
@@ -29,6 +29,6 @@ Set `COMPACT_THRESHOLD` environment variable to override the default 50-call thr
 
 ## Files
 
-- `scripts/suggest-compact.js` — the hook implementation
+- `skills/strategic-compact/scripts/suggest-compact.js` — the hook implementation
 - Registered in `hooks/hooks.json` as a PreToolUse hook on Edit/Write
 - Works with `scripts/hooks/pre-compact.js` which saves state before compaction

--- a/skills/strategic-compact/scripts/suggest-compact.js
+++ b/skills/strategic-compact/scripts/suggest-compact.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Strategic Compact Suggester
+ *
+ * Cross-platform (Windows, macOS, Linux)
+ *
+ * Runs on PreToolUse or periodically to suggest manual compaction at logical intervals
+ *
+ * Why manual over auto-compact:
+ * - Auto-compact happens at arbitrary points, often mid-task
+ * - Strategic compacting preserves context through logical phases
+ * - Compact after exploration, before execution
+ * - Compact after completing a milestone, before starting next
+ */
+
+const path = require('path');
+const {
+  getTempDir,
+  readFile,
+  writeFile,
+  log
+} = require('../../../scripts/lib/utils');
+
+async function main() {
+  // Track tool call count (increment in a temp file)
+  // Use a session-specific counter file based on PID from parent process
+  // or session ID from environment
+  const sessionId = process.env.CLAUDE_SESSION_ID || process.ppid || 'default';
+  const counterFile = path.join(getTempDir(), `claude-tool-count-${sessionId}`);
+  const threshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
+
+  let count = 1;
+
+  // Read existing count or start at 1
+  const existing = readFile(counterFile);
+  if (existing) {
+    count = parseInt(existing.trim(), 10) + 1;
+  }
+
+  // Save updated count
+  writeFile(counterFile, String(count));
+
+  // Suggest compact after threshold tool calls
+  if (count === threshold) {
+    log(`[StrategicCompact] ${threshold} tool calls reached - consider /compact if transitioning phases`);
+  }
+
+  // Suggest at regular intervals after threshold
+  if (count > threshold && count % 25 === 0) {
+    log(`[StrategicCompact] ${count} tool calls - good checkpoint for /compact if context is stale`);
+  }
+
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('[StrategicCompact] Error:', err.message);
+  process.exit(0);
+});

--- a/skills/strategic-compact/scripts/suggest-compact.js
+++ b/skills/strategic-compact/scripts/suggest-compact.js
@@ -27,7 +27,8 @@ async function main() {
   // or session ID from environment
   const sessionId = process.env.CLAUDE_SESSION_ID || process.ppid || 'default';
   const counterFile = path.join(getTempDir(), `claude-tool-count-${sessionId}`);
-  const threshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
+  const parsedThreshold = parseInt(process.env.COMPACT_THRESHOLD || '50', 10);
+  const threshold = Number.isFinite(parsedThreshold) ? parsedThreshold : 50;
 
   let count = 1;
 

--- a/skills/strategic-compact/scripts/suggest-compact.js
+++ b/skills/strategic-compact/scripts/suggest-compact.js
@@ -34,7 +34,8 @@ async function main() {
   // Read existing count or start at 1
   const existing = readFile(counterFile);
   if (existing) {
-    count = parseInt(existing.trim(), 10) + 1;
+    const parsed = parseInt(existing.trim(), 10);
+    count = (Number.isFinite(parsed) ? parsed : 0) + 1;
   }
 
   // Save updated count

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: update-docs
 description: Update project documentation, specs, and changelog based on recent changes
-user_invocable: true
+user-invocable: true
 arguments: Optional spec name to focus on (e.g., "auth-system")
 ---
 

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: update-docs
+description: Update project documentation, specs, and changelog based on recent changes
+user_invocable: true
+arguments: Optional spec name to focus on (e.g., "auth-system")
+---
+
+# /update-docs
+
+Update all project documentation by delegating to the `@doc-updater` agent.
+
+## Instructions
+
+Run the `@doc-updater` agent to detect changed workspaces, update workspace-level docs, and synchronize root-level tracking files (SPECLOG.md, CHANGELOG.md, tasks.md).
+
+If `$ARGUMENTS` is provided, focus the update on the specified spec only — still update SPECLOG.md and CHANGELOG.md but scope task detection and doc updates to that spec's files and related workspaces.
+
+If no arguments are provided, perform a full documentation update across all workspaces and specs.

--- a/templates/CHANGELOG.md
+++ b/templates/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed

--- a/templates/SPECLOG.md
+++ b/templates/SPECLOG.md
@@ -1,0 +1,5 @@
+# SPECLOG
+
+| Spec | Status | Owner | Last Updated |
+|------|--------|-------|--------------|
+| — | — | — | — |

--- a/templates/docs/README.md
+++ b/templates/docs/README.md
@@ -1,9 +1,7 @@
 # Documentation
 
+> This folder is managed by `@doc-updater`. Documentation files (setup.md, architecture.md, api.md, etc.) are generated on first run based on actual project code and specs.
+
 ## Contents
 
-- [Setup Guide](./setup.md)
-- [Architecture](./architecture.md)
-- [API Reference](./api.md)
-
-<!-- This folder is managed by @doc-updater. Files are generated from source code and specs. -->
+Files will appear here after running `/update-docs` or `@doc-updater`.

--- a/templates/docs/README.md
+++ b/templates/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+## Contents
+
+- [Setup Guide](./setup.md)
+- [Architecture](./architecture.md)
+- [API Reference](./api.md)
+
+<!-- This folder is managed by @doc-updater. Files are generated from source code and specs. -->

--- a/templates/specs/design.md
+++ b/templates/specs/design.md
@@ -1,0 +1,26 @@
+# Design: [Spec Name]
+
+## Architecture
+<!-- High-level architecture description and diagram references -->
+
+## Data Model
+<!-- Key entities, relationships, schemas -->
+
+## API Design
+<!-- Endpoints, request/response shapes, auth -->
+
+## Key Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| ... | ... | ... | ... |
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| ... | ... | ... | ... |
+
+## Dependencies
+<!-- External services, libraries, or other specs this depends on -->
+- ...

--- a/templates/specs/requirements.md
+++ b/templates/specs/requirements.md
@@ -1,0 +1,24 @@
+# Requirements: [Spec Name]
+
+## Overview
+<!-- Brief description of what this spec covers -->
+
+## User Stories
+<!-- As a [role], I want [feature], so that [benefit] -->
+- [ ] ...
+
+## Functional Requirements
+<!-- What the system must do -->
+1. ...
+
+## Non-Functional Requirements
+<!-- Performance, security, scalability, etc. -->
+1. ...
+
+## Constraints
+<!-- Technical, timeline, or resource constraints -->
+- ...
+
+## Open Questions
+<!-- Unresolved decisions or unknowns -->
+- [ ] ...

--- a/templates/specs/tasks.md
+++ b/templates/specs/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: [Spec Name]
+
+## Phase 1: [Phase Name]
+- [ ] Task description
+- [ ] Task description
+
+## Phase 2: [Phase Name]
+- [ ] Task description
+- [ ] Task description
+
+## Completed
+<!-- Move completed tasks here with date -->
+
+## Blocked
+<!-- Tasks that are blocked, with reason -->


### PR DESCRIPTION
## Summary
- **Profile-based installer** — auto-detects project type (typescript, python, frontend, backend, monorepo) via `config/profiles.json` and installs only relevant plugins, skills, agents, and templates per profile
- **Spec-driven development** — templates for requirements/design/tasks specs, SPECLOG.md, CHANGELOG.md, and docs/ folders at root and each workspace
- **Two new agents** — `@context-loader` (session briefing + task prioritization) and `@doc-updater` (hierarchical doc updates with parallel sub-agents)
- **Spec-aware session hooks** — session-start detects in-progress specs and suggests `@context-loader`; session-end detects modified spec files and suggests `@doc-updater`
- **`/update-docs` skill** — user-invocable entry point for `@doc-updater`
- **Hook shell fix** — replaced `execSync` with `spawnSync` in `runCommand()` and `check-console-log.js` to fix `ENOENT: posix_spawn '/bin/sh'` errors in sandboxed environments

## Test plan
- [ ] Run `node scripts/configure-claude.js /tmp/test-monorepo` against a mono-repo with `backend/` (react dep) and `frontend/` (tsconfig.json)
- [ ] Verify root gets monorepo-root profile (agents, specs, SPECLOG, CHANGELOG, docs/)
- [ ] Verify workspaces get workspace-specific profiles (no agents, profile-specific plugins)
- [ ] Re-run installer and verify templates are NOT overwritten
- [ ] Verify session-start hook detects specs and suggests @context-loader
- [ ] Verify stop/session-end hooks no longer throw ENOENT errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mono-repo support with automatic workspace detection and per-workspace installs
  * Spec-driven workflow: SPECLOG/CHANGELOG scaffolding, spec/task tracking, and profile-based installer (v1.5)
  * New agents: Context Loader (project briefings) and Doc Updater (automated docs sync)
  * New skills: installer, spec-interview, update-docs, and strategic compaction with suggestion script
  * Session start/end now surface spec status and doc-update prompts

* **Documentation**
  * Added templates for specs, changelogs, and docs; README updated for v1.5
<!-- end of auto-generated comment: release notes by coderabbit.ai -->