### PR TITLE
Add @browser agent, Excalidraw MCP, and installer improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
 skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
-agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater)
+agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
 
@@ -25,7 +25,8 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 - `~/.claude/settings.local.json` — local settings; `enabledMcpjsonServers` is an array of names
 - `~/.claude/plugins/known_marketplaces.json` — object keyed by marketplace name (not an array)
 - `~/.config/ccstatusline/settings.json` — ccstatusline layout config
-- `config/global-settings.json` — this repo's manifest of expected global state
+- `~/.mcp.json` — global MCP server configs; installer auto-adds missing servers from manifest
+- `config/global-settings.json` — this repo's manifest of expected global state; `mcpServers` is an object of server configs (not a name array)
 - `config/profiles.json` — profile detection signals and profile→plugin/skill/agent mappings
 
 ## Gotchas
@@ -44,7 +45,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 
 ## Versioning
 
-Current version: **1.5**
+Current version: **1.6**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -52,6 +53,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.6** — `@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
 - **1.3** — Added `configure-claude.js` installer script, `config/global-settings.json` manifest; skill now invokes the script directly

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ When installed with the `monorepo-root` profile, the installer creates:
 ## MCP Servers
 
 The installer auto-configures MCP servers defined in `config/global-settings.json`:
-- **sequential-thinking** — structured reasoning via `@modelcontextprotocol/server-sequential-thinking`
-- **excalidraw** — hand-drawn architecture diagrams via [Excalidraw MCP](https://github.com/excalidraw/excalidraw-mcp) (used by `@doc-updater`)
+- **sequential-thinking** — structured reasoning via `@modelcontextprotocol/server-sequential-thinking` (stdio, runs locally)
+- **excalidraw** — hand-drawn architecture diagrams via [excalidraw-mcp](https://github.com/excalidraw/excalidraw-mcp) (used by `@doc-updater`)
+  - Default URL points to the Excalidraw team's Vercel deployment (`excalidraw-mcp-ashy.vercel.app`)
+  - To self-host: clone the [repo](https://github.com/excalidraw/excalidraw-mcp), build, and update the `url` in `config/global-settings.json`
 
 Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.json` automatically.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.5**
+**Version: 1.6**
 
 ## Getting started
 
@@ -15,7 +15,7 @@ scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json
 plugins/     # Claude Code plugins
 skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
-agents/      # Agent definitions (@context-loader, @doc-updater)
+agents/      # Agent definitions (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates
 ```
 
@@ -35,7 +35,8 @@ node scripts/configure-claude.js /path/to/monorepo
 ## Agents
 
 - **`@context-loader`** — Reads all spec state, git history, and produces a prioritized briefing for the session
-- **`@doc-updater`** — Detects changed workspaces, fans out parallel sub-agents to update docs, then updates root tracking files
+- **`@doc-updater`** — Detects changed workspaces, fans out parallel sub-agents to update docs, creates architecture diagrams via Excalidraw MCP, then updates root tracking files
+- **`@browser`** — Browser automation via `agent-browser` CLI — screenshots, navigation, clicking, form filling, and visual verification
 
 ## Spec-driven Development
 
@@ -45,8 +46,17 @@ When installed with the `monorepo-root` profile, the installer creates:
 - `CHANGELOG.md` — keep-a-changelog format
 - `docs/` — documentation folder at root and each workspace
 
+## MCP Servers
+
+The installer auto-configures MCP servers defined in `config/global-settings.json`:
+- **sequential-thinking** — structured reasoning via `@modelcontextprotocol/server-sequential-thinking`
+- **excalidraw** — hand-drawn architecture diagrams via [Excalidraw MCP](https://github.com/excalidraw/excalidraw-mcp) (used by `@doc-updater`)
+
+Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.json` automatically.
+
 ## Changelog
 
+- **1.6** — `@browser` agent, Excalidraw MCP integration for `@doc-updater`, MCP auto-installation, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer, agents, templates, spec-aware hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
 - **1.3** — Added `configure-claude.js` installer script + `config/global-settings.json` manifest

--- a/agents/browser.md
+++ b/agents/browser.md
@@ -1,0 +1,108 @@
+---
+name: browser
+description: "Use this agent for browser automation — screenshots, navigation, clicking, form filling, and visual verification. Powered by agent-browser CLI."
+model: sonnet
+color: magenta
+tools: ["Bash", "Read", "Glob", "Grep"]
+---
+
+# Browser Automation Agent
+
+You are a browser automation agent powered by the `agent-browser` CLI tool. You navigate pages, interact with elements, take screenshots, and verify visual state for testing and development workflows.
+
+## Prerequisites
+
+Before any browser operation, verify `agent-browser` is installed:
+
+```bash
+which agent-browser
+```
+
+If not found, prompt the user to install it:
+
+```bash
+npm install -g agent-browser && agent-browser install
+```
+
+Do NOT install automatically — ask the user first.
+
+## Core Workflow
+
+1. **Open** a URL to start a browser session
+2. **Snapshot** to get the accessibility tree with element `@ref` identifiers
+3. **Interact** using `@ref` values (click, fill, select)
+4. **Screenshot** to capture visual state for verification
+5. **Close** the session when done
+
+## Command Reference
+
+All commands are run via `agent-browser <command>`:
+
+| Command | Description |
+|---------|-------------|
+| `open <url>` | Open a URL (starts a session) |
+| `snapshot` | Get accessibility tree with `@ref` element identifiers |
+| `screenshot <path>` | Save a screenshot to file |
+| `click @<ref>` | Click an element by its ref |
+| `fill @<ref> "<value>"` | Type into an input element |
+| `select @<ref> "<value>"` | Select a dropdown option |
+| `hover @<ref>` | Hover over an element |
+| `scroll <direction>` | Scroll up/down/left/right |
+| `wait <ms>` | Wait for a duration |
+| `find "<text>"` | Search visible text on page |
+| `close` | Close the browser session |
+
+## Session Management
+
+Use the `--session <name>` flag to isolate browser instances when running multiple tasks:
+
+```bash
+agent-browser --session login-test open http://localhost:3000/login
+agent-browser --session login-test snapshot
+agent-browser --session login-test screenshot /tmp/login.png
+agent-browser --session login-test close
+```
+
+Always pass the same `--session` flag for all commands in a workflow.
+
+## Testing Patterns
+
+### Visual Verification
+
+1. Navigate to the target page
+2. Take a snapshot to discover element refs
+3. Interact with the page (fill forms, click buttons)
+4. Screenshot after each significant interaction
+5. Compare the result against expected state
+
+### Form Testing
+
+```bash
+agent-browser open http://localhost:3000/login
+agent-browser snapshot                          # Find input refs
+agent-browser fill @username "testuser"
+agent-browser fill @password "testpass"
+agent-browser click @submit
+agent-browser wait 1000
+agent-browser screenshot ./test-results/login-result.png
+agent-browser close
+```
+
+### Page Content Verification
+
+```bash
+agent-browser open http://localhost:3000/dashboard
+agent-browser snapshot                          # Read the accessibility tree
+agent-browser find "Welcome"                    # Verify expected text
+agent-browser close
+```
+
+## Guidelines
+
+- Always close sessions when done to avoid leaked browser processes
+- Use `snapshot` (accessibility tree) for element discovery — it's faster and more reliable than screenshots for finding interactive elements
+- Use `screenshot` for visual verification and capturing test evidence
+- Save screenshots to the project's temp or test-results directory
+- When a page has dynamic content, use `wait` before taking snapshots or screenshots
+- If an element ref from a snapshot doesn't work, re-snapshot — refs can change after page mutations
+- Report clear pass/fail results after verification steps

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -3,7 +3,7 @@ name: doc-updater
 description: "Use this agent when ending a session or after completing work on a spec. Detects which workspaces changed, fans out parallel sub-agents for each, then updates root documentation."
 model: sonnet
 color: green
-tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task"]
+tools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash", "Task", "mcp__excalidraw__read_me", "mcp__excalidraw__create_view", "mcp__excalidraw__export_to_excalidraw"]
 ---
 
 # Doc Updater Agent
@@ -58,6 +58,27 @@ After workspace docs are done, update root-level files:
 #### Update root docs/ and README.md
 - Update root `docs/` folder with any cross-cutting documentation changes
 - Update root `README.md` if project structure or setup instructions changed
+
+#### Create or Update Architecture Diagrams
+
+When documentation changes affect service architecture, data flows, or system structure, create or update diagrams using the Excalidraw MCP:
+
+1. **Get the element format reference** — call `mcp__excalidraw__read_me` to load the Excalidraw cheat sheet (color palettes, element types, layout tips)
+2. **Create the diagram** — call `mcp__excalidraw__create_view` with a JSON array of Excalidraw elements describing the architecture (boxes for services, arrows for data flow, labels for names)
+3. **Export a shareable link** — call `mcp__excalidraw__export_to_excalidraw` with the diagram JSON to get a permanent excalidraw.com URL
+4. **Embed in docs** — add the shareable URL to the relevant documentation file (e.g., `docs/architecture.md`) as a link or in a diagram section
+
+**When to create diagrams:**
+- New service or workspace added to a mono-repo
+- Significant changes to inter-service communication or data flow
+- New API integrations or external dependencies
+- When existing text-only docs would benefit from a visual overview
+
+**Diagram conventions:**
+- Keep diagrams focused — one diagram per concern (architecture overview, data flow, deployment topology)
+- Use clear labels and consistent color coding (refer to the cheat sheet)
+- Store diagram links in `docs/` alongside related documentation
+- Include a brief text description above each diagram link for accessibility
 
 ### 5. Report Summary
 

--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -18,9 +18,18 @@
     "frontend-design@claude-plugins-official",
     "feature-dev@claude-plugins-official"
   ],
-  "mcpServers": [
-    "sequential-thinking"
-  ],
+  "mcpServers": {
+    "sequential-thinking": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+      "env": {}
+    },
+    "excalidraw": {
+      "type": "url",
+      "url": "https://excalidraw-mcp-ashy.vercel.app/mcp"
+    }
+  },
   "statusLine": {
     "type": "command",
     "command": "npx -y ccstatusline@latest",

--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -27,7 +27,9 @@
     },
     "excalidraw": {
       "type": "url",
-      "url": "https://excalidraw-mcp-ashy.vercel.app/mcp"
+      "url": "https://excalidraw-mcp-ashy.vercel.app/mcp",
+      "_repo": "https://github.com/excalidraw/excalidraw-mcp",
+      "_note": "Vercel deployment maintained by the Excalidraw team. Replace URL to use a self-hosted instance."
     }
   },
   "statusLine": {

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -40,7 +40,8 @@
     },
     "frontend": {
       "extends": "typescript",
-      "plugins": ["frontend-design@claude-plugins-official"]
+      "plugins": ["frontend-design@claude-plugins-official"],
+      "agents": ["browser"]
     },
     "backend": {
       "extends": "base",
@@ -49,7 +50,7 @@
     "monorepo-root": {
       "extends": "base",
       "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start"],
-      "agents": ["context-loader", "doc-updater"],
+      "agents": ["context-loader", "doc-updater", "browser"],
       "templates": ["specs"]
     }
   }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -478,7 +478,11 @@ function checkGlobalSettings(manifest, projectSettingsPaths) {
       if (mcpServers[name]) {
         console.log(`  ✓ MCP server: ${name} (already in ~/.mcp.json)`);
       } else {
-        mcpServers[name] = config;
+        // Strip metadata keys (prefixed with _) before writing
+        const cleanConfig = Object.fromEntries(
+          Object.entries(config).filter(([k]) => !k.startsWith('_'))
+        );
+        mcpServers[name] = cleanConfig;
         mcpChanged = true;
         console.log(`  ✓ MCP server: ${name} (added to ~/.mcp.json)`);
       }
@@ -486,6 +490,7 @@ function checkGlobalSettings(manifest, projectSettingsPaths) {
 
     if (mcpChanged) {
       mcpJson.mcpServers = mcpServers;
+      fs.mkdirSync(path.dirname(HOME_MCP_JSON), { recursive: true });
       fs.writeFileSync(HOME_MCP_JSON, JSON.stringify(mcpJson, null, 2) + '\n');
     }
 
@@ -504,6 +509,7 @@ function checkGlobalSettings(manifest, projectSettingsPaths) {
 
     if (localChanged) {
       localSettings.enabledMcpjsonServers = enabledServers;
+      fs.mkdirSync(path.dirname(HOME_SETTINGS_LOCAL), { recursive: true });
       fs.writeFileSync(HOME_SETTINGS_LOCAL, JSON.stringify(localSettings, null, 2) + '\n');
     }
   }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -23,9 +23,11 @@ const SCRIPTS_LIB = path.join(CONFIG_REPO, 'scripts', 'lib');
 const SKILLS_DIR = path.join(CONFIG_REPO, 'skills');
 const AGENTS_DIR = path.join(CONFIG_REPO, 'agents');
 const TEMPLATES_DIR = path.join(CONFIG_REPO, 'templates');
-const HOME_SETTINGS = path.join(require('os').homedir(), '.claude', 'settings.json');
-const HOME_SETTINGS_LOCAL = path.join(require('os').homedir(), '.claude', 'settings.local.json');
-const KNOWN_MARKETPLACES = path.join(require('os').homedir(), '.claude', 'plugins', 'known_marketplaces.json');
+const HOME_DIR = require('os').homedir();
+const HOME_SETTINGS = path.join(HOME_DIR, '.claude', 'settings.json');
+const HOME_SETTINGS_LOCAL = path.join(HOME_DIR, '.claude', 'settings.local.json');
+const HOME_MCP_JSON = path.join(HOME_DIR, '.mcp.json');
+const KNOWN_MARKETPLACES = path.join(HOME_DIR, '.claude', 'plugins', 'known_marketplaces.json');
 
 function copyDirSync(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -407,16 +409,25 @@ function main() {
   if (!manifest) {
     console.log('  ⚠ Could not read global manifest, skipping global check');
   } else {
-    checkGlobalSettings(manifest, path.join(targetDir, '.claude', 'settings.json'));
+    const settingsPaths = [path.join(targetDir, '.claude', 'settings.json')];
+    if (isMonorepo) {
+      const workspaces = findWorkspaces(targetDir);
+      for (const ws of workspaces) {
+        settingsPaths.push(path.join(ws.path, '.claude', 'settings.json'));
+      }
+    }
+    checkGlobalSettings(manifest, settingsPaths);
   }
 
   console.log('\nDone!\n');
 }
 
-function checkGlobalSettings(manifest, projectSettingsPath) {
+function checkGlobalSettings(manifest, projectSettingsPaths) {
   const globalSettings = readJsonSync(HOME_SETTINGS);
   const globalLocal = readJsonSync(HOME_SETTINGS_LOCAL);
-  const projectSettings = readJsonSync(projectSettingsPath);
+  const allProjectSettings = (Array.isArray(projectSettingsPaths) ? projectSettingsPaths : [projectSettingsPaths])
+    .map(p => readJsonSync(p))
+    .filter(Boolean);
   let allGood = true;
 
   // Check marketplaces (prerequisite for plugins)
@@ -434,43 +445,66 @@ function checkGlobalSettings(manifest, projectSettingsPath) {
     }
   }
 
-  // Check plugins (global or project-scoped)
+  // Check plugins (global or project-scoped, including workspace settings)
   if (manifest.plugins) {
     const globalPlugins = globalSettings?.enabledPlugins;
-    const projectPlugins = projectSettings?.enabledPlugins;
-    if (!globalPlugins && !projectPlugins) {
+    if (!globalPlugins && allProjectSettings.length === 0) {
       console.log(`  ⚠ No enabledPlugins found in global or project settings — skipping plugin check`);
     } else {
       for (const plugin of manifest.plugins) {
         if (globalPlugins?.[plugin]) {
           console.log(`  ✓ Plugin: ${plugin} (global)`);
-        } else if (projectPlugins?.[plugin]) {
-          console.log(`  ✓ Plugin: ${plugin} (project)`);
         } else {
-          console.log(`  ✗ Plugin missing: ${plugin}`);
-          console.log(`    → Enable via Claude Code settings or add to ~/.claude/settings.json`);
-          allGood = false;
+          const foundIn = allProjectSettings.find(s => s.enabledPlugins?.[plugin]);
+          if (foundIn) {
+            console.log(`  ✓ Plugin: ${plugin} (project)`);
+          } else {
+            console.log(`  ✗ Plugin missing: ${plugin}`);
+            console.log(`    → Enable via Claude Code settings or add to ~/.claude/settings.json`);
+            allGood = false;
+          }
         }
       }
     }
   }
 
-  // Check MCP servers
-  if (manifest.mcpServers) {
-    const rawMcp = globalLocal?.enabledMcpServers;
-    const enabledMcp = Array.isArray(rawMcp)
-      ? rawMcp
-      : (rawMcp && typeof rawMcp === 'object')
-        ? Object.keys(rawMcp).filter(k => rawMcp[k])
-        : [];
-    for (const server of manifest.mcpServers) {
-      if (enabledMcp.includes(server)) {
-        console.log(`  ✓ MCP server: ${server}`);
+  // Install and check MCP servers
+  if (manifest.mcpServers && typeof manifest.mcpServers === 'object') {
+    const mcpJson = readJsonSync(HOME_MCP_JSON) || {};
+    const mcpServers = mcpJson.mcpServers || {};
+    let mcpChanged = false;
+
+    for (const [name, config] of Object.entries(manifest.mcpServers)) {
+      if (mcpServers[name]) {
+        console.log(`  ✓ MCP server: ${name} (already in ~/.mcp.json)`);
       } else {
-        console.log(`  ✗ MCP server missing: ${server}`);
-        console.log(`    → Add "${server}" to enabledMcpServers in ~/.claude/settings.local.json`);
-        allGood = false;
+        mcpServers[name] = config;
+        mcpChanged = true;
+        console.log(`  ✓ MCP server: ${name} (added to ~/.mcp.json)`);
       }
+    }
+
+    if (mcpChanged) {
+      mcpJson.mcpServers = mcpServers;
+      fs.writeFileSync(HOME_MCP_JSON, JSON.stringify(mcpJson, null, 2) + '\n');
+    }
+
+    // Ensure servers are enabled in settings.local.json
+    const localSettings = readJsonSync(HOME_SETTINGS_LOCAL) || {};
+    const enabledServers = localSettings.enabledMcpjsonServers || [];
+    let localChanged = false;
+
+    for (const name of Object.keys(manifest.mcpServers)) {
+      if (!enabledServers.includes(name)) {
+        enabledServers.push(name);
+        localChanged = true;
+        console.log(`  ✓ MCP server: ${name} (enabled in settings.local.json)`);
+      }
+    }
+
+    if (localChanged) {
+      localSettings.enabledMcpjsonServers = enabledServers;
+      fs.writeFileSync(HOME_SETTINGS_LOCAL, JSON.stringify(localSettings, null, 2) + '\n');
     }
   }
 


### PR DESCRIPTION
## Summary

- **New `@browser` agent** — browser automation via `agent-browser` CLI (screenshots, navigation, clicking, form filling, visual verification)
- **Excalidraw MCP integration** — `@doc-updater` agent can now create architecture diagrams using the Excalidraw MCP (`read_me`, `create_view`, `export_to_excalidraw`)
- **MCP auto-installation** — `configure-claude.js` now writes MCP server configs to `~/.mcp.json` and enables them in `settings.local.json` (previously only checked, didn't install)
- **Monorepo plugin check fix** — global settings check now scans workspace-level `.claude/settings.json` files, eliminating false negatives for profile-specific plugins

## Test plan

- [ ] Run `node scripts/configure-claude.js /tmp/test-project` — verify MCP servers are added to `~/.mcp.json`
- [ ] Run against a frontend project — verify `browser.md` agent is copied
- [ ] Run against a monorepo — verify all plugins show green (no false missing plugins)
- [ ] Verify `~/.claude/settings.local.json` has `excalidraw` in `enabledMcpjsonServers`
- [ ] Clean up test dirs after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser Automation Agent for interactive web testing and page automation.
  * Excalidraw integration for generating and embedding architecture diagrams.
  * Configurable MCP servers (including sequential-thinking and excalidraw) with automatic configuration handling.

* **Documentation**
  * Detailed Browser Agent guide and command references.
  * Doc Updater docs updated with diagram-creation workflows and templates.

* **Bug Fixes**
  * Improved workspace/plugin checks and multi-workspace settings handling.

* **Version**
  * Released version 1.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->