### PR TITLE
Add Context7 MCP server and /context7 skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7)
 agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
@@ -45,7 +45,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 
 ## Versioning
 
-Current version: **1.6**
+Current version: **1.7**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -53,6 +53,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 - `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths
 - `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`
 - Git repo lives at `Projects/claude/`, NOT at parent `Projects/` — was migrated in this session
+- Profiles in `profiles.json` with an explicit `skills` array override (not merge with) the parent — when adding a new skill to `base`, also add it to `monorepo-root` and any other profile that declares its own `skills`
+- `config/global-settings.json` stores empty placeholders for API keys (e.g., `CONTEXT7_API_KEY: ""`); actual keys go in `~/.mcp.json` only — never commit real keys to the manifest
+- When writing MCP skills, verify tool names against the live server or latest README — tool names change across versions (e.g., Context7 renamed `get-library-docs` → `query-docs`)
 
 ## Testing configure-claude.js
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The installer auto-configures MCP servers defined in `config/global-settings.jso
 - **excalidraw** — hand-drawn architecture diagrams via [excalidraw-mcp](https://github.com/excalidraw/excalidraw-mcp) (used by `@doc-updater`)
   - Default URL points to the Excalidraw team's Vercel deployment (`excalidraw-mcp-ashy.vercel.app`)
   - To self-host: clone the [repo](https://github.com/excalidraw/excalidraw-mcp), build, and update the `url` in `config/global-settings.json`
+- **context7** — current, version-specific library documentation via [Context7](https://github.com/upstash/context7) (used by `/context7` skill, no API key required)
 
 Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.json` automatically.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.6**
+**Version: 1.7**
 
 ## Getting started
 
@@ -14,7 +14,7 @@ commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs)
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7)
 agents/      # Agent definitions (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates
 ```
@@ -59,6 +59,7 @@ Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.js
 
 ## Changelog
 
+- **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent, Excalidraw MCP integration for `@doc-updater`, MCP auto-installation, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer, agents, templates, spec-aware hooks
 - **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array

--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -32,14 +32,13 @@
       "_note": "Vercel deployment maintained by the Excalidraw team. Replace URL to use a self-hosted instance."
     },
     "context7": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"],
-      "env": {
+      "type": "url",
+      "url": "https://mcp.context7.com/mcp",
+      "headers": {
         "CONTEXT7_API_KEY": ""
       },
       "_repo": "https://github.com/upstash/context7",
-      "_note": "Fetches current library documentation. No API key required (optional for higher rate limits)."
+      "_note": "Fetches current library documentation. Set CONTEXT7_API_KEY for higher rate limits."
     }
   },
   "statusLine": {

--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -35,6 +35,9 @@
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp"],
+      "env": {
+        "CONTEXT7_API_KEY": ""
+      },
       "_repo": "https://github.com/upstash/context7",
       "_note": "Fetches current library documentation. No API key required (optional for higher rate limits)."
     }

--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -30,6 +30,13 @@
       "url": "https://excalidraw-mcp-ashy.vercel.app/mcp",
       "_repo": "https://github.com/excalidraw/excalidraw-mcp",
       "_note": "Vercel deployment maintained by the Excalidraw team. Replace URL to use a self-hosted instance."
+    },
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"],
+      "_repo": "https://github.com/upstash/context7",
+      "_note": "Fetches current library documentation. No API key required (optional for higher rate limits)."
     }
   },
   "statusLine": {

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -27,7 +27,7 @@
         "security-guidance@claude-plugins-official",
         "feature-dev@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7"],
       "agents": []
     },
     "typescript": {

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -49,7 +49,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7"],
       "agents": ["context-loader", "doc-updater", "browser"],
       "templates": ["specs"]
     }

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: context7
+description: "Look up current, version-specific library documentation using Context7. Use proactively when working with libraries or explicitly via /context7."
+user-invocable: true
+arguments: "Optional library name and query (e.g., 'next.js app router', 'react useEffect cleanup')"
+argument-hint: "[library] [query]"
+---
+
+# /context7
+
+Fetch up-to-date library documentation using the Context7 MCP server. This avoids generating code with deprecated APIs or hallucinated methods.
+
+## Instructions
+
+### Explicit invocation (`/context7 <args>`)
+
+If `$ARGUMENTS` is provided, parse it as a library name and optional query:
+1. Call `mcp__context7__resolve-library-id` with the library name to get the Context7 library ID
+2. Call `mcp__context7__get-library-docs` with the resolved ID and query to fetch current documentation
+3. Summarize the relevant docs and apply them to the current task
+
+Examples:
+- `/context7 next.js app router` — look up Next.js App Router docs
+- `/context7 react` — browse React documentation
+- `/context7 prisma migrations` — look up Prisma migration docs
+
+### Proactive use (no explicit invocation)
+
+Use Context7 automatically during normal coding when:
+- **Implementing with a framework you're unsure about** — check current API before generating code
+- **Version-specific behavior matters** — the project pins a specific major version and you need to match its API
+- **Recently evolved libraries** — Next.js, React (server components), SvelteKit, tRPC, Prisma, Drizzle, TanStack, and similar fast-moving projects
+- **New dependencies** — the project has a dependency you haven't seen in this session; look up its API before using it
+- **User asks to "use context7"** — always honor explicit requests
+
+Skip Context7 when:
+- Working with stable, well-known APIs (Node.js built-ins, basic Express patterns, standard SQL)
+- The user has already provided documentation or examples in the conversation
+- Making trivial changes that don't involve library API calls
+
+### MCP Tools Reference
+
+| Tool | Purpose | Key Parameters |
+|------|---------|----------------|
+| `mcp__context7__resolve-library-id` | Find a library's Context7 ID | `libraryName` (required) |
+| `mcp__context7__get-library-docs` | Fetch docs for a library | `libraryId` (required, e.g., `/vercel/next.js`), `query` (required), `topic` (optional) |
+
+### Workflow
+
+1. **Resolve** — call `resolve-library-id` with the library name to get its ID (format: `/org/project`)
+2. **Query** — call `get-library-docs` with the ID and a specific question
+3. **Apply** — use the returned documentation to write accurate, current code

--- a/skills/context7/SKILL.md
+++ b/skills/context7/SKILL.md
@@ -16,7 +16,7 @@ Fetch up-to-date library documentation using the Context7 MCP server. This avoid
 
 If `$ARGUMENTS` is provided, parse it as a library name and optional query:
 1. Call `mcp__context7__resolve-library-id` with the library name to get the Context7 library ID
-2. Call `mcp__context7__get-library-docs` with the resolved ID and query to fetch current documentation
+2. Call `mcp__context7__query-docs` with the resolved ID and query to fetch current documentation
 3. Summarize the relevant docs and apply them to the current task
 
 Examples:
@@ -43,10 +43,10 @@ Skip Context7 when:
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `mcp__context7__resolve-library-id` | Find a library's Context7 ID | `libraryName` (required) |
-| `mcp__context7__get-library-docs` | Fetch docs for a library | `libraryId` (required, e.g., `/vercel/next.js`), `query` (required), `topic` (optional) |
+| `mcp__context7__query-docs` | Fetch docs for a library | `libraryId` (required, e.g., `/vercel/next.js`), `query` (required) |
 
 ### Workflow
 
 1. **Resolve** — call `resolve-library-id` with the library name to get its ID (format: `/org/project`)
-2. **Query** — call `get-library-docs` with the ID and a specific question
+2. **Query** — call `query-docs` with the ID and a specific question
 3. **Apply** — use the returned documentation to write accurate, current code


### PR DESCRIPTION
## Summary
- Adds Context7 MCP server (`@upstash/context7-mcp`) to `config/global-settings.json` for fetching current, version-specific library documentation
- Creates `/context7` skill with guidance for explicit invocation and proactive use during coding sessions
- Adds `context7` to the `base` profile in `config/profiles.json` so it's available in all projects
- Documents the new MCP server in `README.md`

## Test plan
- [x] Ran `configure-claude.js` against `/tmp/test-project` — Context7 MCP added to `~/.mcp.json` and skill copied successfully
- [ ] Verify `/context7 next.js app router` resolves library and fetches docs in a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Context7 skill to retrieve current library documentation.

* **Documentation**
  * Updated docs and changelog to v1.7 with Context7 usage, invocation examples, and proactive-use guidance.

* **Configuration**
  * Added Context7 MCP server to global settings and enabled the skill in base and monorepo-root profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->