### PR TITLE
Add Guardian + pre-commit review gate (v1.8–1.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Local project config (installed by configure-claude.js)
 .claude/
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
 skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
-agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser)
+agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser, @code-reviewer)
 templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
 
@@ -40,6 +40,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 - `config/global-settings.json` stores empty placeholders for API keys (e.g., `CONTEXT7_API_KEY: ""`); actual keys go in `~/.mcp.json` only — never commit real keys to the manifest
 - When writing MCP skills, verify tool names against the live server or latest README — tool names change across versions (e.g., Context7 renamed `get-library-docs` → `query-docs`)
 - Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"` — `"url"` fails schema validation
+- Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]` in commit message, `docs:`/`chore:`/`style:` prefix, or md-only changes
 
 ## Testing configure-claude.js
 
@@ -49,7 +50,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 
 ## Versioning
 
-Current version: **1.8**
+Current version: **1.9**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -57,6 +58,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.9** — Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits
 - **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
 - **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7)
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
 agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
@@ -49,7 +49,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 
 ## Versioning
 
-Current version: **1.7**
+Current version: **1.8**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -57,6 +57,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
 - **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.7**
+**Version: 1.8**
 
 ## Getting started
 
@@ -14,7 +14,7 @@ commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7)
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
 agents/      # Agent definitions (@context-loader, @doc-updater, @browser)
 templates/   # Spec, doc, and changelog templates
 ```
@@ -59,6 +59,7 @@ Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.js
 
 ## Changelog
 
+- **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
 - **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent, Excalidraw MCP integration for `@doc-updater`, MCP auto-installation, monorepo workspace plugin check fix
 - **1.5** — Mono-repo support + spec-driven development: profile-based installer, agents, templates, spec-aware hooks

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 1.8**
+**Version: 1.9**
 
 ## Getting started
 
@@ -15,7 +15,7 @@ scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json
 plugins/     # Claude Code plugins
 skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
-agents/      # Agent definitions (@context-loader, @doc-updater, @browser)
+agents/      # Agent definitions (@context-loader, @doc-updater, @browser, @code-reviewer)
 templates/   # Spec, doc, and changelog templates
 ```
 
@@ -37,6 +37,7 @@ node scripts/configure-claude.js /path/to/monorepo
 - **`@context-loader`** — Reads all spec state, git history, and produces a prioritized briefing for the session
 - **`@doc-updater`** — Detects changed workspaces, fans out parallel sub-agents to update docs, creates architecture diagrams via Excalidraw MCP, then updates root tracking files
 - **`@browser`** — Browser automation via `agent-browser` CLI — screenshots, navigation, clicking, form filling, and visual verification
+- **`@code-reviewer`** — Reviews staged git changes against CLAUDE.md conventions and codebase patterns; writes a review stamp on PASS to unlock the commit gate
 
 ## Spec-driven Development
 
@@ -59,6 +60,7 @@ Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.js
 
 ## Changelog
 
+- **1.9** — Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits
 - **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
 - **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
 - **1.6** — `@browser` agent, Excalidraw MCP integration for `@doc-updater`, MCP auto-installation, monorepo workspace plugin check fix

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -1,0 +1,123 @@
+---
+name: code-reviewer
+description: "Reviews staged git changes against CLAUDE.md conventions and codebase patterns. Returns PASS/BLOCKED verdict. Spawn with: @code-reviewer"
+model: sonnet
+color: yellow
+tools: ["Read", "Glob", "Grep", "Bash", "Write"]
+---
+
+# Code Reviewer Agent
+
+You review staged git changes for convention compliance, common issues, and pattern consistency. You produce a structured PASS or BLOCKED verdict.
+
+## Workflow
+
+### 1. Gather Input
+
+Run these commands to understand the change:
+
+```bash
+git diff --cached
+git diff --cached --name-only
+git log --oneline -5
+```
+
+### 2. Load Conventions
+
+Read all `CLAUDE.md` files in the repository (root + any workspace-level):
+
+```bash
+find . -name "CLAUDE.md" -not -path "*/node_modules/*" -not -path "*/.git/*" 2>/dev/null
+```
+
+Extract conventions, gotchas, patterns, and coding standards. If no CLAUDE.md exists, fall back to general best practices.
+
+### 3. Detect Active Spec (if applicable)
+
+If `.claude/specs/` exists:
+1. Get current branch name: `git branch --show-current`
+2. Check for spec keywords in the branch name
+3. Read matching `design.md` / `requirements.md` if found
+
+### 4. Scan Sibling Patterns
+
+For each changed file, read 1-2 sibling files in the same directory to understand established patterns:
+- Import style and ordering
+- Naming conventions (camelCase, snake_case, etc.)
+- Error handling approach
+- Type annotation patterns
+
+### 5. Review Checklist
+
+Check the staged diff against:
+
+- **Convention compliance** — Does the code follow CLAUDE.md rules and gotchas?
+- **Secrets and credentials** — No API keys, tokens, passwords, or .env values
+- **Debug artifacts** — No `console.log`, `debugger`, `TODO` left in production code
+- **Dead code** — No commented-out blocks, unused imports, unreachable code
+- **Error handling** — Are errors handled appropriately at system boundaries?
+- **Spec alignment** — If a spec is active, do changes match requirements?
+- **Pattern consistency** — Do changes match sibling file patterns?
+- **Security** — No obvious injection vectors, unsafe eval, or OWASP top-10 issues
+
+### 6. Verdict
+
+#### PASS
+
+If all checks pass:
+
+1. Print a structured summary:
+   ```
+   ## Review: PASS
+
+   **Files reviewed:** <list>
+   **Summary:** <1-2 sentence description of changes>
+   **Notes:** <any minor observations, optional>
+   ```
+
+2. Compute the diff hash and write the review stamp:
+   ```bash
+   node -e "
+     const crypto = require('crypto');
+     const { execSync } = require('child_process');
+     const fs = require('fs');
+     const path = require('path');
+     const diff = execSync('git diff --cached', { encoding: 'utf8' });
+     const hash = crypto.createHash('sha256').update(diff).digest('hex');
+     const reviewDir = path.join(process.cwd(), '.claude');
+     if (!fs.existsSync(reviewDir)) fs.mkdirSync(reviewDir, { recursive: true });
+     fs.writeFileSync(path.join(reviewDir, '.last-review'), JSON.stringify({
+       diffHash: hash,
+       reviewedAt: new Date().toISOString(),
+       reviewer: 'code-reviewer'
+     }) + '\n');
+     console.log('Review stamp written: ' + hash.slice(0, 12) + '...');
+   "
+   ```
+
+#### BLOCKED
+
+If any issues are found:
+
+1. Print findings with `file:line` references and fix suggestions:
+   ```
+   ## Review: BLOCKED
+
+   ### Findings
+
+   1. **[severity]** `file.ts:42` — Description of issue
+      **Fix:** Suggested resolution
+
+   2. **[severity]** `file.ts:87` — Description of issue
+      **Fix:** Suggested resolution
+   ```
+
+2. Do **NOT** write the review stamp.
+
+## Guidelines
+
+- Be concise — focus on real issues, not style preferences already handled by formatters
+- Severity levels: `critical` (must fix), `warning` (should fix), `info` (consider)
+- Only BLOCK on `critical` findings — `warning` and `info` can pass with notes
+- When unsure if something is a real issue, check the codebase for precedent before flagging
+- The review stamp file (`.claude/.last-review`) should be in `.gitignore`

--- a/config/guardian-rules.json
+++ b/config/guardian-rules.json
@@ -1,0 +1,240 @@
+{
+  "mode": "autonomous",
+  "permissions": {
+    "autonomous": {
+      "allow": [
+        "Read",
+        "Glob",
+        "Grep",
+        "Write",
+        "Edit",
+        "NotebookEdit",
+        "WebFetch",
+        "WebSearch",
+        "Bash(git:*)",
+        "Bash(npm:*)",
+        "Bash(npx:*)",
+        "Bash(pnpm:*)",
+        "Bash(yarn:*)",
+        "Bash(bun:*)",
+        "Bash(node:*)",
+        "Bash(gh:*)",
+        "Bash(ls:*)",
+        "Bash(cat:*)",
+        "Bash(head:*)",
+        "Bash(tail:*)",
+        "Bash(wc:*)",
+        "Bash(find:*)",
+        "Bash(grep:*)",
+        "Bash(rg:*)",
+        "Bash(jq:*)",
+        "Bash(which:*)",
+        "Bash(pwd:*)",
+        "Bash(echo:*)",
+        "Bash(mkdir:*)",
+        "Bash(cp:*)",
+        "Bash(mv:*)",
+        "Bash(touch:*)",
+        "Bash(diff:*)",
+        "Bash(sort:*)",
+        "Bash(uniq:*)",
+        "Bash(tee:*)",
+        "Bash(sed:*)",
+        "Bash(awk:*)",
+        "Bash(curl:*)",
+        "Bash(wget:*)",
+        "Bash(docker:*)",
+        "Bash(python:*)",
+        "Bash(python3:*)",
+        "Bash(pip:*)",
+        "Bash(cargo:*)",
+        "Bash(make:*)",
+        "Bash(cmake:*)",
+        "Bash(go:*)",
+        "Bash(pytest:*)",
+        "Bash(vitest:*)",
+        "Bash(jest:*)",
+        "Bash(playwright:*)",
+        "Bash(tsc:*)",
+        "Bash(eslint:*)",
+        "Bash(prettier:*)",
+        "Bash(rm:*)",
+        "Bash(tmux:*)",
+        "Bash(env:*)",
+        "Bash(printenv:*)",
+        "Bash(date:*)",
+        "Bash(stat:*)",
+        "Bash(file:*)",
+        "Bash(realpath:*)",
+        "Bash(dirname:*)",
+        "Bash(basename:*)",
+        "Bash(xargs:*)",
+        "Bash(tr:*)",
+        "Bash(cut:*)"
+      ]
+    },
+    "supervised": {
+      "allow": [
+        "Read",
+        "Glob",
+        "Grep",
+        "WebFetch",
+        "WebSearch",
+        "Bash(git status:*)",
+        "Bash(git diff:*)",
+        "Bash(git log:*)",
+        "Bash(git branch:*)",
+        "Bash(ls:*)",
+        "Bash(cat:*)",
+        "Bash(head:*)",
+        "Bash(tail:*)",
+        "Bash(find:*)",
+        "Bash(grep:*)",
+        "Bash(rg:*)",
+        "Bash(jq:*)",
+        "Bash(which:*)",
+        "Bash(pwd:*)",
+        "Bash(echo:*)",
+        "Bash(wc:*)"
+      ]
+    },
+    "lockdown": {
+      "allow": [
+        "Read",
+        "Glob",
+        "Grep",
+        "Bash(git log:*)",
+        "Bash(git status:*)",
+        "Bash(ls:*)",
+        "Bash(pwd:*)"
+      ]
+    }
+  },
+  "rules": {
+    "deny": [
+      {
+        "id": "deny-force-push",
+        "tool": "Bash",
+        "match": { "command": "git\\s+push.*(-f\\b|--force)" },
+        "reason": "Destroys remote history"
+      },
+      {
+        "id": "deny-hard-reset",
+        "tool": "Bash",
+        "match": { "command": "git\\s+reset\\s+--hard" },
+        "reason": "Discards uncommitted work"
+      },
+      {
+        "id": "deny-git-clean",
+        "tool": "Bash",
+        "match": { "command": "git\\s+clean\\s+-[a-zA-Z]*f" },
+        "reason": "Deletes untracked files"
+      },
+      {
+        "id": "deny-rm-dangerous",
+        "tool": "Bash",
+        "match": { "command": "rm\\s+-[a-zA-Z]*r.*(/ |~/|\\$HOME|\\.\\.)" },
+        "reason": "Recursive delete of root/home/parent"
+      },
+      {
+        "id": "deny-rm-rf-cwd",
+        "tool": "Bash",
+        "match": { "command": "rm\\s+-[a-zA-Z]*rf?\\s+\\." },
+        "reason": "Recursive force-delete from cwd"
+      },
+      {
+        "id": "deny-curl-pipe-sh",
+        "tool": "Bash",
+        "match": { "command": "(curl|wget).*\\|\\s*(bash|sh|node)" },
+        "reason": "Remote code execution"
+      },
+      {
+        "id": "deny-chmod-777",
+        "tool": "Bash",
+        "match": { "command": "chmod\\s+777" },
+        "reason": "World-writable permissions"
+      },
+      {
+        "id": "deny-drop-database",
+        "tool": "Bash",
+        "match": { "command": "drop\\s+(database|schema)" },
+        "reason": "Irreversible data loss"
+      },
+      {
+        "id": "deny-sudo",
+        "tool": "Bash",
+        "match": { "command": "\\bsudo\\b" },
+        "reason": "Privilege escalation"
+      },
+      {
+        "id": "deny-dev-server",
+        "tool": "Bash",
+        "match": { "command": "(npm run dev|pnpm dev|yarn dev|bun run dev)" },
+        "reason": "Dev server must run in tmux — use: tmux new-session -d -s dev \"npm run dev\""
+      },
+      {
+        "id": "deny-write-env",
+        "tool": "Write",
+        "match": { "file_path": "\\.env(\\..*)?$" },
+        "reason": "Secret file exposure"
+      },
+      {
+        "id": "deny-write-credentials",
+        "tool": "Write",
+        "match": { "file_path": "(credentials|secrets|token)\\." },
+        "reason": "Credential file write"
+      },
+      {
+        "id": "deny-write-ssh",
+        "tool": "Write",
+        "match": { "file_path": "(\\.ssh/|\\.pem$|\\.key$)" },
+        "reason": "SSH key/cert write"
+      },
+      {
+        "id": "deny-edit-env",
+        "tool": "Edit",
+        "match": { "file_path": "\\.env(\\..*)?$" },
+        "reason": "Secret file edit"
+      },
+      {
+        "id": "deny-random-docs",
+        "tool": "Write",
+        "match": { "file_path": "\\.(md|txt)$" },
+        "except": { "file_path": "(README|CLAUDE|AGENTS|CONTRIBUTING|SPECLOG|CHANGELOG)\\.md$|\\.claude/" },
+        "reason": "Unnecessary documentation file — use README.md or .claude/ instead"
+      }
+    ],
+    "warn": [
+      {
+        "id": "warn-git-push",
+        "tool": "Bash",
+        "match": { "command": "git\\s+push" },
+        "reason": "Review changes before pushing"
+      },
+      {
+        "id": "warn-npm-install",
+        "tool": "Bash",
+        "match": { "command": "(npm|pnpm|yarn|bun)\\s+install" },
+        "reason": "Dependency changes"
+      },
+      {
+        "id": "warn-docker",
+        "tool": "Bash",
+        "match": { "command": "docker\\s+(run|compose|build)" },
+        "reason": "Resource/port exposure"
+      },
+      {
+        "id": "warn-curl-mutate",
+        "tool": "Bash",
+        "match": { "command": "curl.*-X\\s*(POST|PUT|DELETE)" },
+        "reason": "External API mutation"
+      },
+      {
+        "id": "warn-ci-config",
+        "tool": "Write",
+        "match": { "file_path": "(\\.github/|\\.gitlab-ci|Jenkinsfile)" },
+        "reason": "Pipeline changes"
+      }
+    ]
+  }
+}

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -28,7 +28,7 @@
         "feature-dev@claude-plugins-official"
       ],
       "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7", "guardian"],
-      "agents": []
+      "agents": ["code-reviewer"]
     },
     "typescript": {
       "extends": "base",
@@ -41,7 +41,7 @@
     "frontend": {
       "extends": "typescript",
       "plugins": ["frontend-design@claude-plugins-official"],
-      "agents": ["browser"]
+      "agents": ["browser", "code-reviewer"]
     },
     "backend": {
       "extends": "base",
@@ -50,7 +50,7 @@
     "monorepo-root": {
       "extends": "base",
       "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7", "guardian"],
-      "agents": ["context-loader", "doc-updater", "browser"],
+      "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }
   }

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -27,7 +27,7 @@
         "security-guidance@claude-plugins-official",
         "feature-dev@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7", "guardian"],
       "agents": []
     },
     "typescript": {
@@ -49,7 +49,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7", "guardian"],
       "agents": ["context-loader", "doc-updater", "browser"],
       "templates": ["specs"]
     }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,6 +13,16 @@
         "description": "Guardian: evaluate tool call risk and block dangerous operations"
       },
       {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"git commit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/review-gate.js\""
+          }
+        ],
+        "description": "Review gate: require code review before commits"
+      },
+      {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm (install|test)|pnpm (install|test)|yarn (install|test)?|bun (install|test)|cargo build|make|docker|pytest|vitest|playwright)\"",
         "hooks": [
           {

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -3,14 +3,14 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm run dev|pnpm( run)? dev|yarn dev|bun run dev)\"",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"console.error('[Hook] BLOCKED: Dev server must run in tmux for log access');console.error('[Hook] Use: tmux new-session -d -s dev \\\"npm run dev\\\"');console.error('[Hook] Then: tmux attach -t dev');process.exit(1)\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/guardian.js\""
           }
         ],
-        "description": "Block dev servers outside tmux - ensures you can access logs"
+        "description": "Guardian: evaluate tool call risk and block dangerous operations"
       },
       {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm (install|test)|pnpm (install|test)|yarn (install|test)?|bun (install|test)|cargo build|make|docker|pytest|vitest|playwright)\"",
@@ -21,26 +21,6 @@
           }
         ],
         "description": "Reminder to use tmux for long-running commands"
-      },
-      {
-        "matcher": "tool == \"Bash\" && tool_input.command matches \"git push\"",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node -e \"console.error('[Hook] Review changes before push...');console.error('[Hook] Continuing with push (remove this hook to add interactive review)')\""
-          }
-        ],
-        "description": "Reminder before git push to review changes"
-      },
-      {
-        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"README\\\\.md|CLAUDE\\\\.md|AGENTS\\\\.md|CONTRIBUTING\\\\.md|SPECLOG\\\\.md|CHANGELOG\\\\.md|\\\\.claude/specs/\")",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path||'';if(/\\.(md|txt)$/.test(p)&&!/(README|CLAUDE|AGENTS|CONTRIBUTING|SPECLOG|CHANGELOG)\\.md$/.test(p)&&!/\\.claude\\/specs\\//.test(p)){console.error('[Hook] BLOCKED: Unnecessary documentation file creation');console.error('[Hook] File: '+p);console.error('[Hook] Use README.md for documentation instead');process.exit(1)}console.log(d)})\""
-          }
-        ],
-        "description": "Block creation of random .md files - keeps docs consolidated"
       },
       {
         "matcher": "tool == \"Edit\" || tool == \"Write\"",

--- a/scripts/hooks/guardian.js
+++ b/scripts/hooks/guardian.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Guardian — PreToolUse hook for semantic risk assessment.
+ * Evaluates tool calls against configurable deny/warn rules.
+ * Fail-open: if anything goes wrong, exits 0 (allows).
+ */
+
+const path = require('path');
+const { readStdinJson, log, getClaudeDir, getSessionIdShort, ensureDir, appendFile, readFile, getDateString } = require('../lib/utils');
+
+function loadRules() {
+  // Check project-local config first, then fall back to co-located config/
+  const projectConfig = path.join(process.cwd(), '.claude', 'config', 'guardian-rules.json');
+  const repoConfig = path.resolve(__dirname, '..', '..', 'config', 'guardian-rules.json');
+
+  const content = readFile(projectConfig) || readFile(repoConfig);
+  if (!content) return null;
+
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+function getMode(config) {
+  return process.env.GUARDIAN_MODE || config.mode || 'supervised';
+}
+
+function matchRule(rule, tool, toolInput) {
+  if (rule.tool !== tool) return false;
+
+  // All match patterns must hit
+  for (const [field, pattern] of Object.entries(rule.match)) {
+    const value = toolInput[field] || '';
+    try {
+      if (!new RegExp(pattern, 'i').test(value)) return false;
+    } catch {
+      return false; // bad regex → skip rule
+    }
+  }
+
+  // No except pattern must hit
+  if (rule.except) {
+    for (const [field, pattern] of Object.entries(rule.except)) {
+      const value = toolInput[field] || '';
+      try {
+        if (new RegExp(pattern, 'i').test(value)) return false;
+      } catch {
+        // bad except regex → skip exception (rule still matches)
+      }
+    }
+  }
+
+  return true;
+}
+
+function getSummary(tool, toolInput) {
+  if (tool === 'Bash') return toolInput.command || '';
+  if (tool === 'Write' || tool === 'Edit' || tool === 'Read') return toolInput.file_path || '';
+  return Object.values(toolInput).filter(v => typeof v === 'string').join(' ').slice(0, 120);
+}
+
+function auditLog(entry) {
+  try {
+    const logsDir = path.join(getClaudeDir(), 'guardian', 'logs');
+    ensureDir(logsDir);
+    const logFile = path.join(logsDir, `${getDateString()}.jsonl`);
+    appendFile(logFile, JSON.stringify(entry) + '\n');
+  } catch {
+    // best-effort — never fail on audit logging
+  }
+}
+
+async function main() {
+  const input = await readStdinJson();
+  const { tool, tool_input: toolInput } = input;
+  if (!tool || !toolInput) process.exit(0);
+
+  const config = loadRules();
+  if (!config || !config.rules) process.exit(0);
+
+  const mode = getMode(config);
+  const session = getSessionIdShort();
+  const summary = getSummary(tool, toolInput);
+
+  const baseEntry = { ts: new Date().toISOString(), session, tool, summary, mode };
+
+  // Check deny rules (first match wins)
+  for (const rule of config.rules.deny || []) {
+    if (matchRule(rule, tool, toolInput)) {
+      auditLog({ ...baseEntry, decision: 'deny', rule_id: rule.id });
+      log(`[Guardian] BLOCKED: ${rule.reason} (${rule.id})`);
+      process.exit(1);
+    }
+  }
+
+  // Check warn rules (first match wins)
+  for (const rule of config.rules.warn || []) {
+    if (matchRule(rule, tool, toolInput)) {
+      auditLog({ ...baseEntry, decision: 'warn', rule_id: rule.id });
+      log(`[Guardian] WARNING: ${rule.reason} (${rule.id})`);
+      process.exit(0);
+    }
+  }
+
+  // Allow
+  auditLog({ ...baseEntry, decision: 'allow' });
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0)); // fail-open

--- a/scripts/hooks/review-gate.js
+++ b/scripts/hooks/review-gate.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+/**
+ * Review Gate — PreToolUse hook that blocks git commits without prior code review.
+ * Checks .claude/.last-review for a matching SHA-256 hash of the staged diff.
+ * Fail-open: if anything goes wrong, exits 0 (allows).
+ */
+
+const path = require('path');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+const { readStdinJson, runCommand, readFile, log } = require('../lib/utils');
+
+const REVIEW_FILE = path.join(process.cwd(), '.claude', '.last-review');
+
+async function main() {
+  const input = await readStdinJson();
+
+  // Only intercept git commit commands
+  const command = input.tool_input?.command || '';
+  if (!/git\s+commit/.test(command)) {
+    process.exit(0);
+  }
+
+  // Extract commit message from -m "..." or heredoc
+  const msgMatch = command.match(/-m\s+(?:"([^"]*(?:\\.[^"]*)*)"|'([^']*)'|(\S+))/);
+  const heredocMatch = command.match(/<<\s*'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+  const commitMsg = msgMatch ? (msgMatch[1] || msgMatch[2] || msgMatch[3] || '') : (heredocMatch ? heredocMatch[1] : '');
+
+  // Skip conditions based on commit message
+  if (/\[skip-review\]/i.test(commitMsg)) {
+    process.exit(0);
+  }
+  if (/^(docs|chore|style):/i.test(commitMsg.trim())) {
+    process.exit(0);
+  }
+
+  // Get staged files
+  const stagedResult = runCommand('git diff --cached --name-only');
+  if (!stagedResult.success || !stagedResult.output.trim()) {
+    process.exit(0); // No staged files
+  }
+
+  // Skip if all staged files are markdown
+  const stagedFiles = stagedResult.output.trim().split('\n');
+  if (stagedFiles.every(f => f.endsWith('.md'))) {
+    process.exit(0);
+  }
+
+  // Hash the staged diff (use spawnSync directly to get raw output matching the agent's execSync)
+  const diffProc = spawnSync('git', ['diff', '--cached'], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+  if (diffProc.status !== 0 || !diffProc.stdout) {
+    process.exit(0); // Empty diff
+  }
+  const diffHash = crypto.createHash('sha256').update(diffProc.stdout).digest('hex');
+
+  // Check .last-review for matching hash
+  const reviewData = readFile(REVIEW_FILE);
+  if (reviewData) {
+    try {
+      const review = JSON.parse(reviewData);
+      if (review.diffHash === diffHash) {
+        process.exit(0); // Review matches current diff
+      }
+    } catch {
+      // Corrupt file — fall through to block
+    }
+  }
+
+  // Block the commit
+  log('');
+  log('[Review Gate] Commit blocked — code review required.');
+  log('[Review Gate] Run: @code-reviewer to review staged changes.');
+  log('[Review Gate] Or add [skip-review] to your commit message to bypass.');
+  log('');
+  process.exit(1);
+}
+
+main().catch(() => process.exit(0));

--- a/skills/guardian/SKILL.md
+++ b/skills/guardian/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: guardian
+description: "Configure Guardian autonomous mode, switch modes, view audit log, and manage rules"
+user-invocable: true
+argument-hint: "[mode|log|rules] [args]"
+allowed-tools: Bash(node *), Bash(cat *), Bash(tail *), Bash(jq *), Read, Glob, Edit
+---
+
+# /guardian
+
+Manage the Guardian autonomous approval system — switch modes, view audit logs, and edit rules.
+
+## Instructions
+
+Parse `$ARGUMENTS` to determine the subcommand:
+
+### `mode <autonomous|supervised|lockdown>`
+
+Switch Guardian's operating mode:
+
+1. Read the project's `.claude/config/guardian-rules.json` (or fall back to the repo's `config/guardian-rules.json`)
+2. Update the `"mode"` field to the requested value
+3. Read the `permissions` object for the new mode
+4. Update the project's `.claude/settings.json` — merge the mode's `allow` list into `permissions.allow`
+5. Report what changed
+
+**Modes:**
+- **autonomous** — Broad permissions, guardian blocks only dangerous ops. Best for unattended work.
+- **supervised** — Read-only tools + safe git. Good for review/exploration sessions.
+- **lockdown** — Minimal read-only access. For auditing or untrusted environments.
+
+### `log [N]`
+
+View the Guardian audit log:
+
+1. Find log files at `~/.claude/guardian/logs/*.jsonl`
+2. Show the last N entries (default 20), formatted with jq
+3. If no logs exist, say so
+
+```bash
+tail -n 20 ~/.claude/guardian/logs/$(date +%Y-%m-%d).jsonl | jq .
+```
+
+### `rules list`
+
+Display all current deny and warn rules from the guardian config, formatted as a table.
+
+### `rules add <deny|warn> <json>`
+
+Add a new rule to the config. The JSON should include `id`, `tool`, `match`, and `reason` fields.
+
+### `rules remove <rule-id>`
+
+Remove a rule by its ID from either the deny or warn list.
+
+### No arguments / `status`
+
+Show current mode, number of deny/warn rules, and last 5 audit log entries.


### PR DESCRIPTION
## Summary

- **v1.8 — Guardian autonomous approval system**: Smart `PreToolUse` hook (`guardian.js`) with configurable deny/warn rules (`config/guardian-rules.json`), audit logging, and mode-based permissions (supervised/autonomous)
- **v1.9 — Pre-commit review gate**: `review-gate.js` hook intercepts `git commit`, hashes the staged diff (SHA-256), and checks `.claude/.last-review` for a matching stamp. `@code-reviewer` agent reviews staged changes against CLAUDE.md conventions and writes the stamp on PASS to unlock the gate
- Skip conditions: `[skip-review]` in commit message, `docs:`/`chore:`/`style:` prefix, md-only staged files, empty diffs
- `@code-reviewer` agent added to all profiles (`base`, `frontend`, `monorepo-root`)

## Test plan

- [ ] Block test: commit without review stamp → blocked (exit 1)
- [ ] Skip-review test: `[skip-review]` in message → allowed (exit 0)
- [ ] Docs prefix test: `docs:` prefix → allowed (exit 0)
- [ ] Non-commit passthrough: `git push` → allowed (exit 0)
- [ ] MD-only test: only `.md` files staged → allowed (exit 0)
- [ ] Hash match test: write stamp then commit → allowed (exit 0)
- [ ] Integration: `node scripts/configure-claude.js /tmp/test` installs agent + hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Guardian autonomous approval system with configurable security policies and three permission modes (autonomous, supervised, lockdown)
  * Added Code-Reviewer agent to perform pre-commit code reviews
  * Implemented pre-commit review gate requiring approval before commits, with bypass options available

* **Chores**
  * Version bumped to 1.9
  * Updated changelog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->