### PR TITLE
Fix review findings: harden guardian, tighten matchers, close edit gaps

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -67,7 +67,7 @@ Check the staged diff against:
 If all checks pass:
 
 1. Print a structured summary:
-   ```
+   ```text
    ## Review: PASS
 
    **Files reviewed:** <list>
@@ -100,7 +100,7 @@ If all checks pass:
 If any issues are found:
 
 1. Print findings with `file:line` references and fix suggestions:
-   ```
+   ```text
    ## Review: BLOCKED
 
    ### Findings

--- a/config/guardian-rules.json
+++ b/config/guardian-rules.json
@@ -1,4 +1,5 @@
 {
+  "_notes": "Bash(rm:*) is intentionally allowed — guarded by deny-rm-dangerous and deny-rm-rf-cwd rules for defense-in-depth",
   "mode": "autonomous",
   "permissions": {
     "autonomous": {
@@ -139,7 +140,7 @@
       {
         "id": "deny-rm-rf-cwd",
         "tool": "Bash",
-        "match": { "command": "rm\\s+-[a-zA-Z]*rf?\\s+\\." },
+        "match": { "command": "rm\\s+-[a-zA-Z]*rf?\\s+\\.(\\s|/|$)" },
         "reason": "Recursive force-delete from cwd"
       },
       {
@@ -195,6 +196,18 @@
         "tool": "Edit",
         "match": { "file_path": "\\.env(\\..*)?$" },
         "reason": "Secret file edit"
+      },
+      {
+        "id": "deny-edit-credentials",
+        "tool": "Edit",
+        "match": { "file_path": "(credentials|secrets|token)\\." },
+        "reason": "Credential file edit"
+      },
+      {
+        "id": "deny-edit-ssh",
+        "tool": "Edit",
+        "match": { "file_path": "(\\.ssh/|\\.pem$|\\.key$)" },
+        "reason": "SSH key/cert edit"
       },
       {
         "id": "deny-random-docs",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,7 +13,7 @@
         "description": "Guardian: evaluate tool call risk and block dangerous operations"
       },
       {
-        "matcher": "tool == \"Bash\" && tool_input.command matches \"git commit\"",
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"git commit(\\\\s|$)\"",
         "hooks": [
           {
             "type": "command",

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -334,7 +334,7 @@ function installForProfile(targetDir, resolvedProfile, label) {
         ...merged.permissions,
         allow: [...new Set([...(merged.permissions?.allow || []), ...modePerms.allow])],
       };
-      console.log(`  ✓ Merged guardian permissions for "${mode}" mode (${modePerms.allow.length} rules)`);
+      console.log(`  ✓ Merged guardian permissions for "${mode}" mode (${modePerms.allow.length} allow entries)`);
     }
   }
 

--- a/scripts/hooks/guardian.js
+++ b/scripts/hooks/guardian.js
@@ -30,6 +30,7 @@ function getMode(config) {
 
 function matchRule(rule, tool, toolInput) {
   if (rule.tool !== tool) return false;
+  if (!rule.match || typeof rule.match !== 'object') return false;
 
   // All match patterns must hit
   for (const [field, pattern] of Object.entries(rule.match)) {

--- a/scripts/hooks/review-gate.js
+++ b/scripts/hooks/review-gate.js
@@ -18,12 +18,12 @@ async function main() {
 
   // Only intercept git commit commands
   const command = input.tool_input?.command || '';
-  if (!/git\s+commit/.test(command)) {
+  if (!/git\s+commit(\s|$)/.test(command)) {
     process.exit(0);
   }
 
-  // Extract commit message from -m "..." or heredoc
-  const msgMatch = command.match(/-m\s+(?:"([^"]*(?:\\.[^"]*)*)"|'([^']*)'|(\S+))/);
+  // Extract commit message from -m "...", --message="...", or heredoc
+  const msgMatch = command.match(/(?:-m\s+|--message(?:=|\s+))(?:"([^"]*(?:\\.[^"]*)*)"|'([^']*)'|(\S+))/);
   const heredocMatch = command.match(/<<\s*'?EOF'?\s*\n([\s\S]*?)\nEOF/);
   const commitMsg = msgMatch ? (msgMatch[1] || msgMatch[2] || msgMatch[3] || '') : (heredocMatch ? heredocMatch[1] : '');
 
@@ -62,8 +62,8 @@ async function main() {
       if (review.diffHash === diffHash) {
         process.exit(0); // Review matches current diff
       }
-    } catch {
-      // Corrupt file — fall through to block
+    } catch (e) {
+      log(`[Review Gate] Warning: corrupt .last-review file (${e.message}) — ignoring`);
     }
   }
 


### PR DESCRIPTION
## Summary

- **guardian.js**: Guard against undefined `rule.match` in `matchRule()` — prevents crash that skips remaining rules
- **guardian-rules.json**: Add `deny-edit-credentials` and `deny-edit-ssh` rules mirroring Write rules; fix `deny-rm-rf-cwd` regex false-positives on dot-prefixed files (`.bashrc`, `.git`); add `_notes` metadata for `Bash(rm:*)` rationale
- **hooks.json + review-gate.js**: Tighten `git commit` matcher with `(\s|$)` boundary to exclude `commit-tree` etc.
- **review-gate.js**: Add `--message=` form parsing; log warning on corrupt `.last-review` instead of silent swallow
- **code-reviewer.md**: Add language tags to fenced code blocks (MD040)
- **configure-claude.js**: Fix mislabeled "rules" → "allow entries" in guardian merge log

## Test plan

- [ ] `git commit -m "test"` → blocked (no review stamp)
- [ ] `git commit -m "[skip-review] test"` → allowed
- [ ] `git commit --message="docs: update"` → allowed (new `--message=` form)
- [ ] `git commit-tree` → passthrough (no longer matched)
- [ ] `rm -rf .` → denied by guardian
- [ ] `rm -rf .bashrc` → no longer false-positive denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review cache system to skip redundant reviews for unchanged code
  * Skip review functionality with [skip-review] tag in commits
  * New security rules blocking credential and SSH file edits

* **Bug Fixes**
  * Improved git commit detection precision
  * Enhanced commit message parsing for multiple flag formats
  * Strengthened error handling in review process

* **Chores**
  * Updated diagnostic logging
  * Improved rule validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->