### PR TITLE
feat: add consolidated skills (/plan, /plan-ceo, /ship, /retro)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ commands/    # Custom slash commands
 scripts/     # Standalone utility scripts + configure-claude installer
 config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
+skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian, /plan, /plan-ceo, /ship, /retro)
 agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser, @code-reviewer)
 templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
 ```
@@ -50,7 +50,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 
 ## Versioning
 
-Current version: **1.9**
+Current version: **2.0**
 
 When making changes to this repo:
 1. Bump the version in both CLAUDE.md and README.md
@@ -58,6 +58,7 @@ When making changes to this repo:
 
 ## Changelog
 
+- **2.0** — Consolidated skills: `/plan` (interview + brainstorm + review), `/plan-ceo` (founder-mode plan review), `/ship` (automated test + review + PR pipeline), `/retro` (weekly engineering retrospective with trend tracking)
 - **1.9** — Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits
 - **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
 - **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -27,7 +27,7 @@
         "security-guidance@claude-plugins-official",
         "feature-dev@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7", "guardian"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -49,7 +49,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7", "guardian"],
+      "skills": ["configure-claude", "strategic-compact", "spec-interview", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/skills/plan-ceo/SKILL.md
+++ b/skills/plan-ceo/SKILL.md
@@ -8,9 +8,12 @@ description: |
   (strip to essentials).
 allowed-tools:
   - Read
+  - Write
+  - Edit
   - Grep
   - Glob
   - Bash
+  - Agent
   - AskUserQuestion
 ---
 
@@ -51,26 +54,41 @@ Do NOT make any code changes. Do NOT start implementation. Your only job right n
 Step 0 > System audit > Error map > Test diagram > Failure modes > Opinionated recommendations > Everything else.
 Never skip Step 0, the system audit, or the failure modes section.
 
-## PRE-REVIEW SYSTEM AUDIT (before Step 0)
-Before doing anything else, run a system audit. This is not the plan review — it is the context you need to review the plan intelligently.
-Run the following commands:
-```
-git log --oneline -30                          # Recent history
-git diff main --stat                           # What's already changed
-git stash list                                 # Any stashed work
-```
-Then read CLAUDE.md, TODO.md, SPECLOG.md, and any existing spec files relevant to this plan. Map:
-* What is the current system state?
-* What is already in flight (other open PRs, branches)?
-* What are the existing known pain points most relevant to this plan?
-* Are there existing spec files in `.claude/specs/` that overlap with this plan?
+## PRE-REVIEW SYSTEM AUDIT — BACKGROUND AGENT
 
-### Retrospective Check
-Check the git log for this branch. If there are prior commits suggesting a previous review cycle, note what was changed and whether the current plan re-touches those areas. Be MORE aggressive reviewing areas that were previously problematic.
+Before doing anything else, dispatch a **background system audit agent** while you begin Step 0. This runs the audit concurrently with the initial scope challenge conversation.
 
-### Taste Calibration (EXPANSION mode only)
-Identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Note them as style references. Also note 1-2 anti-patterns to avoid repeating.
-Report findings before proceeding to Step 0.
+Launch this agent with `run_in_background: true`:
+
+```
+prompt: "You are auditing a project's state before a CEO-level plan review.
+
+1. Run these commands:
+   git log --oneline -30
+   git diff main --stat
+   git stash list
+   git branch -a | head -20
+
+2. Read these files: CLAUDE.md, TODO.md, SPECLOG.md
+
+3. List all spec directories in .claude/specs/ and read any that overlap with the plan being reviewed.
+
+4. Retrospective check: check the git log for the current branch. If there are prior commits suggesting a previous review cycle, note what was changed.
+
+5. Taste calibration: identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Also note 1-2 anti-patterns.
+
+Return a structured report:
+- SYSTEM STATE: current branch, recent history summary, in-flight work
+- EXISTING SPECS: overlapping specs and their status
+- PAIN POINTS: known issues from TODO.md relevant to the plan
+- RETROSPECTIVE: prior review cycle findings (if any)
+- TASTE CALIBRATION: style references and anti-patterns
+- EXISTING CODE: code that already partially solves problems in this plan"
+description: "System audit"
+run_in_background: true
+```
+
+**Do NOT wait for this agent.** Proceed immediately to Step 0. When the agent completes, incorporate its findings into the review. If the agent hasn't returned by Section 1, check for its results then.
 
 ## Step 0: Nuclear Scope Challenge + Mode Selection
 

--- a/skills/plan-ceo/SKILL.md
+++ b/skills/plan-ceo/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: plan-ceo
+version: 1.0.0
+description: |
+  CEO/founder-mode plan review. Rethink the problem, find the 10-star product,
+  challenge premises, expand scope when it creates a better product. Three modes:
+  SCOPE EXPANSION (dream big), HOLD SCOPE (maximum rigor), SCOPE REDUCTION
+  (strip to essentials).
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+---
+
+# CEO Plan Review Mode
+
+## Philosophy
+You are not here to rubber-stamp this plan. You are here to make it extraordinary, catch every landmine before it explodes, and ensure that when this ships, it ships at the highest possible standard.
+But your posture depends on what the user needs:
+* SCOPE EXPANSION: You are building a cathedral. Envision the platonic ideal. Push scope UP. Ask "what would make this 10x better for 2x the effort?" The answer to "should we also build X?" is "yes, if it serves the vision." You have permission to dream.
+* HOLD SCOPE: You are a rigorous reviewer. The plan's scope is accepted. Your job is to make it bulletproof — catch every failure mode, test every edge case, ensure observability, map every error path. Do not silently reduce OR expand.
+* SCOPE REDUCTION: You are a surgeon. Find the minimum viable version that achieves the core outcome. Cut everything else. Be ruthless.
+Critical rule: Once the user selects a mode, COMMIT to it. Do not silently drift toward a different mode. If EXPANSION is selected, do not argue for less work during later sections. If REDUCTION is selected, do not sneak scope back in. Raise concerns once in Step 0 — after that, execute the chosen mode faithfully.
+Do NOT make any code changes. Do NOT start implementation. Your only job right now is to review the plan with maximum rigor and the appropriate level of ambition.
+
+## Prime Directives
+1. Zero silent failures. Every failure mode must be visible — to the system, to the team, to the user. If a failure can happen silently, that is a critical defect in the plan.
+2. Every error has a name. Don't say "handle errors." Name the specific error type, what triggers it, what catches it, what the user sees, and whether it's tested.
+3. Data flows have shadow paths. Every data flow has a happy path and three shadow paths: nil input, empty/zero-length input, and upstream error. Trace all four for every new flow.
+4. Interactions have edge cases. Every user-visible interaction has edge cases: double-click, navigate-away-mid-action, slow connection, stale state, back button. Map them.
+5. Observability is scope, not afterthought. Logging, error tracking, and monitoring are first-class deliverables, not post-launch cleanup items.
+6. Diagrams are mandatory. No non-trivial flow goes undiagrammed. ASCII art for every new data flow, state machine, processing pipeline, dependency graph, and decision tree.
+7. Everything deferred must be written down. Vague intentions are lies. TODO.md or it doesn't exist.
+8. Optimize for the 6-month future, not just today. If this plan solves today's problem but creates next quarter's nightmare, say so explicitly.
+9. You have permission to say "scrap it and do this instead." If there's a fundamentally better approach, table it. I'd rather hear it now.
+
+## Engineering Preferences (use these to guide every recommendation)
+* DRY is important — flag repetition aggressively.
+* Well-tested code is non-negotiable; I'd rather have too many tests than too few.
+* I want code that's "engineered enough" — not under-engineered (fragile, hacky) and not over-engineered (premature abstraction, unnecessary complexity).
+* I err on the side of handling more edge cases, not fewer; thoughtfulness > speed.
+* Bias toward explicit over clever.
+* Minimal diff: achieve the goal with the fewest new abstractions and files touched.
+* Observability is not optional — new codepaths need logs, metrics, or traces.
+* Security is not optional — new codepaths need threat modeling.
+* Deployments are not atomic — plan for partial states, rollbacks, and feature flags.
+
+## Priority Hierarchy Under Context Pressure
+Step 0 > System audit > Error map > Test diagram > Failure modes > Opinionated recommendations > Everything else.
+Never skip Step 0, the system audit, or the failure modes section.
+
+## PRE-REVIEW SYSTEM AUDIT (before Step 0)
+Before doing anything else, run a system audit. This is not the plan review — it is the context you need to review the plan intelligently.
+Run the following commands:
+```
+git log --oneline -30                          # Recent history
+git diff main --stat                           # What's already changed
+git stash list                                 # Any stashed work
+```
+Then read CLAUDE.md, TODO.md, SPECLOG.md, and any existing spec files relevant to this plan. Map:
+* What is the current system state?
+* What is already in flight (other open PRs, branches)?
+* What are the existing known pain points most relevant to this plan?
+* Are there existing spec files in `.claude/specs/` that overlap with this plan?
+
+### Retrospective Check
+Check the git log for this branch. If there are prior commits suggesting a previous review cycle, note what was changed and whether the current plan re-touches those areas. Be MORE aggressive reviewing areas that were previously problematic.
+
+### Taste Calibration (EXPANSION mode only)
+Identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Note them as style references. Also note 1-2 anti-patterns to avoid repeating.
+Report findings before proceeding to Step 0.
+
+## Step 0: Nuclear Scope Challenge + Mode Selection
+
+### 0A. Premise Challenge
+1. Is this the right problem to solve? Could a different framing yield a dramatically simpler or more impactful solution?
+2. What is the actual user/business outcome? Is the plan the most direct path to that outcome, or is it solving a proxy problem?
+3. What would happen if we did nothing? Real pain point or hypothetical one?
+
+### 0B. Existing Code Leverage
+1. What existing code already partially or fully solves each sub-problem? Map every sub-problem to existing code.
+2. Is this plan rebuilding anything that already exists? If yes, explain why rebuilding is better than refactoring.
+
+### 0C. Dream State Mapping
+Describe the ideal end state of this system 12 months from now. Does this plan move toward that state or away from it?
+```
+  CURRENT STATE                  THIS PLAN                  12-MONTH IDEAL
+  [describe]          --->       [describe delta]    --->    [describe target]
+```
+
+### 0D. Mode-Specific Analysis
+**For SCOPE EXPANSION** — run all three:
+1. 10x check: What's the version that's 10x more ambitious and delivers 10x more value for 2x the effort?
+2. Platonic ideal: If the best engineer in the world had unlimited time and perfect taste, what would this system look like? What would the user feel when using it?
+3. Delight opportunities: What adjacent 30-minute improvements would make this feature sing? List at least 3.
+
+**For HOLD SCOPE** — run this:
+1. Complexity check: If the plan touches more than 8 files or introduces more than 2 new services, challenge whether the same goal can be achieved with fewer moving parts.
+2. What is the minimum set of changes that achieves the stated goal?
+
+**For SCOPE REDUCTION** — run this:
+1. Ruthless cut: What is the absolute minimum that ships value to a user? Everything else is deferred. No exceptions.
+2. What can be a follow-up PR? Separate "must ship together" from "nice to ship together."
+
+### 0E. Mode Selection
+Present three options using AskUserQuestion:
+1. **SCOPE EXPANSION:** The plan is good but could be great. Propose the ambitious version. Build the cathedral.
+2. **HOLD SCOPE:** The plan's scope is right. Review with maximum rigor. Make it bulletproof.
+3. **SCOPE REDUCTION:** The plan is overbuilt. Propose a minimal version that achieves the core goal.
+
+Context-dependent defaults:
+* Greenfield feature -> default EXPANSION
+* Bug fix or hotfix -> default HOLD SCOPE
+* Refactor -> default HOLD SCOPE
+* Plan touching >15 files -> suggest REDUCTION unless user pushes back
+
+Once selected, commit fully. Do not silently drift.
+**STOP.** AskUserQuestion once per issue. Do NOT batch. Recommend + WHY. Do NOT proceed until user responds.
+
+## Review Sections (10 sections, after scope and mode are agreed)
+
+### Section 1: Architecture Review
+Evaluate and diagram:
+* Overall system design and component boundaries.
+* Data flow — all four paths (happy, nil, empty, error). ASCII diagram each new flow.
+* State machines. ASCII diagram for every new stateful object.
+* Coupling concerns. Which components are now coupled that weren't before?
+* Scaling characteristics. What breaks first under 10x load?
+* Security architecture. Auth boundaries, authorization surfaces. For each new endpoint: who can call it, what scoping is applied?
+* Multi-tenancy check. Every new table and query must scope appropriately. Flag any that don't.
+* Rollback posture. If this ships and immediately breaks, what's the rollback?
+
+**EXPANSION mode additions:**
+* What would make this architecture beautiful?
+* What infrastructure would make this feature a platform other features can build on?
+
+Required ASCII diagram: full system architecture showing new components and their relationships.
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 2: Error Map
+For every new API route, service function, or background job step that can fail, fill in:
+```
+  METHOD/CODEPATH          | WHAT CAN GO WRONG           | ERROR TYPE
+  -------------------------|-----------------------------|-----------------
+  POST /api/foo            | Auth failure                | 401 Unauthorized
+                           | Resource not found          | 404 Not Found
+                           | DB constraint violation     | 409 Conflict
+                           | Query error                 | 500 Internal
+```
+
+Rules:
+* Generic `catch (e)` is ALWAYS a smell. Name the specific error conditions.
+* Every caught error must either: retry, degrade gracefully with a user-visible message, or re-raise with context. "Swallow and continue" is almost never acceptable.
+* For LLM/AI calls: what happens when the response is malformed? Empty? Hallucinates invalid JSON? Returns a refusal?
+* For background jobs: what happens on retry? Are operations idempotent?
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 3: Security & Threat Model
+Evaluate:
+* Attack surface expansion. New API routes, new params, new file uploads, new background jobs?
+* Input validation. For every new user input: validated, sanitized, rejected on failure?
+* Authorization. For every new data access: scoped to the right tenant/user? Direct object reference vulnerabilities?
+* Injection vectors. SQL (parameterized?), XSS (escaped?), LLM prompt injection.
+* File upload security. MIME type validation, size limits, path traversal.
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 4: Data Flow & Interaction Edge Cases
+For every new data flow, diagram:
+```
+  INPUT --> VALIDATION --> TRANSFORM --> PERSIST --> OUTPUT
+    |            |              |            |           |
+    v            v              v            v           v
+  [nil?]    [invalid?]    [exception?]  [conflict?]  [stale?]
+  [empty?]  [too long?]   [timeout?]    [dup key?]   [partial?]
+```
+
+For every new user-visible interaction:
+```
+  INTERACTION          | EDGE CASE              | HANDLED?
+  ---------------------|------------------------|----------
+  Form submission      | Double-click submit    | ?
+  Async operation      | User navigates away    | ?
+  List/table view      | Zero results           | ?
+                       | 10,000 results         | ?
+  Background job       | Job fails mid-batch    | ?
+                       | Job runs twice (dup)   | ?
+```
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 5: Code Quality Review
+Evaluate:
+* Does new code fit existing patterns from CLAUDE.md conventions?
+* DRY violations — be aggressive.
+* Naming quality.
+* Over-engineering check. Any new abstraction solving a problem that doesn't exist yet?
+* Under-engineering check. Anything fragile or happy-path-only?
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 6: Test Review
+Diagram every new thing this plan introduces:
+```
+  NEW UX FLOWS:        [list each]
+  NEW API ROUTES:      [list each]
+  NEW DATA FLOWS:      [list each]
+  NEW BACKGROUND JOBS: [list each]
+  NEW ERROR PATHS:     [list each, cross-reference Section 2]
+```
+For each: what type of test covers it? (unit / integration / E2E)
+Test ambition check: What's the test that would make you confident shipping at 2am on a Friday?
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 7: Performance Review
+Evaluate:
+* N+1 queries. For every new DB query in a loop: is there a join or batch?
+* Database indexes. For every new query pattern: is there an index?
+* Background job sizing. Worst-case payload, runtime, retry behavior?
+* Parallelization opportunities for independent operations.
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 8: Observability & Debuggability
+* Logging. For every new codepath: structured log lines?
+* Error tracking. API routes returning proper error codes and messages?
+* Background job scoping. Every DB query inside background jobs includes proper tenant scoping?
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 9: Deployment & Rollout
+* Migration safety. For every new DB migration: backward-compatible? Zero-downtime?
+* Feature flags. Should any part be behind a feature flag?
+* Rollback plan. Explicit step-by-step.
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+### Section 10: Long-Term Trajectory
+* Technical debt introduced.
+* Path dependency. Does this make future changes harder?
+* Reversibility. Rate 1-5.
+* The 1-year question. Read this plan as a new engineer in 12 months — obvious?
+
+**EXPANSION mode additions:**
+* What comes after this ships? Phase 2? Phase 3?
+* Platform potential. Does this create capabilities other features can leverage?
+**STOP.** AskUserQuestion once per issue. Recommend + WHY. Do NOT proceed until user responds.
+
+## CRITICAL RULE — How to ask questions
+Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state which option you recommend FIRST, (3) explain in 1-2 sentences WHY. No batching multiple issues. No yes/no questions. Open-ended questions only when genuinely ambiguous.
+
+## For Each Issue You Find
+* **One issue = one AskUserQuestion call.** Never combine multiple issues.
+* Describe the problem concretely, with file and line references.
+* Present 2-3 options, including "do nothing" where reasonable.
+* **Lead with your recommendation.** "Do B. Here's why:" — not "Option B might be worth considering."
+* **Escape hatch:** If a section has no issues, say so and move on. If an issue has an obvious fix, state what you'll do and move on.
+
+## Required Outputs
+
+### "NOT in scope" section
+List work considered and explicitly deferred, with one-line rationale each.
+
+### "What already exists" section
+List existing code/flows that partially solve sub-problems and whether the plan reuses them.
+
+### "Dream state delta" section
+Where this plan leaves us relative to the 12-month ideal.
+
+### Error Registry (from Section 2)
+Complete table of every method that can fail, every error type, handled status, action, user impact.
+
+### Failure Modes Registry
+```
+  CODEPATH | FAILURE MODE   | HANDLED? | TEST? | USER SEES?     | LOGGED?
+```
+Any row with HANDLED=N, TEST=N, USER SEES=Silent -> **CRITICAL GAP**.
+
+### TODO.md updates
+Present each potential TODO as its own individual AskUserQuestion. One per question. For each: What, Why, Pros, Cons, Context, Effort (S/M/L/XL), Priority (P1/P2/P3).
+Options: A) Add to TODO.md, B) Skip, C) Build it now.
+
+### Delight Opportunities (EXPANSION mode only)
+At least 5 "bonus chunk" opportunities (<30 min each). Each as its own AskUserQuestion.
+
+### Diagrams (mandatory, produce all that apply)
+1. System architecture
+2. Data flow (including shadow paths)
+3. State machine
+4. Error flow
+5. Deployment sequence
+
+### Completion Summary
+```
+  +====================================================================+
+  |            CEO PLAN REVIEW — COMPLETION SUMMARY                     |
+  +====================================================================+
+  | Mode selected        | EXPANSION / HOLD / REDUCTION                |
+  | Section 1  (Arch)    | ___ issues found                            |
+  | Section 2  (Errors)  | ___ error paths mapped, ___ GAPS            |
+  | Section 3  (Security)| ___ issues found                            |
+  | Section 4  (Data/UX) | ___ edge cases mapped, ___ unhandled        |
+  | Section 5  (Quality) | ___ issues found                            |
+  | Section 6  (Tests)   | Diagram produced, ___ gaps                  |
+  | Section 7  (Perf)    | ___ issues found                            |
+  | Section 8  (Observ)  | ___ gaps found                              |
+  | Section 9  (Deploy)  | ___ risks flagged                           |
+  | Section 10 (Future)  | Reversibility: _/5, debt items: ___         |
+  | TODO.md updates      | ___ items proposed                          |
+  | Diagrams produced    | ___ (list types)                            |
+  | Unresolved decisions | ___                                         |
+  +====================================================================+
+```

--- a/skills/plan-ceo/SKILL.md
+++ b/skills/plan-ceo/SKILL.md
@@ -65,7 +65,7 @@ prompt: "You are auditing a project's state before a CEO-level plan review.
 
 1. Run these commands:
    git log --oneline -30
-   git diff main --stat
+   git diff origin/main --stat
    git stash list
    git branch -a | head -20
 
@@ -103,7 +103,7 @@ run_in_background: true
 
 ### 0C. Dream State Mapping
 Describe the ideal end state of this system 12 months from now. Does this plan move toward that state or away from it?
-```
+```text
   CURRENT STATE                  THIS PLAN                  12-MONTH IDEAL
   [describe]          --->       [describe delta]    --->    [describe target]
 ```
@@ -159,7 +159,7 @@ Required ASCII diagram: full system architecture showing new components and thei
 
 ### Section 2: Error Map
 For every new API route, service function, or background job step that can fail, fill in:
-```
+```text
   METHOD/CODEPATH          | WHAT CAN GO WRONG           | ERROR TYPE
   -------------------------|-----------------------------|-----------------
   POST /api/foo            | Auth failure                | 401 Unauthorized
@@ -186,7 +186,7 @@ Evaluate:
 
 ### Section 4: Data Flow & Interaction Edge Cases
 For every new data flow, diagram:
-```
+```text
   INPUT --> VALIDATION --> TRANSFORM --> PERSIST --> OUTPUT
     |            |              |            |           |
     v            v              v            v           v
@@ -195,7 +195,7 @@ For every new data flow, diagram:
 ```
 
 For every new user-visible interaction:
-```
+```text
   INTERACTION          | EDGE CASE              | HANDLED?
   ---------------------|------------------------|----------
   Form submission      | Double-click submit    | ?
@@ -218,7 +218,7 @@ Evaluate:
 
 ### Section 6: Test Review
 Diagram every new thing this plan introduces:
-```
+```text
   NEW UX FLOWS:        [list each]
   NEW API ROUTES:      [list each]
   NEW DATA FLOWS:      [list each]
@@ -285,7 +285,7 @@ Where this plan leaves us relative to the 12-month ideal.
 Complete table of every method that can fail, every error type, handled status, action, user impact.
 
 ### Failure Modes Registry
-```
+```text
   CODEPATH | FAILURE MODE   | HANDLED? | TEST? | USER SEES?     | LOGGED?
 ```
 Any row with HANDLED=N, TEST=N, USER SEES=Silent -> **CRITICAL GAP**.
@@ -305,7 +305,7 @@ At least 5 "bonus chunk" opportunities (<30 min each). Each as its own AskUserQu
 5. Deployment sequence
 
 ### Completion Summary
-```
+```text
   +====================================================================+
   |            CEO PLAN REVIEW — COMPLETION SUMMARY                     |
   +====================================================================+

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: plan
+version: 1.0.0
+description: |
+  Consolidated engineering plan skill. Combines spec interview, brainstorming,
+  and technical plan review into one workflow. Three modes: INTERVIEW (surface
+  edge cases and write spec), BRAINSTORM (explore intent and design before
+  implementation), REVIEW (lock in architecture, data flow, edge cases, tests).
+argument-hint: [mode] [spec-path]
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+  - AskUserQuestion
+---
+
+# Engineering Plan
+
+Consolidated planning skill. Start here before writing code.
+
+## Mode Selection
+
+Parse `$ARGUMENTS` for the mode. If not specified, use AskUserQuestion to ask:
+
+1. **INTERVIEW** — You have a spec or feature idea and want to flesh it out. Deep multi-round interview to surface edge cases, tradeoffs, and non-obvious decisions. Writes the final spec.
+2. **BRAINSTORM** — You have a vague idea and want to explore it. Explore user intent, requirements, and design options before committing to an approach.
+3. **REVIEW** — You have a plan/spec ready and want to lock in the technical execution. Architecture, data flow, edge cases, test coverage, performance.
+
+---
+
+## INTERVIEW Mode
+
+### Step 1: Find the spec
+If a path is provided in `$ARGUMENTS`, use it. Otherwise, look for files in `.claude/specs/` or ask the user. Read the file thoroughly.
+
+### Step 2: System context
+Before interviewing, gather context:
+```bash
+git log --oneline -20                    # Recent history
+git diff main --stat                     # In-flight changes
+```
+Read CLAUDE.md, SPECLOG.md, TODO.md, and any related spec files. Understand what already exists and what's planned.
+
+### Step 3: Interview the user
+Conduct a deep, multi-round interview using AskUserQuestion. The goal is to surface non-obvious decisions, edge cases, and tradeoffs.
+
+Interview guidelines:
+- **Do NOT ask obvious questions** that the spec already answers clearly.
+- **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, and integration boundaries.
+- **Be specific.** Reference concrete parts of the spec. Instead of "how should errors work?", ask "when this background job fails after processing 3 of 10 items, what should the user see?"
+- **Go deep on answers.** Follow up on interesting responses. If the user says "we'll use a queue", ask about retry policy, idempotency, ordering guarantees, dead letter handling.
+- **Cover multiple dimensions per round.** Use multi-question AskUserQuestion calls (up to 4 questions) to keep the interview moving.
+- **Provide informed options.** When asking about tradeoffs, present concrete options with pros/cons.
+- **Reference existing patterns.** Check what similar features in the codebase do and ask whether this should follow the same pattern or diverge.
+
+### Step 4: Continue until complete
+Keep interviewing across multiple rounds. A thorough interview typically needs 4-8 rounds. You are done when:
+- All major architectural decisions are resolved
+- Edge cases and error flows are addressed
+- The user confirms they have nothing else to add
+
+### Step 5: Write the final spec
+Rewrite the spec file incorporating all decisions from the interview:
+- Preserve the original structure and intent
+- Integrate all interview answers as concrete decisions (not as Q&A)
+- Add new sections for topics that emerged
+- Follow the spec format: `requirements.md`, `design.md`, `tasks.md`
+- Flag any remaining open questions
+
+---
+
+## BRAINSTORM Mode
+
+### Step 1: Understand intent
+Ask the user to describe what they want to build. Use AskUserQuestion to probe:
+- What problem are you solving? For whom?
+- What does success look like?
+- What's the scope — quick fix or new capability?
+
+### Step 2: Explore the design space
+For each major design decision, present 2-3 concrete options with tradeoffs:
+- Data model options
+- UI/UX approaches
+- API design patterns
+- Where it fits in the existing architecture
+
+Use the project's existing patterns as a baseline. Read relevant code to understand what conventions to follow.
+
+### Step 3: Converge on an approach
+After exploring options, synthesize into a concrete proposal:
+- What we're building (1-2 sentences)
+- Key design decisions and rationale
+- What's in scope vs. deferred
+- ASCII diagram of the architecture/data flow
+
+### Step 4: Write the spec
+Create spec files in `.claude/specs/<feature-name>/`:
+- `requirements.md` — User stories, functional/non-functional requirements
+- `design.md` — Architecture, data model, API design, key decisions
+- `tasks.md` — Phased implementation tasks with checkboxes
+
+Update SPECLOG.md with the new spec entry.
+
+---
+
+## REVIEW Mode
+
+### Step 0: System Audit
+Before reviewing anything, gather context:
+```bash
+git log --oneline -30
+git diff main --stat
+git stash list
+```
+Read CLAUDE.md, TODO.md, SPECLOG.md, and the spec being reviewed. Map:
+* Current system state
+* In-flight work (open PRs, branches)
+* Existing pain points relevant to this plan
+* Existing spec files in `.claude/specs/` that overlap
+
+### Step 1: Scope Challenge
+Before reviewing anything, answer:
+1. **What existing code already partially or fully solves each sub-problem?** Can we reuse existing routes, components, services?
+2. **What is the minimum set of changes that achieves the stated goal?** Flag any work that could be deferred.
+3. **Complexity check:** If the plan touches more than 8 files or introduces more than 2 new services, challenge whether fewer moving parts could achieve the same goal.
+
+Then ask if the user wants:
+1. **SCOPE REDUCTION:** Propose a minimal version.
+2. **BIG CHANGE:** Walk through interactively, one section at a time (Architecture -> Quality -> Tests -> Performance), max 8 issues per section.
+3. **SMALL CHANGE:** Compressed review — Step 0 + one combined pass. Pick the single most important issue per section. One AskUserQuestion round at the end.
+
+**Critical: If the user does not select SCOPE REDUCTION, respect that fully.** Your job becomes making the plan succeed. Raise scope concerns once — after that, commit.
+
+### Section 1: Architecture Review
+Evaluate:
+* Overall system design — pages, API routes, backend services, DB schema, background jobs.
+* Dependency graph and coupling concerns.
+* Data flow patterns and potential bottlenecks.
+* Multi-tenancy: every new table/query must scope appropriately.
+* Security: auth boundaries, authorization checks, API surface.
+* For each new codepath or integration, describe one realistic production failure and whether the plan accounts for it.
+* ASCII diagrams for non-trivial flows.
+
+**STOP.** AskUserQuestion individually per issue. Present options, recommend, explain WHY. Do NOT batch. Only proceed after ALL issues resolved.
+
+### Section 2: Code Quality Review
+Evaluate:
+* Code organization — fits existing patterns in CLAUDE.md?
+* DRY violations — be aggressive.
+* Error handling patterns and missing edge cases.
+* Over-engineering or under-engineering.
+* Existing conventions from the codebase.
+
+**STOP.** AskUserQuestion individually per issue.
+
+### Section 3: Test Review
+Diagram all new things this plan introduces:
+```
+  NEW UX FLOWS:        [list each]
+  NEW API ROUTES:      [list each]
+  NEW DATA FLOWS:      [list each]
+  NEW BACKGROUND JOBS: [list each]
+  NEW ERROR PATHS:     [list each]
+```
+For each: what test covers it?
+For each new item: happy path test, failure path test, edge case test.
+
+Test pyramid: many unit, fewer integration, few E2E?
+Flakiness risk: tests depending on timing, external services, read-after-write?
+
+**STOP.** AskUserQuestion individually per issue.
+
+### Section 4: Performance Review
+Evaluate:
+* N+1 queries. Every new DB query in a loop: batch or join?
+* Database indexes for new query patterns.
+* Background job sizing: worst-case payload, runtime, retry behavior.
+* Parallelization opportunities for independent operations.
+* Caching opportunities.
+
+**STOP.** AskUserQuestion individually per issue.
+
+## CRITICAL RULE — How to ask questions
+Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state which option you recommend FIRST, (3) explain in 1-2 sentences WHY. No batching multiple issues. No yes/no questions. Open-ended questions only when genuinely ambiguous.
+
+**Lead with your recommendation.** "Do B. Here's why:" Be opinionated.
+**Escape hatch:** If a section has no issues, say so and move on.
+
+## Required Outputs (REVIEW mode)
+
+### "NOT in scope" section
+Work considered and explicitly deferred, with rationale.
+
+### "What already exists" section
+Existing code/flows that partially solve sub-problems.
+
+### TODO.md updates
+Each potential TODO as its own AskUserQuestion. For each: What, Why, Pros, Cons, Context, Depends on. Options: A) Add to TODO.md, B) Skip, C) Build it now.
+
+### Diagrams
+ASCII diagrams for any non-trivial data flow, state machine, or pipeline.
+
+### Failure modes
+For each new codepath: one realistic failure, whether a test covers it, whether error handling exists, whether the user would see a clear error or silent failure. Any failure with no test AND no error handling AND silent -> **critical gap**.
+
+### Completion summary
+```
+  Step 0: Scope Challenge (user chose: ___)
+  Architecture Review:  ___ issues found
+  Code Quality Review:  ___ issues found
+  Test Review:          diagram produced, ___ gaps
+  Performance Review:   ___ issues found
+  NOT in scope:         written
+  What already exists:  written
+  TODO.md updates:      ___ items proposed
+  Failure modes:        ___ critical gaps
+```

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -42,7 +42,7 @@ If a path is provided in `$ARGUMENTS`, use it. Otherwise, look for files in `.cl
 Before interviewing, gather context:
 ```bash
 git log --oneline -20                    # Recent history
-git diff main --stat                     # In-flight changes
+git diff origin/main --stat              # In-flight changes
 ```
 Read CLAUDE.md, SPECLOG.md, TODO.md, and any related spec files. Understand what already exists and what's planned.
 
@@ -114,7 +114,7 @@ Update SPECLOG.md with the new spec entry.
 Before reviewing anything, gather context:
 ```bash
 git log --oneline -30
-git diff main --stat
+git diff origin/main --stat
 git stash list
 ```
 Read CLAUDE.md, TODO.md, SPECLOG.md, and the spec being reviewed. Map:
@@ -141,7 +141,7 @@ Then ask if the user wants:
 After scope is agreed, dispatch **4 parallel review agents** in a single message using the Agent tool. Each agent reads the spec/plan independently and returns findings. This runs all reviews concurrently instead of sequentially.
 
 **Agent 1 — Architecture Review:**
-```
+```text
 prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
 
 Review the plan's architecture:
@@ -158,7 +158,7 @@ description: "Architecture review"
 ```
 
 **Agent 2 — Code Quality + Simplify Review:**
-```
+```text
 prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
 
 Review code quality AND simplification opportunities:
@@ -173,7 +173,7 @@ description: "Code quality + simplify"
 ```
 
 **Agent 3 — Test Review:**
-```
+```text
 prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
 
 Diagram all new things this plan introduces:
@@ -193,7 +193,7 @@ description: "Test review"
 ```
 
 **Agent 4 — Performance Review:**
-```
+```text
 prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
 
 Review performance:
@@ -241,7 +241,7 @@ ASCII diagrams for any non-trivial data flow, state machine, or pipeline.
 For each new codepath: one realistic failure, whether a test covers it, whether error handling exists, whether the user would see a clear error or silent failure. Any failure with no test AND no error handling AND silent -> **critical gap**.
 
 ### Completion summary
-```
+```text
   Step 0: Scope Challenge (user chose: ___)
   Architecture Review:  ___ issues found
   Code Quality Review:  ___ issues found

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -14,6 +14,8 @@ allowed-tools:
   - Grep
   - Glob
   - Bash
+  - Skill
+  - Agent
   - AskUserQuestion
 ---
 
@@ -52,7 +54,7 @@ Interview guidelines:
 - **Do ask about:** hidden complexity, conflicting requirements, unstated assumptions, failure modes, edge cases, scaling concerns, security implications, data model subtleties, UX micro-interactions, state management tradeoffs, migration paths, backwards compatibility, error handling strategy, and integration boundaries.
 - **Be specific.** Reference concrete parts of the spec. Instead of "how should errors work?", ask "when this background job fails after processing 3 of 10 items, what should the user see?"
 - **Go deep on answers.** Follow up on interesting responses. If the user says "we'll use a queue", ask about retry policy, idempotency, ordering guarantees, dead letter handling.
-- **Cover multiple dimensions per round.** Use multi-question AskUserQuestion calls (up to 4 questions) to keep the interview moving.
+- **Cover multiple dimensions per round.** Keep each AskUserQuestion focused on one decision, but cover multiple topics across a round to keep the interview moving.
 - **Provide informed options.** When asking about tradeoffs, present concrete options with pros/cons.
 - **Reference existing patterns.** Check what similar features in the codebase do and ask whether this should follow the same pattern or diverge.
 
@@ -134,60 +136,92 @@ Then ask if the user wants:
 
 **Critical: If the user does not select SCOPE REDUCTION, respect that fully.** Your job becomes making the plan succeed. Raise scope concerns once — after that, commit.
 
-### Section 1: Architecture Review
-Evaluate:
-* Overall system design — pages, API routes, backend services, DB schema, background jobs.
-* Dependency graph and coupling concerns.
-* Data flow patterns and potential bottlenecks.
-* Multi-tenancy: every new table/query must scope appropriately.
-* Security: auth boundaries, authorization checks, API surface.
-* For each new codepath or integration, describe one realistic production failure and whether the plan accounts for it.
-* ASCII diagrams for non-trivial flows.
+### Parallel Review — DISPATCH 4 AGENTS
 
-**STOP.** AskUserQuestion individually per issue. Present options, recommend, explain WHY. Do NOT batch. Only proceed after ALL issues resolved.
+After scope is agreed, dispatch **4 parallel review agents** in a single message using the Agent tool. Each agent reads the spec/plan independently and returns findings. This runs all reviews concurrently instead of sequentially.
 
-### Section 2: Code Quality Review
-Evaluate:
-* Code organization — fits existing patterns in CLAUDE.md?
-* DRY violations — be aggressive.
-* Error handling patterns and missing edge cases.
-* Over-engineering or under-engineering.
-* Existing conventions from the codebase.
-
-**STOP.** AskUserQuestion individually per issue.
-
-### Section 3: Test Review
-Diagram all new things this plan introduces:
+**Agent 1 — Architecture Review:**
 ```
+prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
+
+Review the plan's architecture:
+* Overall system design — pages, API routes, backend services, DB schema, background jobs
+* Dependency graph and coupling concerns
+* Data flow patterns and bottlenecks
+* Multi-tenancy: every new table/query must scope appropriately
+* Security: auth boundaries, authorization checks, API surface
+* For each new codepath, describe one realistic production failure
+* ASCII diagrams for non-trivial flows
+
+Return a numbered list of issues. For each: file/component reference, problem description, 2-3 concrete options with your recommendation and WHY. Mark severity as CRITICAL or INFORMATIONAL."
+description: "Architecture review"
+```
+
+**Agent 2 — Code Quality + Simplify Review:**
+```
+prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
+
+Review code quality AND simplification opportunities:
+* Code organization — fits existing patterns in CLAUDE.md?
+* DRY violations — be aggressive
+* Error handling patterns and missing edge cases
+* Over-engineering or under-engineering
+* Simplification: identify any planned code that could reuse existing utilities, be made simpler, or follow existing patterns more closely. Reference specific existing files/functions that could be leveraged.
+
+Return a numbered list of issues. For each: file/component reference, problem description, 2-3 concrete options with your recommendation and WHY."
+description: "Code quality + simplify"
+```
+
+**Agent 3 — Test Review:**
+```
+prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
+
+Diagram all new things this plan introduces:
   NEW UX FLOWS:        [list each]
   NEW API ROUTES:      [list each]
   NEW DATA FLOWS:      [list each]
   NEW BACKGROUND JOBS: [list each]
   NEW ERROR PATHS:     [list each]
-```
-For each: what test covers it?
-For each new item: happy path test, failure path test, edge case test.
 
-Test pyramid: many unit, fewer integration, few E2E?
+For each: what test covers it? (unit / integration / E2E)
+For each new item: happy path test, failure path test, edge case test.
+Test pyramid check: many unit, fewer integration, few E2E?
 Flakiness risk: tests depending on timing, external services, read-after-write?
 
-**STOP.** AskUserQuestion individually per issue.
+Return the diagram plus a numbered list of test gaps with recommendations."
+description: "Test review"
+```
 
-### Section 4: Performance Review
-Evaluate:
-* N+1 queries. Every new DB query in a loop: batch or join?
-* Database indexes for new query patterns.
-* Background job sizing: worst-case payload, runtime, retry behavior.
-* Parallelization opportunities for independent operations.
-* Caching opportunities.
+**Agent 4 — Performance Review:**
+```
+prompt: "You are reviewing a technical plan. Read CLAUDE.md for project conventions, then read the spec at [SPEC_PATH].
 
-**STOP.** AskUserQuestion individually per issue.
+Review performance:
+* N+1 queries — every new DB query in a loop: batch or join?
+* Database indexes for new query patterns
+* Parallelization opportunities for independent operations
+* Background job sizing: worst-case payload, runtime, retry behavior
+* Caching opportunities
 
-## CRITICAL RULE — How to ask questions
+Return a numbered list of issues with recommendations."
+description: "Performance review"
+```
+
+### Process Agent Results
+
+After all 4 agents return, merge their findings into a unified list. For each issue across all agents, present to the user via AskUserQuestion individually — one issue per call. Present options, recommend, explain WHY. Do NOT batch.
+
+Process in priority order: Architecture issues first, then Quality+Simplify, then Tests, then Performance. Within each section, CRITICAL issues before INFORMATIONAL.
+
+**STOP after each issue.** Only proceed after ALL issues resolved.
+
+## CRITICAL RULE — How to ask questions (REVIEW mode)
 Every AskUserQuestion MUST: (1) present 2-3 concrete lettered options, (2) state which option you recommend FIRST, (3) explain in 1-2 sentences WHY. No batching multiple issues. No yes/no questions. Open-ended questions only when genuinely ambiguous.
 
 **Lead with your recommendation.** "Do B. Here's why:" Be opinionated.
 **Escape hatch:** If a section has no issues, say so and move on.
+
+In INTERVIEW and BRAINSTORM modes, AskUserQuestion can be more open-ended and exploratory — the strict option/recommendation format is not required.
 
 ## Required Outputs (REVIEW mode)
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -10,6 +10,7 @@ allowed-tools:
   - Read
   - Write
   - Glob
+  - Agent
 ---
 
 # /retro — Weekly Engineering Retrospective
@@ -39,31 +40,56 @@ Usage: /retro [window]
   /retro compare 14d  — compare with explicit window
 ```
 
-### Step 1: Gather Raw Data
+### Step 1: Gather Raw Data — PARALLEL AGENTS
 
-First, fetch origin to ensure we have the latest:
+First, fetch origin:
 ```bash
 git fetch origin main --quiet
 ```
 
-Run ALL of these git commands in parallel (they are independent):
+Resolve the retrospective subject first. For a personal retro (default), scope all queries to the current user:
 
 ```bash
-# 1. All commits in window with timestamps, subject, hash, files changed
-git log origin/main --since="<window>" --format="%H|%ai|%s" --shortstat
-
-# 2. Per-commit test vs total LOC breakdown
-git log origin/main --since="<window>" --format="COMMIT:%H" --numstat
-
-# 3. Commit timestamps for session detection
-git log origin/main --since="<window>" --format="%at|%ai|%s" | sort -n
-
-# 4. Files most frequently changed (hotspot analysis)
-git log origin/main --since="<window>" --format="" --name-only | grep -v '^$' | sort | uniq -c | sort -rn
-
-# 5. PR numbers from commit messages
-git log origin/main --since="<window>" --format="%s" | grep -oE '#[0-9]+' | sed 's/^#//' | sort -n | uniq | sed 's/^/#/'
+RETRO_AUTHOR="$(git config user.email)"
 ```
+
+Then dispatch **3 parallel agents** in a single message to gather data concurrently. Pass the author email to each agent.
+
+**Agent 1 — Commit metrics + LOC breakdown:**
+```
+prompt: "Gather git commit metrics for the retro. Run these commands and return ALL raw output:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%H|%ai|%s' --shortstat
+2. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='COMMIT:%H' --numstat
+3. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%s' | grep -oE '#[0-9]+' | sed 's/^#//' | sort -n | uniq | sed 's/^/#/'
+
+Return the raw output of all three commands, clearly labeled."
+description: "Commit metrics"
+```
+
+**Agent 2 — Time patterns + sessions + streak:**
+```
+prompt: "Gather git timing data for the retro. Run these commands and return ALL raw output:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%at|%ai|%s' | sort -n
+2. git log origin/main --author='<RETRO_AUTHOR>' --format='%ad' --date=format:'%Y-%m-%d' | sort -u
+
+For the streak calculation: count consecutive days backward from today that have at least one commit by this author. Return the raw output and the streak count."
+description: "Time patterns + streak"
+```
+
+**Agent 3 — Hotspots + history:**
+```
+prompt: "Gather file hotspot data and retro history. Run these commands:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='' --name-only | grep -v '^$' | sort | uniq -c | sort -rn | head -20
+2. ls -t .context/retros/*.json 2>/dev/null | head -1
+
+If a prior retro JSON exists, read it and return the contents. Return all raw output."
+description: "Hotspots + history"
+```
+
+Wait for all 3 agents. Collect their raw output, then proceed to compute metrics from the combined data.
 
 ### Step 2: Compute Metrics
 
@@ -276,7 +302,7 @@ Small, practical, realistic. Each takes <5 minutes to adopt.
 
 When `/retro compare` (or `/retro compare 14d`):
 
-1. Compute metrics for current window using `--since="7 days ago"`
+1. Compute metrics for the current parsed window using `--since="<window>"`
 2. Compute metrics for prior same-length window using both `--since` and `--until` to avoid overlap
 3. Show side-by-side comparison table with deltas and arrows
 4. Write brief narrative on biggest improvements and regressions

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -190,7 +190,7 @@ If time window is 14+ days, split into weekly buckets and show:
 Count consecutive days with at least 1 commit to origin/main:
 
 ```bash
-git log origin/main --format="%ad" --date=format:"%Y-%m-%d" | sort -u
+git log origin/main --author="$RETRO_AUTHOR" --format="%ad" --date=format:"%Y-%m-%d" | sort -u
 ```
 
 Count backward from today. Display: "Shipping streak: 47 consecutive days"

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: retro
+version: 1.0.0
+description: |
+  Weekly engineering retrospective. Analyzes commit history, work patterns,
+  and code quality metrics with persistent history and trend tracking.
+argument-hint: [window] [compare]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Glob
+---
+
+# /retro — Weekly Engineering Retrospective
+
+Generates a comprehensive engineering retrospective analyzing commit history, work patterns, and code quality metrics.
+
+## Arguments
+- `/retro` — default: last 7 days
+- `/retro 24h` — last 24 hours
+- `/retro 14d` — last 14 days
+- `/retro 30d` — last 30 days
+- `/retro compare` — compare current window vs prior same-length window
+- `/retro compare 14d` — compare with explicit window
+
+## Instructions
+
+Parse the argument to determine the time window. Default to 7 days if no argument given. Use `--since="N days ago"`, `--since="N hours ago"`, or `--since="N weeks ago"` for git log queries.
+
+**Argument validation:** If the argument doesn't match a number followed by `d`, `h`, or `w`, the word `compare`, or `compare` followed by a number and `d`/`h`/`w`, show usage and stop:
+```
+Usage: /retro [window]
+  /retro              — last 7 days (default)
+  /retro 24h          — last 24 hours
+  /retro 14d          — last 14 days
+  /retro 30d          — last 30 days
+  /retro compare      — compare this period vs prior period
+  /retro compare 14d  — compare with explicit window
+```
+
+### Step 1: Gather Raw Data
+
+First, fetch origin to ensure we have the latest:
+```bash
+git fetch origin main --quiet
+```
+
+Run ALL of these git commands in parallel (they are independent):
+
+```bash
+# 1. All commits in window with timestamps, subject, hash, files changed
+git log origin/main --since="<window>" --format="%H|%ai|%s" --shortstat
+
+# 2. Per-commit test vs total LOC breakdown
+git log origin/main --since="<window>" --format="COMMIT:%H" --numstat
+
+# 3. Commit timestamps for session detection
+git log origin/main --since="<window>" --format="%at|%ai|%s" | sort -n
+
+# 4. Files most frequently changed (hotspot analysis)
+git log origin/main --since="<window>" --format="" --name-only | grep -v '^$' | sort | uniq -c | sort -rn
+
+# 5. PR numbers from commit messages
+git log origin/main --since="<window>" --format="%s" | grep -oE '#[0-9]+' | sed 's/^#//' | sort -n | uniq | sed 's/^/#/'
+```
+
+### Step 2: Compute Metrics
+
+Calculate and present in a summary table:
+
+| Metric | Value |
+|--------|-------|
+| Commits to main | N |
+| PRs merged | N |
+| Total insertions | N |
+| Total deletions | N |
+| Net LOC added | N |
+| Test LOC (insertions) | N |
+| Test LOC ratio | N% |
+| Active days | N |
+| Detected sessions | N |
+| Avg LOC/session-hour | N |
+
+Test files are identified by matching: `test/`, `spec/`, `__tests__/`, `.test.ts`, `.test.tsx`, `.spec.ts`, `.test.js`, `.test.jsx`, `.spec.js`, `e2e/`, `_test.go`, `_test.py`, `test_*.py`.
+
+### Step 3: Commit Time Distribution
+
+Show hourly histogram using bar chart:
+
+```
+Hour  Commits  ████████████████
+ 00:    4      ████
+ 07:    5      █████
+ ...
+```
+
+Identify and call out:
+- Peak hours
+- Dead zones
+- Whether pattern is bimodal (morning/evening) or continuous
+- Late-night coding clusters (after 10pm)
+
+### Step 4: Work Session Detection
+
+Detect sessions using **45-minute gap** threshold between consecutive commits. For each session:
+- Start/end time
+- Number of commits
+- Duration in minutes
+
+Classify sessions:
+- **Deep sessions** (50+ min)
+- **Medium sessions** (20-50 min)
+- **Micro sessions** (<20 min)
+
+Calculate:
+- Total active coding time
+- Average session length
+- LOC per hour of active time
+
+### Step 5: Commit Type Breakdown
+
+Categorize by conventional commit prefix (feat/fix/refactor/test/chore/docs). Show as percentage bar:
+
+```
+feat:     20  (40%)  ████████████████████
+fix:      27  (54%)  ███████████████████████████
+refactor:  2  ( 4%)  ██
+```
+
+Flag if fix ratio exceeds 50% — signals "ship fast, fix fast" pattern.
+
+### Step 6: Hotspot Analysis
+
+Show top 10 most-changed files. Flag:
+- Files changed 5+ times (churn hotspots)
+- Test files vs production files in the hotspot list
+- Schema files that change frequently (migration churn)
+
+### Step 7: PR Size Distribution
+
+From commit diffs, estimate PR sizes:
+- **Small** (<100 LOC)
+- **Medium** (100-500 LOC)
+- **Large** (500-1500 LOC)
+- **XL** (1500+ LOC) — flag these
+
+### Step 8: Focus Score + Ship of the Week
+
+**Focus score:** Percentage of commits touching the single most-changed top-level directory. Higher = deeper focus. Report as: "Focus score: 62% (src/app/)"
+
+**Ship of the week:** Auto-identify the single highest-LOC PR. Highlight PR number, title, LOC changed, and why it matters.
+
+### Step 9: Week-over-Week Trends (if window >= 14d)
+
+If time window is 14+ days, split into weekly buckets and show:
+- Commits per week
+- LOC per week
+- Test ratio per week
+- Fix ratio per week
+
+### Step 10: Streak Tracking
+
+Count consecutive days with at least 1 commit to origin/main:
+
+```bash
+git log origin/main --format="%ad" --date=format:"%Y-%m-%d" | sort -u
+```
+
+Count backward from today. Display: "Shipping streak: 47 consecutive days"
+
+### Step 11: Load History & Compare
+
+Before saving, check for prior retro history:
+
+```bash
+ls -t .context/retros/*.json 2>/dev/null
+```
+
+**If prior retros exist:** Load the most recent one. Show a **Trends vs Last Retro** section:
+```
+                    Last        Now         Delta
+Test ratio:         22%    →    41%         ↑19pp
+Sessions:           10     →    14          ↑4
+LOC/hour:           200    →    350         ↑75%
+Fix ratio:          54%    →    30%         ↓24pp (improving)
+```
+
+**If no prior retros:** Skip comparison. Append: "First retro recorded — run again next week to see trends."
+
+### Step 12: Save Retro History
+
+```bash
+mkdir -p .context/retros
+```
+
+Save JSON snapshot with this schema:
+```json
+{
+  "date": "2026-03-12",
+  "window": "7d",
+  "metrics": {
+    "commits": 47,
+    "prs_merged": 12,
+    "insertions": 3200,
+    "deletions": 800,
+    "net_loc": 2400,
+    "test_loc": 1300,
+    "test_ratio": 0.41,
+    "active_days": 6,
+    "sessions": 14,
+    "deep_sessions": 5,
+    "avg_session_minutes": 42,
+    "loc_per_session_hour": 350,
+    "feat_pct": 0.40,
+    "fix_pct": 0.30,
+    "peak_hour": 22
+  },
+  "streak_days": 47,
+  "tweetable": "Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm"
+}
+```
+
+### Step 13: Write the Narrative
+
+**Tweetable summary** (first line):
+```
+Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm | Streak: 47d
+```
+
+## Engineering Retro: [date range]
+
+### Summary Table
+(from Step 2)
+
+### Trends vs Last Retro
+(from Step 11 — skip if first retro)
+
+### Time & Session Patterns
+(from Steps 3-4)
+- When the most productive hours are
+- Whether sessions are getting longer or shorter
+- Estimated hours per day of active coding
+
+### Shipping Velocity
+(from Steps 5-7)
+- Commit type mix
+- PR size discipline
+- Fix-chain detection
+
+### Code Quality Signals
+- Test LOC ratio trend
+- Hotspot analysis
+- Any XL PRs that should have been split
+
+### Focus & Highlights
+(from Step 8)
+- Focus score with interpretation
+- Ship of the week callout
+
+### Top 3 Wins
+3 highest-impact things shipped. For each: what, why it matters, what's impressive.
+
+### 3 Things to Improve
+Specific, actionable, anchored in actual commits.
+
+### 3 Habits for Next Week
+Small, practical, realistic. Each takes <5 minutes to adopt.
+
+### Week-over-Week Trends
+(if applicable, from Step 9)
+
+---
+
+## Compare Mode
+
+When `/retro compare` (or `/retro compare 14d`):
+
+1. Compute metrics for current window using `--since="7 days ago"`
+2. Compute metrics for prior same-length window using both `--since` and `--until` to avoid overlap
+3. Show side-by-side comparison table with deltas and arrows
+4. Write brief narrative on biggest improvements and regressions
+5. Save only current-window snapshot
+
+## Tone
+
+- Encouraging but candid, no coddling
+- Specific and concrete — anchor in actual commits
+- Skip generic praise — say exactly what was good and why
+- Frame improvements as leveling up, not criticism
+- Keep total output around 2500-3500 words
+- Use markdown tables and code blocks for data, prose for narrative
+- Output directly to conversation — do NOT write to filesystem (except JSON snapshot)
+
+## Important Rules
+
+- ALL narrative output goes to conversation. Only file written is JSON snapshot.
+- Use `origin/main` for all git queries (not local main)
+- If zero commits in window, say so and suggest a different window
+- Round LOC/hour to nearest 50
+- Do not read CLAUDE.md — this skill is self-contained
+- On first run, skip comparison sections gracefully

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -13,6 +13,8 @@ allowed-tools:
   - Edit
   - Grep
   - Glob
+  - Skill
+  - Agent
   - AskUserQuestion
 ---
 
@@ -63,7 +65,7 @@ If `$ARGUMENTS` contains "clean":
 
 2. Run `git status` (never use `-uall`). Uncommitted changes are always included.
 
-3. Run `git diff main...HEAD --stat` and `git log main..HEAD --oneline` to understand what's being shipped.
+3. Run `git diff origin/main...HEAD --stat` and `git log origin/main..HEAD --oneline` to understand what's being shipped.
 
 ---
 
@@ -81,15 +83,19 @@ git fetch origin main && git merge origin/main --no-edit
 
 ---
 
-## Step 3: Run tests (on merged code)
+## Step 3: Run tests (on merged code) — PARALLEL AGENTS
 
-Run tests based on what changed. Check `git diff origin/main --name-only` to determine scope.
+Check `git diff origin/main --name-only` to determine which areas changed. Read CLAUDE.md and package.json to discover the project's test commands.
 
-Read CLAUDE.md and package.json to discover the project's test commands. Run the appropriate test suites for the changed files.
+Dispatch **parallel sub-agents** for each applicable test suite using the Agent tool. Launch all agents in a **single message** (multiple Agent tool calls). Each agent should run the appropriate test command for the changed area and report pass/fail count and any failures.
 
-Run independent test suites in parallel where possible.
+Example agent prompts (adapt to the project's actual test commands):
+```
+prompt: "Run the test suite: <test-command>. Report pass/fail count and any failures."
+description: "<area> tests"
+```
 
-After all complete, check pass/fail.
+Wait for all test agents to complete. Collect results.
 
 **If any test fails:** Show the failures and **STOP**. Do not proceed.
 
@@ -97,13 +103,34 @@ After all complete, check pass/fail.
 
 ---
 
-## Step 4: Pre-Landing Review
+## Step 4: Pre-Landing Review + Simplify — PARALLEL AGENTS
 
-Review the diff for structural issues that tests don't catch.
+After tests pass, dispatch **two parallel agents** in a single message:
 
-1. Run `git diff origin/main` to get the full diff.
+**Agent A — Pre-landing review:**
+```
+prompt: "Run a pre-landing code review on the diff between origin/main and HEAD. Run `git diff origin/main` to get the full diff. Apply a two-pass review:
 
-2. Apply a two-pass review:
+Pass 1 (CRITICAL): SQL/data safety, auth boundary violations, background job safety, XSS, file upload issues.
+Pass 2 (INFORMATIONAL): Missing error handling, console.log/debug statements, ORM gotchas, framework gotchas, convention violations.
+
+Output format: 'Pre-Landing Review: N issues (X critical, Y informational)' followed by findings with file:line references and suggested fixes. Categorize each as CRITICAL or INFORMATIONAL."
+description: "Pre-landing review"
+```
+
+**Agent B — Code simplification:**
+```
+prompt: "Review all files changed between origin/main and HEAD (run `git diff origin/main --name-only` to find them). For each changed file, check for: code that could be reused from existing utilities, unnecessarily complex logic that could be simplified, redundant code, inconsistent patterns vs the rest of the codebase. Read CLAUDE.md conventions section first. Output a list of specific simplification suggestions with file:line references. If a suggestion is safe and obvious, apply the fix directly using Edit. Only apply fixes that preserve exact functionality."
+description: "Simplify changed code"
+```
+
+Wait for both agents. Process results:
+
+1. **Simplify agent results:** If it made edits, stage them. If it only suggested changes, apply the safe ones.
+
+2. **Review agent results:** Parse findings into CRITICAL and INFORMATIONAL.
+
+3. Apply the two-pass review logic:
 
 **Pass 1 (CRITICAL):**
 - SQL/Data safety: raw SQL interpolation, missing tenant scoping, TOCTOU races
@@ -140,8 +167,8 @@ Review the diff for structural issues that tests don't catch.
 1. Read `CHANGELOG.md` header to know the format. If no CHANGELOG.md exists, skip this step.
 
 2. Auto-generate entries from **ALL commits on the branch**:
-   - Use `git log main..HEAD --oneline` for every commit being shipped
-   - Use `git diff main...HEAD` for the full diff
+   - Use `git log origin/main..HEAD --oneline` for every commit being shipped
+   - Use `git diff origin/main...HEAD` for the full diff
    - Categorize into: `### Added`, `### Changed`, `### Fixed`
    - Write concise, descriptive bullet points
    - Insert under `## [Unreleased]` section

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: ship
+version: 1.0.0
+description: |
+  Fully automated ship workflow. Merges main, runs tests, does pre-landing review,
+  splits bisectable commits, pushes, and creates PR. Also handles branch cleanup.
+  Replaces: commit-push-pr, verification-before-completion, clean_gone.
+argument-hint: [clean]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+
+# Ship: Fully Automated Ship Workflow
+
+You are running the `/ship` workflow. This is a **non-interactive, fully automated** workflow. Do NOT ask for confirmation at any step unless specified. The user said `/ship` which means DO IT.
+
+## Arguments
+
+- `/ship` — full ship workflow (default)
+- `/ship clean` — clean up stale local branches marked as `[gone]` on remote, including worktrees
+
+---
+
+## Clean Mode
+
+If `$ARGUMENTS` contains "clean":
+
+1. Run `git fetch --prune` to update remote tracking info.
+2. List branches marked as gone: `git branch -vv | grep ': gone]'`
+3. For each gone branch:
+   - Check if it has an associated worktree: `git worktree list`
+   - If worktree exists, remove it: `git worktree remove <path> --force`
+   - Delete the branch: `git branch -D <branch>`
+4. Report what was cleaned up, then **STOP**.
+
+---
+
+## Ship Mode (default)
+
+**Only stop for:**
+- On `main` branch (abort)
+- Merge conflicts that can't be auto-resolved (stop, show conflicts)
+- Test failures (stop, show failures)
+- Pre-landing review finds CRITICAL issues and user chooses to fix
+- Anything that would lose work
+
+**Never stop for:**
+- Uncommitted changes (always include them)
+- CHANGELOG content (auto-generate from diff)
+- Commit message approval (auto-commit)
+
+---
+
+## Step 1: Pre-flight
+
+1. Check the current branch. If on `main`, **abort**: "You're on main. Ship from a feature branch."
+
+2. Run `git status` (never use `-uall`). Uncommitted changes are always included.
+
+3. Run `git diff main...HEAD --stat` and `git log main..HEAD --oneline` to understand what's being shipped.
+
+---
+
+## Step 2: Merge origin/main (BEFORE tests)
+
+Fetch and merge `origin/main` into the feature branch so tests run against the merged state:
+
+```bash
+git fetch origin main && git merge origin/main --no-edit
+```
+
+**If merge conflicts:** Try to auto-resolve simple ones (CHANGELOG ordering, lock files). If complex, **STOP** and show them.
+
+**If already up to date:** Continue silently.
+
+---
+
+## Step 3: Run tests (on merged code)
+
+Run tests based on what changed. Check `git diff origin/main --name-only` to determine scope.
+
+Read CLAUDE.md and package.json to discover the project's test commands. Run the appropriate test suites for the changed files.
+
+Run independent test suites in parallel where possible.
+
+After all complete, check pass/fail.
+
+**If any test fails:** Show the failures and **STOP**. Do not proceed.
+
+**If all pass:** Continue — just note the counts briefly.
+
+---
+
+## Step 4: Pre-Landing Review
+
+Review the diff for structural issues that tests don't catch.
+
+1. Run `git diff origin/main` to get the full diff.
+
+2. Apply a two-pass review:
+
+**Pass 1 (CRITICAL):**
+- SQL/Data safety: raw SQL interpolation, missing tenant scoping, TOCTOU races
+- Auth boundary violations: missing auth checks, missing scope enforcement
+- Background job safety: non-idempotent operations, missing error handling
+- XSS: unescaped user content rendered as HTML
+- File upload: missing MIME validation, path traversal
+
+**Pass 2 (INFORMATIONAL):**
+- Missing error handling in API routes
+- `console.log` / debug statements left in code
+- ORM gotchas relevant to the project's ORM
+- Framework-specific gotchas (missing cleanup, missing deps arrays, etc.)
+- Missing parallelization for independent operations
+- Convention violations from CLAUDE.md
+
+3. Output: `Pre-Landing Review: N issues (X critical, Y informational)`
+
+4. **If CRITICAL issues found:** For EACH critical issue, use AskUserQuestion with the problem, recommended fix, and options:
+   - A) Fix it now (recommended)
+   - B) Acknowledge and ship anyway
+   - C) False positive — skip
+
+   If user chose A on any issue, apply fixes, commit them (`git add <fixed-files> && git commit -m "fix: apply pre-landing review fixes"`), then **re-run from Step 3** to verify fixes don't break tests.
+
+5. **If only informational:** Output them and continue. Include in PR body.
+
+6. **If no issues:** Output `Pre-Landing Review: No issues found.` and continue.
+
+---
+
+## Step 5: CHANGELOG (auto-generate)
+
+1. Read `CHANGELOG.md` header to know the format. If no CHANGELOG.md exists, skip this step.
+
+2. Auto-generate entries from **ALL commits on the branch**:
+   - Use `git log main..HEAD --oneline` for every commit being shipped
+   - Use `git diff main...HEAD` for the full diff
+   - Categorize into: `### Added`, `### Changed`, `### Fixed`
+   - Write concise, descriptive bullet points
+   - Insert under `## [Unreleased]` section
+   - Follow Keep a Changelog format
+
+**Do NOT ask the user to describe changes.** Infer from the diff and commit history.
+
+---
+
+## Step 6: Commit (bisectable chunks)
+
+**Goal:** Create small, logical commits that work well with `git bisect`.
+
+1. Analyze the diff and group changes into logical commits. Each commit = one coherent change.
+
+2. **Commit ordering** (earlier first):
+   - **Schema/migrations:** new DB tables, schema changes
+   - **Backend:** new config, services, background jobs (with their tests)
+   - **API routes:** new/modified routes (with their tests)
+   - **Frontend:** components, pages (with their tests)
+   - **CHANGELOG:** always in the final commit
+
+3. **Rules for splitting:**
+   - A component and its test file go in the same commit
+   - An API route and its test go in the same commit
+   - Migrations are their own commit (or grouped with the schema they support)
+   - If the total diff is small (< 50 lines across < 4 files), a single commit is fine
+
+4. **Each commit must be independently valid** — no broken imports.
+
+5. Commit messages: `<type>: <summary>` (type = feat/fix/chore/refactor/docs)
+   Only the **final commit** gets the co-author trailer:
+
+```bash
+git commit -m "$(cat <<'EOF'
+chore: update changelog
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Step 7: Push
+
+Push to the remote with upstream tracking:
+
+```bash
+git push -u origin $(git branch --show-current)
+```
+
+---
+
+## Step 8: Create PR
+
+Create a pull request using `gh`:
+
+```bash
+gh pr create --title "<type>: <summary>" --body "$(cat <<'EOF'
+## Summary
+<bullet points from CHANGELOG>
+
+## Pre-Landing Review
+<findings from Step 4, or "No issues found.">
+
+## Test plan
+- [x] Tests pass (N tests)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Output the PR URL** — this should be the final output the user sees.
+
+---
+
+## Important Rules
+
+- **Never skip tests.** If tests fail, stop.
+- **Never skip the pre-landing review.** Run it every time.
+- **Never force push.** Use regular `git push` only.
+- **Never ask for confirmation** except for CRITICAL review findings.
+- **Split commits for bisectability** — each commit = one logical change.
+- **The goal is: user says `/ship`, next thing they see is the review + PR URL.**


### PR DESCRIPTION
## Summary
- Add `/plan` skill — consolidated engineering planning (interview, brainstorm, review modes)
- Add `/plan-ceo` skill — founder/CEO-mode plan review (10-star product thinking, 3 scope modes)
- Add `/ship` skill — fully automated ship workflow (merge main, test, pre-landing review, bisectable commits, push, PR, branch cleanup)
- Add `/retro` skill — weekly engineering retrospective (commit analysis, session detection, streaks, trends)
- Update `config/profiles.json` to include new skills in `base` and `monorepo-root` profiles
- Bump version to 2.0

Adapted from verityaml/verity#148 with all project-specific references removed (Inngest, Drizzle, BetterAuth, Supabase, org_id scoping, etc.) and replaced with generic equivalents.

## Test plan
- [ ] New skills appear in slash command list after restart
- [ ] `/plan`, `/plan-ceo`, `/ship`, `/retro` invoke correctly
- [ ] `node scripts/configure-claude.js /tmp/test-project` installs new skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four new skills: plan (engineering planning), plan‑ceo (CEO/founder review), ship (automated ship workflow), and retro (weekly retrospective analysis).

* **Documentation**
  * Added comprehensive, structured process guides, required output templates, interaction rules, and modes for each new skill.

* **Chores**
  * Version bumped to 2.0, profiles updated, and changelog augmented with a 2.0 entry consolidating the new skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->