### PR TITLE
feat: add PR intent gate, merged branch guard, and CI monitor hooks

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,6 +13,26 @@
         "description": "Guardian: evaluate tool call risk and block dangerous operations"
       },
       {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"gh\\\\s+pr\\\\s+create\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/pr-intent-gate.js\""
+          }
+        ],
+        "description": "PR Intent Gate: require ## Why section in PR body"
+      },
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"git\\\\s+(push|commit|rebase|merge)(\\\\s|$)\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/merged-branch-guard.js\""
+          }
+        ],
+        "description": "Merged Branch Guard: block operations on branches with merged PRs"
+      },
+      {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"git commit(\\\\s|$)\"",
         "hooks": [
           {
@@ -77,6 +97,18 @@
           }
         ],
         "description": "Log PR URL and provide review command after PR creation"
+      },
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"gh\\\\s+pr\\\\s+create\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/ci-monitor.js\"",
+            "async": true,
+            "timeout": 30
+          }
+        ],
+        "description": "CI Monitor: spawn background poller for PR check status"
       },
       {
         "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm run build|pnpm build|yarn build)\"",

--- a/scripts/hooks/ci-monitor-poller.js
+++ b/scripts/hooks/ci-monitor-poller.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+/**
+ * CI Monitor Poller — Detached background process spawned by ci-monitor.js.
+ * Polls GitHub check-runs using ETag-based conditional requests (304 = zero cost).
+ * Writes results to /tmp/claude-ci-<prNumber>.json when checks complete.
+ *
+ * Usage: node ci-monitor-poller.js <owner/repo> <prNumber>
+ */
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+const ownerRepo = process.argv[2];
+const prNumber = process.argv[3];
+
+if (!ownerRepo || !prNumber) process.exit(1);
+
+const POLL_INTERVAL_MS = 30_000; // 30 seconds
+const MAX_POLL_MS = 30 * 60_000; // 30 minutes
+const RESULT_FILE = path.join(os.tmpdir(), `claude-ci-${prNumber}.json`);
+
+function getHeadSha() {
+  const result = spawnSync('gh', [
+    'api', `repos/${ownerRepo}/pulls/${prNumber}`, '--jq', '.head.sha'
+  ], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function getGhToken() {
+  const result = spawnSync('gh', ['auth', 'token'], {
+    encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function fetchCheckRuns(sha, token, etag) {
+  return new Promise((resolve, reject) => {
+    const headers = {
+      'User-Agent': 'claude-ci-monitor',
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28'
+    };
+    if (etag) headers['If-None-Match'] = etag;
+
+    const req = https.request({
+      hostname: 'api.github.com',
+      path: `/repos/${ownerRepo}/commits/${sha}/check-runs`,
+      method: 'GET',
+      headers
+    }, (res) => {
+      let body = '';
+      res.on('data', chunk => body += chunk);
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode,
+          etag: res.headers['etag'] || null,
+          body: res.statusCode === 200 ? JSON.parse(body) : null
+        });
+      });
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+function writeResult(sha, status, checks) {
+  const result = {
+    pr: parseInt(prNumber),
+    url: `https://github.com/${ownerRepo}/pull/${prNumber}`,
+    sha,
+    status,
+    checks: checks.map(c => ({
+      name: c.name,
+      status: c.status,
+      conclusion: c.conclusion
+    })),
+    completedAt: new Date().toISOString()
+  };
+  fs.writeFileSync(RESULT_FILE, JSON.stringify(result, null, 2));
+}
+
+async function poll() {
+  const sha = getHeadSha();
+  if (!sha) process.exit(1);
+
+  const token = getGhToken();
+  if (!token) process.exit(1);
+
+  let etag = null;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < MAX_POLL_MS) {
+    try {
+      const response = await fetchCheckRuns(sha, token, etag);
+
+      if (response.status === 304) {
+        // Not modified — zero API cost, continue polling
+      } else if (response.status === 200 && response.body) {
+        etag = response.etag;
+        const checks = response.body.check_runs || [];
+
+        if (checks.length > 0 && checks.every(c => c.status === 'completed')) {
+          const allPassed = checks.every(c => c.conclusion === 'success' || c.conclusion === 'skipped');
+          const status = allPassed ? 'pass' : 'fail';
+          writeResult(sha, status, checks);
+
+          // Log to a file Claude's hooks can pick up
+          const summary = allPassed
+            ? `All ${checks.length} checks passed`
+            : `${checks.filter(c => c.conclusion !== 'success' && c.conclusion !== 'skipped').length} check(s) failed`;
+          const logFile = path.join(os.tmpdir(), `claude-ci-${prNumber}.log`);
+          fs.writeFileSync(logFile, `[CI Monitor] PR #${prNumber}: ${summary}\n`);
+          process.exit(0);
+        }
+      }
+    } catch {
+      // Network error — continue polling
+    }
+
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  // Timeout — write pending result
+  writeResult(sha, 'timeout', []);
+  process.exit(0);
+}
+
+poll().catch(() => process.exit(1));

--- a/scripts/hooks/ci-monitor.js
+++ b/scripts/hooks/ci-monitor.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+/**
+ * CI Monitor — PostToolUse hook that spawns a background poller after
+ * `gh pr create` to watch CI check status using ETag-based conditional requests.
+ * Writes results to a temp file when checks complete.
+ * Fail-open: errors are silently ignored.
+ */
+
+const path = require('path');
+const { spawn } = require('child_process');
+const { readStdinJson, log } = require('../lib/utils');
+
+async function main() {
+  const input = await readStdinJson();
+
+  // Pass through stdin to stdout (required for PostToolUse)
+  console.log(JSON.stringify(input));
+
+  const command = input.tool_input?.command || '';
+  const output = input.tool_output?.output || '';
+
+  // Only trigger on gh pr create
+  if (!/gh\s+pr\s+create/.test(command)) return;
+
+  // Extract PR URL from output
+  const prMatch = output.match(/https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/(\d+)/);
+  if (!prMatch) return;
+
+  const ownerRepo = prMatch[1];
+  const prNumber = prMatch[2];
+
+  log(`[CI Monitor] Spawning background poller for PR #${prNumber}...`);
+
+  // Spawn detached poller
+  const pollerScript = path.join(__dirname, 'ci-monitor-poller.js');
+  const child = spawn('node', [pollerScript, ownerRepo, prNumber], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env }
+  });
+  child.unref();
+}
+
+main().catch(() => {});

--- a/scripts/hooks/merged-branch-guard.js
+++ b/scripts/hooks/merged-branch-guard.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * Merged Branch Guard — PreToolUse hook that blocks git push, commit, rebase,
+ * and merge on branches that already have a merged PR.
+ * Uses a session-scoped file cache to avoid repeated gh API calls.
+ * Fail-open: if anything goes wrong, exits 0 (allows).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+const { readStdinJson, log, getSessionIdShort } = require('../lib/utils');
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function getCachePath() {
+  return path.join(os.tmpdir(), `claude-merged-cache-${getSessionIdShort()}.json`);
+}
+
+function readCache() {
+  try {
+    return JSON.parse(fs.readFileSync(getCachePath(), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeCache(cache) {
+  try {
+    fs.writeFileSync(getCachePath(), JSON.stringify(cache), 'utf8');
+  } catch {
+    // Best-effort
+  }
+}
+
+function getCurrentBranch() {
+  const result = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+    encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function checkMergedPR(branch) {
+  const result = spawnSync('gh', [
+    'pr', 'list', '--state', 'merged', '--head', branch,
+    '--json', 'number', '--limit', '1'
+  ], { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+
+  if (result.status !== 0) return null; // gh failed, fail-open
+
+  try {
+    const prs = JSON.parse(result.stdout);
+    return prs.length > 0 ? prs[0].number : false;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const input = await readStdinJson();
+  const command = input.tool_input?.command || '';
+
+  // Only intercept git push/commit/rebase/merge
+  if (!/git\s+(push|commit|rebase|merge)(\s|$)/.test(command)) {
+    process.exit(0);
+  }
+
+  const branch = getCurrentBranch();
+  if (!branch || branch === 'main' || branch === 'master' || branch === 'HEAD') {
+    process.exit(0);
+  }
+
+  // Check cache first
+  const cache = readCache();
+  const cached = cache[branch];
+  if (cached && (Date.now() - cached.checkedAt) < CACHE_TTL_MS) {
+    if (cached.merged) {
+      log('');
+      log(`[Merged Branch Guard] BLOCKED — branch "${branch}" has a merged PR (#${cached.prNumber}).`);
+      log(`[Merged Branch Guard] Create a new branch instead: git checkout -b <new-branch>`);
+      log('');
+      process.exit(1);
+    }
+    process.exit(0);
+  }
+
+  // Query GitHub
+  const prNumber = checkMergedPR(branch);
+  if (prNumber === null) {
+    // gh failed — fail-open
+    process.exit(0);
+  }
+
+  // Update cache
+  cache[branch] = { merged: !!prNumber, prNumber: prNumber || null, checkedAt: Date.now() };
+  writeCache(cache);
+
+  if (prNumber) {
+    log('');
+    log(`[Merged Branch Guard] BLOCKED — branch "${branch}" has a merged PR (#${prNumber}).`);
+    log(`[Merged Branch Guard] Create a new branch instead: git checkout -b <new-branch>`);
+    log('');
+    process.exit(1);
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/scripts/hooks/pr-intent-gate.js
+++ b/scripts/hooks/pr-intent-gate.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * PR Intent Gate — PreToolUse hook that blocks `gh pr create` unless the
+ * PR body contains a "## Why" section explaining business intent.
+ * Fail-open: if anything goes wrong, exits 0 (allows).
+ */
+
+const { readStdinJson, log } = require('../lib/utils');
+
+async function main() {
+  const input = await readStdinJson();
+  const command = input.tool_input?.command || '';
+
+  // Only intercept gh pr create
+  if (!/gh\s+pr\s+create/.test(command)) {
+    process.exit(0);
+  }
+
+  // Check if --body contains a ## Why section
+  // Handle: --body "...", --body '...', and heredoc --body "$(cat <<'EOF'...EOF)"
+  const bodyMatch = command.match(/--body\s+(?:"([\s\S]*?)(?:(?<!\\)")|'([\s\S]*?)')/);
+  const bodyContent = bodyMatch ? (bodyMatch[1] || bodyMatch[2] || '') : '';
+
+  if (/##\s*why/i.test(bodyContent)) {
+    process.exit(0);
+  }
+
+  // Block — tell Claude to ask for intent
+  log('');
+  log('[PR Intent Gate] Blocked — missing "## Why" section in PR body.');
+  log('[PR Intent Gate] Before creating this PR, ask the user:');
+  log('[PR Intent Gate]   "Why are we shipping this? What business problem does it solve?"');
+  log('[PR Intent Gate] Then add a ## Why section to the PR body with their answer.');
+  log('');
+  process.exit(1);
+}
+
+main().catch(() => process.exit(0));


### PR DESCRIPTION
## Summary
- **PR Intent Gate**: PreToolUse hook that blocks `gh pr create` unless the PR body contains a `## Why` section, forcing business intent capture before shipping
- **Merged Branch Guard**: PreToolUse hook that blocks git push/commit/rebase/merge on branches with already-merged PRs (5-min session cache to avoid API spam)
- **CI Monitor**: PostToolUse async hook that spawns a detached background poller after PR creation, using ETag-based conditional requests (304 = zero rate-limit cost) to watch CI checks

## Why
PRs should capture business intent, not just diffs. Stale branches with merged PRs cause confusion. CI status should be monitored automatically without manual polling.

## Test plan
- [x] PR Intent Gate blocks without `## Why`, allows with it
- [x] Merged Branch Guard correctly detected merged PR #8 on `feat/review-qa-skills`
- [x] CI Monitor poller spawns detached process after PR creation
- [x] hooks.json validates as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated CI check monitoring after PR creation that tracks check-run status and logs completion results for reference.
  * Added branch guard that prevents git operations (push, commit, rebase, merge) on branches with merged pull requests, with guidance for users.
  * PR creation now requires a "Why" section in the description to clearly document intent before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->