### PR TITLE
refactor: extract inline hooks to files, fix permission drift

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -103,7 +103,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const cmd=i.tool_input?.command||'';if(/gh pr create/.test(cmd)){const out=i.tool_output?.output||'';const m=out.match(/https:\\/\\/github.com\\/[^/]+\\/[^/]+\\/pull\\/\\d+/);if(m){console.error('[Hook] PR created: '+m[0]);const repo=m[0].replace(/https:\\/\\/github.com\\/([^/]+\\/[^/]+)\\/pull\\/\\d+/,'$1');const pr=m[0].replace(/.*\\/pull\\/(\\d+)/,'$1');console.error('[Hook] To review: gh pr review '+pr+' --repo '+repo)}}console.log(d)})\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/pr-url-logger.js\""
           }
         ],
         "description": "Log PR URL and provide review command after PR creation"
@@ -125,7 +125,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execFileSync}=require('child_process');const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){try{execFileSync('npx',['prettier','--write',p],{stdio:['pipe','pipe','pipe']})}catch(e){}}console.log(d)})\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/prettier-format.js\""
           }
         ],
         "description": "Auto-format JS/TS files with Prettier after edits"
@@ -135,7 +135,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const{execSync}=require('child_process');const fs=require('fs');const path=require('path');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){let dir=path.dirname(p);while(dir!==path.dirname(dir)&&!fs.existsSync(path.join(dir,'tsconfig.json'))){dir=path.dirname(dir)}if(fs.existsSync(path.join(dir,'tsconfig.json'))){try{const r=execSync('npx tsc --noEmit --pretty false 2>&1',{cwd:dir,encoding:'utf8',stdio:['pipe','pipe','pipe']});const lines=r.split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}catch(e){const lines=(e.stdout||'').split('\\n').filter(l=>l.includes(p)).slice(0,10);if(lines.length)console.error(lines.join('\\n'))}}}console.log(d)})\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/typescript-check.js\""
           }
         ],
         "description": "TypeScript check after editing .ts/.tsx files"
@@ -145,7 +145,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node -e \"const fs=require('fs');let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const i=JSON.parse(d);const p=i.tool_input?.file_path;if(p&&fs.existsSync(p)){const c=fs.readFileSync(p,'utf8');const lines=c.split('\\n');const matches=[];lines.forEach((l,idx)=>{if(/console\\.log/.test(l))matches.push((idx+1)+': '+l.trim())});if(matches.length){console.error('[Hook] WARNING: console.log found in '+p);matches.slice(0,5).forEach(m=>console.error(m));console.error('[Hook] Remove console.log before committing')}}console.log(d)})\""
+            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/console-log-warn.js\""
           }
         ],
         "description": "Warn about console.log statements after edits"

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -332,7 +332,8 @@ function installForProfile(targetDir, resolvedProfile, label) {
     enabledPlugins: { ...existingSettings.enabledPlugins, ...pluginsToEnable },
   };
 
-  // Merge guardian permissions for active mode
+  // Derive permissions from guardian-rules.json (single source of truth).
+  // On re-install, this replaces the entire allow list to prevent drift.
   const guardianConfig = readJsonSync(guardianDest);
   if (guardianConfig?.permissions) {
     const mode = guardianConfig.mode || 'supervised';
@@ -340,9 +341,9 @@ function installForProfile(targetDir, resolvedProfile, label) {
     if (modePerms?.allow) {
       merged.permissions = {
         ...merged.permissions,
-        allow: [...new Set([...(merged.permissions?.allow || []), ...modePerms.allow])],
+        allow: modePerms.allow,
       };
-      console.log(`  ✓ Merged guardian permissions for "${mode}" mode (${modePerms.allow.length} allow entries)`);
+      console.log(`  ✓ Set guardian permissions from "${mode}" mode (${modePerms.allow.length} allow entries)`);
     }
   }
 

--- a/scripts/hooks/console-log-warn.js
+++ b/scripts/hooks/console-log-warn.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook: Warn about console.log statements after editing JS/TS files.
+ * Fires on Edit tool calls targeting .ts/.tsx/.js/.jsx files.
+ *
+ * stdin: JSON with tool_input.file_path
+ * stdout: pass-through (PostToolUse pattern)
+ * stderr: warnings about console.log statements
+ */
+
+const fs = require('fs');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && fs.existsSync(filePath)) {
+      const content = fs.readFileSync(filePath, 'utf8');
+      const lines = content.split('\n');
+      const matches = [];
+
+      lines.forEach((line, idx) => {
+        if (/console\.log/.test(line)) {
+          matches.push(`${idx + 1}: ${line.trim()}`);
+        }
+      });
+
+      if (matches.length) {
+        console.error(`[Hook] WARNING: console.log found in ${filePath}`);
+        matches.slice(0, 5).forEach(m => console.error(m));
+        console.error('[Hook] Remove console.log before committing');
+      }
+    }
+  } catch (e) {
+    // fail-open
+  }
+
+  console.log(data);
+});

--- a/scripts/hooks/pr-url-logger.js
+++ b/scripts/hooks/pr-url-logger.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook: Log PR URL and review command after `gh pr create`.
+ * Fires on all Bash tool calls, checks if the command was `gh pr create`,
+ * and if so extracts the PR URL from the output.
+ *
+ * stdin: JSON with tool_input.command and tool_output.output
+ * stdout: pass-through (PostToolUse pattern)
+ * stderr: informational messages for the user
+ */
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    const cmd = input.tool_input?.command || '';
+
+    if (/gh pr create/.test(cmd)) {
+      const output = input.tool_output?.output || '';
+      const match = output.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/);
+
+      if (match) {
+        const url = match[0];
+        const repo = url.replace(/https:\/\/github\.com\/([^/]+\/[^/]+)\/pull\/\d+/, '$1');
+        const pr = url.replace(/.*\/pull\/(\d+)/, '$1');
+
+        console.error(`[Hook] PR created: ${url}`);
+        console.error(`[Hook] To review: gh pr review ${pr} --repo ${repo}`);
+      }
+    }
+  } catch (e) {
+    // fail-open
+  }
+
+  // PostToolUse: pass-through stdin to stdout
+  console.log(data);
+});

--- a/scripts/hooks/prettier-format.js
+++ b/scripts/hooks/prettier-format.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook: Auto-format JS/TS files with Prettier after edits.
+ * Fires on Edit tool calls targeting .ts/.tsx/.js/.jsx files.
+ *
+ * stdin: JSON with tool_input.file_path
+ * stdout: pass-through (PostToolUse pattern)
+ */
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && fs.existsSync(filePath)) {
+      try {
+        execFileSync('npx', ['prettier', '--write', filePath], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+      } catch (e) {
+        // Prettier not available or failed — not blocking
+      }
+    }
+  } catch (e) {
+    // fail-open
+  }
+
+  console.log(data);
+});

--- a/scripts/hooks/typescript-check.js
+++ b/scripts/hooks/typescript-check.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * PostToolUse hook: Run TypeScript type-check after editing .ts/.tsx files.
+ * Walks up from the edited file to find tsconfig.json, runs `tsc --noEmit`,
+ * and reports errors scoped to the edited file.
+ *
+ * stdin: JSON with tool_input.file_path
+ * stdout: pass-through (PostToolUse pattern)
+ * stderr: TypeScript errors for the edited file
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+let data = '';
+process.stdin.on('data', chunk => data += chunk);
+process.stdin.on('end', () => {
+  try {
+    const input = JSON.parse(data);
+    const filePath = input.tool_input?.file_path;
+
+    if (filePath && fs.existsSync(filePath)) {
+      // Walk up to find tsconfig.json
+      let dir = path.dirname(filePath);
+      while (dir !== path.dirname(dir) && !fs.existsSync(path.join(dir, 'tsconfig.json'))) {
+        dir = path.dirname(dir);
+      }
+
+      if (fs.existsSync(path.join(dir, 'tsconfig.json'))) {
+        try {
+          const result = execSync('npx tsc --noEmit --pretty false 2>&1', {
+            cwd: dir,
+            encoding: 'utf8',
+            stdio: ['pipe', 'pipe', 'pipe'],
+          });
+          const lines = result.split('\n').filter(l => l.includes(filePath)).slice(0, 10);
+          if (lines.length) console.error(lines.join('\n'));
+        } catch (e) {
+          const lines = (e.stdout || '').split('\n').filter(l => l.includes(filePath)).slice(0, 10);
+          if (lines.length) console.error(lines.join('\n'));
+        }
+      }
+    }
+  } catch (e) {
+    // fail-open
+  }
+
+  console.log(data);
+});


### PR DESCRIPTION
## Summary
- Extracted 4 inline Node.js programs from hooks.json into separate files under `scripts/hooks/`
- Fixed permission duplication: installer now replaces (not merges) settings.json permissions from guardian-rules.json

## Important Files
| File | Change |
|------|--------|
| `scripts/hooks/pr-url-logger.js` | Extracted from inline — logs PR URL + review command |
| `scripts/hooks/prettier-format.js` | Extracted from inline — auto-formats JS/TS with Prettier |
| `scripts/hooks/typescript-check.js` | Extracted from inline — runs tsc --noEmit on edited file |
| `scripts/hooks/console-log-warn.js` | Extracted from inline — warns about console.log |
| `hooks/hooks.json` | Replaced 4 inline commands with file references |
| `scripts/configure-claude.js` | Permissions: replace instead of merge on re-install |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined hook system with dedicated handlers for PR logging, code formatting, TypeScript type-checking, and console.log detection after edits.

* **Improvements**
  * Enhanced automated code quality checks and developer workflow organization.
  * Updated permission handling strategy for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->