### PR TITLE
feat: absorb pr-review-toolkit into /review, clean up global manifest

### DIFF
--- a/config/global-settings.json
+++ b/config/global-settings.json
@@ -6,17 +6,13 @@
   ],
   "plugins": [
     "commit-commands@claude-plugins-official",
-    "superpowers@claude-plugins-official",
     "claude-md-management@claude-plugins-official",
     "hookify@claude-plugins-official",
     "typescript-lsp@claude-plugins-official",
     "pyright-lsp@claude-plugins-official",
     "code-simplifier@claude-plugins-official",
-    "code-review@claude-plugins-official",
-    "pr-review-toolkit@claude-plugins-official",
     "security-guidance@claude-plugins-official",
-    "frontend-design@claude-plugins-official",
-    "feature-dev@claude-plugins-official"
+    "frontend-design@claude-plugins-official"
   ],
   "mcpServers": {
     "sequential-thinking": {

--- a/skills/receiving-pr-feedback/SKILL.md
+++ b/skills/receiving-pr-feedback/SKILL.md
@@ -48,6 +48,20 @@ For each review comment, classify it:
 | **Nitpick** | Fix if trivial, skip if subjective |
 | **Wrong / outdated** | Push back with evidence |
 
+## Step 2.5: Clarify ALL unclear items first
+
+Before implementing anything, check if any comments are unclear or ambiguous. If so, **stop and ask for clarification on ALL unclear items before touching any code.**
+
+Items may be related — partial understanding leads to wrong implementation.
+
+```
+IF you understand items 1,2,3,6 but not 4,5:
+  ❌ WRONG: Implement 1,2,3,6 now, ask about 4,5 later
+  ✅ RIGHT: "Understand 1,2,3,6. Need clarification on 4 and 5 before implementing."
+```
+
+---
+
 ## Step 3: Process each comment
 
 For each comment, follow this protocol:
@@ -72,7 +86,7 @@ Instead: verify, then respond with facts.
 Push back when a suggestion:
 - **Breaks functionality** — "This would break X because Y. The current approach handles Z."
 - **Lacks context** — "This pattern is intentional because [reason from spec/CLAUDE.md]."
-- **Violates YAGNI** — "Adding this abstraction isn't needed yet — only one callsite exists."
+- **Violates YAGNI** — grep the codebase for actual usage. "This endpoint isn't called anywhere. Remove it (YAGNI)? Or is there usage I'm missing?"
 - **Is technically incorrect** — "This would actually cause [problem]. Here's why: [evidence]."
 - **Conflicts with project conventions** — "CLAUDE.md specifies [convention]. Should we update the convention instead?"
 
@@ -87,9 +101,15 @@ Acknowledge with brief, factual statements: "Fixed — the null check was missin
 
 ## Step 4: Apply fixes
 
+Implement in this order:
+1. **Blocking issues** (breaks, security) — fix first
+2. **Simple fixes** (typos, imports, one-liners) — batch these
+3. **Complex fixes** (refactoring, logic changes) — one at a time, test each
+
 For each accepted comment:
 1. Make the fix
-2. Reply on the PR with what you changed (one-liner)
+2. Test it (run relevant tests to verify no regression)
+3. Reply on the PR with what you changed (one-liner)
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment-id>/replies -f body="Fixed — added null check for empty array case."

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -165,12 +165,15 @@ description: "Code comment compliance"
 
 **Agent F — Silent failure hunter (conditional):**
 
-Only dispatch if the diff contains error handling code (try/catch, .catch, error callbacks, Result types, fallback logic).
+Only dispatch if the diff contains error-handling code (try/catch, .catch, error callbacks, Result types, fallback logic).
 
 ```text
-prompt: "Hunt for silent failures in the changes between origin/main and HEAD.
+prompt: "Hunt for silent failures in the target diff for this review.
 
-Run `git diff origin/main` to get the full diff. For every error handling
+Use the same diff source selected in Step 1:
+- local mode: `git diff origin/main`
+- PR mode: the `gh pr diff <number>` output already fetched
+For every error-handling
 location in the changed code, scrutinize:
 
 1. **Catch block specificity:** Does it catch only expected errors, or could
@@ -198,12 +201,15 @@ description: "Silent failure hunter"
 
 **Agent G — Type design review (conditional):**
 
-Only dispatch if the diff introduces new types, interfaces, or enums (TypeScript/Python/Go/Rust).
+Only dispatch if the diff introduces or significantly modifies type definitions (types, interfaces, enums, classes, structs in TypeScript/Python/Go/Rust).
 
 ```text
-prompt: "Review type design in the changes between origin/main and HEAD.
+prompt: "Review type design in the target diff for this review.
 
-Run `git diff origin/main` to find new or modified type definitions
+Use the same diff source selected in Step 1:
+- local mode: `git diff origin/main`
+- PR mode: the `gh pr diff <number>` output already fetched
+Find new or modified type definitions
 (interfaces, types, enums, classes, structs).
 
 For each new or significantly modified type, evaluate:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -4,9 +4,9 @@ version: 1.0.0
 description: |
   review this, pre-landing review, check my code, review before merge, code review,
   look over my changes, audit this PR, review PR, review pull request.
-  Five-agent parallel review: conventions, security checklist, git blame history,
-  previous PR comments, code comment compliance. Confidence scoring, Greptile triage,
-  TODO cross-reference, flow diagrams.
+  Up to 7 parallel review agents: conventions, security checklist, git blame history,
+  previous PR comments, code comment compliance, silent failure hunting, type design.
+  Confidence scoring, Greptile triage, TODO cross-reference, flow diagrams.
 argument-hint: [greptile | pr <number>]
 allowed-tools:
   - Bash
@@ -70,7 +70,7 @@ Read `.claude/skills/review/greptile-triage.md` and follow the fetch, filter, cl
 
 ## Step 3: Dispatch Parallel Review Agents
 
-Dispatch **5 parallel agents** in a single message using the Agent tool:
+Dispatch **up to 7 parallel agents** in a single message using the Agent tool. Agents F and G are conditional — only dispatch them if the diff contains relevant code.
 
 **Agent A — Convention review (@code-reviewer):**
 ```text
@@ -163,13 +163,79 @@ not stale comments about unrelated code."
 description: "Code comment compliance"
 ```
 
-Wait for all 5 agents to return.
+**Agent F — Silent failure hunter (conditional):**
+
+Only dispatch if the diff contains error handling code (try/catch, .catch, error callbacks, Result types, fallback logic).
+
+```text
+prompt: "Hunt for silent failures in the changes between origin/main and HEAD.
+
+Run `git diff origin/main` to get the full diff. For every error handling
+location in the changed code, scrutinize:
+
+1. **Catch block specificity:** Does it catch only expected errors, or could
+   it accidentally suppress unrelated errors? List every unexpected error type
+   that could be hidden.
+2. **Logging quality:** Is the error logged with enough context to debug
+   6 months from now? Does it include what operation failed and relevant IDs?
+3. **User feedback:** Does the user receive actionable feedback, or does the
+   error vanish silently?
+4. **Fallback behavior:** Is fallback logic explicitly justified, or does it
+   mask the underlying problem? Would the user be confused by fallback behavior?
+5. **Error propagation:** Should this error bubble up instead of being caught here?
+
+Flag these patterns as CRITICAL:
+- Empty catch blocks
+- Catch blocks that only log and continue without user feedback
+- Returning null/undefined/default on error without logging
+- Broad exception catching that hides unrelated errors
+- Retry logic that exhausts attempts without informing the user
+
+Return findings with file:line, severity (CRITICAL/HIGH/MEDIUM),
+issue description, hidden error types, and recommended fix."
+description: "Silent failure hunter"
+```
+
+**Agent G — Type design review (conditional):**
+
+Only dispatch if the diff introduces new types, interfaces, or enums (TypeScript/Python/Go/Rust).
+
+```text
+prompt: "Review type design in the changes between origin/main and HEAD.
+
+Run `git diff origin/main` to find new or modified type definitions
+(interfaces, types, enums, classes, structs).
+
+For each new or significantly modified type, evaluate:
+
+1. **Invariant expression:** Are constraints obvious from the type definition?
+   Can illegal states be represented? Rate 1-10.
+2. **Encapsulation:** Are internals properly hidden? Can invariants be
+   violated from outside? Rate 1-10.
+3. **Enforcement:** Are invariants checked at construction? Are all mutation
+   points guarded? Rate 1-10.
+4. **Usefulness:** Do the invariants prevent real bugs? Are they aligned
+   with business requirements? Rate 1-10.
+
+Flag these anti-patterns:
+- Anemic types with no behavior or validation
+- Types exposing mutable internals
+- Invariants enforced only through documentation/comments
+- Missing validation at construction boundaries
+- Types that rely on external code to maintain invariants
+
+Return findings with file:line, the type name, ratings, and specific
+improvement suggestions. Keep suggestions pragmatic — don't overcomplicate."
+description: "Type design review"
+```
+
+Wait for all agents to return.
 
 ---
 
 ## Step 4: Merge, Score, and Filter Findings
 
-1. Collect findings from all 5 agents.
+1. Collect findings from all agents (5-7 depending on which conditional agents ran).
 2. Deduplicate: if multiple agents flag the same file:line for the same issue, keep the one with most detail.
 3. **Confidence score each finding** on a 0-100 scale:
    - **0-25:** Likely false positive — doesn't stand up to scrutiny, or is a pre-existing issue.
@@ -193,7 +259,7 @@ Output all findings:
 ### CRITICAL (blocking) — confidence ≥ 80
 1. [file:line] Problem description (score: 85)
    Fix: suggested fix
-   Source: convention | checklist | blame | prev-PR | comments | greptile
+   Source: convention | checklist | blame | prev-PR | comments | silent-failure | type-design | greptile
 
 ### INFORMATIONAL (advisory) — confidence 60-79
 1. [file:line] Problem description (score: 65)


### PR DESCRIPTION
## Summary
- Absorbed `pr-review-toolkit` plugin's unique agents into `/review` (silent failure hunter + type design review)
- Cleaned up global-settings.json manifest — removed 4 pruned plugins (superpowers, code-review, pr-review-toolkit, feature-dev)

## How It Works
```mermaid
flowchart TD
    A["/review dispatches agents"] --> B[A: Conventions]
    A --> C[B: Security checklist]
    A --> D[C: Git blame]
    A --> E[D: Previous PR comments]
    A --> F[E: Code comments]
    A --> G{Error handling in diff?}
    A --> H{New types in diff?}
    G -->|Yes| I[F: Silent failure hunter]
    H -->|Yes| J[G: Type design review]
    G -->|No| K[Skip]
    H -->|No| L[Skip]
```

## Important Files
| File | Change |
|------|--------|
| `skills/review/SKILL.md` | Added Agent F (silent failure hunter) and Agent G (type design review) as conditional agents |
| `config/global-settings.json` | Removed superpowers, code-review, pr-review-toolkit, feature-dev from plugin manifest |

## Test plan
- [ ] Run `/review` on a diff with try/catch — verify Agent F dispatches
- [x] Run `/review` on a diff with new types — verify Agent G dispatches
- [ ] Run `/review` on a docs-only diff — verify F and G are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated global plugin configuration, removing several deprecated plugin entries while retaining the core frontend plugin.

* **Improvements**
  * Expanded the review workflow to support up to 7 parallel reviewers with two conditional specialist reviewers (silent-failure and type-design); synchronization now waits for all dispatched reviewers and merge scoring aggregates results accordingly; critical findings can record silent-failure and type-design sources.
  * Added a mandatory clarification checkpoint, required usage checks for YAGNI pushback, enforced running relevant tests before replying, and clarified fix ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->