### PR TITLE
feat: add adversarial converse mode, fix PR comment fetching

### DIFF
--- a/skills/receiving-pr-feedback/SKILL.md
+++ b/skills/receiving-pr-feedback/SKILL.md
@@ -23,12 +23,20 @@ Handle PR review feedback with technical rigor. Verify suggestions before implem
 
 ## Step 1: Load feedback
 
-If a PR number is in `$ARGUMENTS`, fetch comments:
+If a PR number is in `$ARGUMENTS`, fetch ALL comment types:
 
 ```bash
+# Issue-level comments (general PR discussion, including /review bot comments)
 gh pr view <number> --comments --json comments,reviews,reviewDecision
-gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {path: .path, line: .line, body: .body, user: .user.login}'
+
+# Inline review comments (line-level code review feedback)
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {id: .id, path: .path, line: .line, body: .body, user: .user.login}'
+
+# Top-level issue comments (general discussion not tied to specific lines)
+gh api repos/{owner}/{repo}/issues/<number>/comments --jq '.[] | {id: .id, body: .body, user: .user.login}'
 ```
+
+**Important:** PRs have TWO comment APIs — `/pulls/.../comments` for inline review comments and `/issues/.../comments` for general discussion. Both must be fetched. Automated review bots (like `/review pr`) post to issue comments, not inline comments.
 
 If no PR number, check the current branch:
 ```bash

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -57,8 +57,21 @@ IFS=':' read -r ADVERSARY_CLI ADVERSARY_MODEL <<< "<converse-value>"
 | `gemini` | `-m <model>` | CLI default | `gemini [-m <model>] -p "prompt" > "$CONVERSE_TMPDIR/file.txt"` |
 | `claude` | `--model <model>` | CLI default | `claude [--model <model>] --print "prompt" > "$CONVERSE_TMPDIR/file.txt"` |
 
-Build the model flag:
+Validate the CLI is supported and installed:
 ```bash
+# Allowlist check — reject unknown CLIs immediately
+case "$ADVERSARY_CLI" in
+  codex|gemini|claude) ;;
+  *) echo "Unsupported CLI: $ADVERSARY_CLI"; exit 1 ;;
+esac
+
+# Existence check — stop if not installed
+command -v "$ADVERSARY_CLI" >/dev/null 2>&1 || {
+  echo "CLI '$ADVERSARY_CLI' not found. Install it first."
+  exit 1
+}
+
+# Build model flag
 MODEL_FLAG=""
 if [ -n "$ADVERSARY_MODEL" ]; then
   case "$ADVERSARY_CLI" in
@@ -69,11 +82,20 @@ if [ -n "$ADVERSARY_MODEL" ]; then
 fi
 ```
 
-If the CLI is not installed, **STOP**: "CLI `<cli>` not found. Install it first."
+### CLI dispatch helper
 
-Verify the CLI exists:
+Use the appropriate invocation per CLI. All three execution phases use this pattern:
 ```bash
-which $ADVERSARY_CLI || echo "NOT_FOUND"
+# Usage: run_adversary <output-file> [&]
+# Reads prompt from stdin, writes response to <output-file>
+run_adversary() {
+  local outfile="$1"
+  case "$ADVERSARY_CLI" in
+    codex)  codex exec $MODEL_FLAG -o "$outfile" - ;;
+    gemini) gemini $MODEL_FLAG -p "$(cat -)" > "$outfile" ;;
+    claude) claude $MODEL_FLAG --print "$(cat -)" > "$outfile" ;;
+  esac
+}
 ```
 
 ### Converse workflow
@@ -97,7 +119,7 @@ git diff origin/main > "$CONVERSE_TMPDIR/diff.txt"
 Start the other model's independent review in the background BEFORE Claude begins its own review. Pipe the diff and a review prompt via stdin. Use **unquoted** heredoc delimiter so `$(cat ...)` expands:
 
 ```bash
-cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/adversary-review.txt" - &
+cat <<PROMPT_EOF | run_adversary "$CONVERSE_TMPDIR/adversary-review.txt" &
 You are a code reviewer. Below is a diff. Perform a thorough code review.
 
 For each issue found, output:
@@ -133,7 +155,7 @@ Both reviews are now complete — neither has seen the other's findings.
 Now both models have independent findings. Send BOTH sets to the adversary and ask it to compare:
 
 ```bash
-cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/round-1.txt" -
+cat <<PROMPT_EOF | run_adversary "$CONVERSE_TMPDIR/round-1.txt"
 You previously reviewed a diff and found these issues:
 
 YOUR FINDINGS:
@@ -171,7 +193,7 @@ For each round:
 4. Send Claude's responses back to the adversary:
 
 ```bash
-cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/round-N.txt" -
+cat <<PROMPT_EOF | run_adversary "$CONVERSE_TMPDIR/round-N.txt"
 Continuing the code review debate. Only respond to unresolved items.
 
 For each item, respond:

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,7 +7,8 @@ description: |
   Up to 7 parallel review agents: conventions, security checklist, git blame history,
   previous PR comments, code comment compliance, silent failure hunting, type design.
   Confidence scoring, Greptile triage, TODO cross-reference, flow diagrams.
-argument-hint: [greptile | pr <number>]
+  Adversarial converse mode: /review pr 123 --converse codex runs Claude's review then debates findings with another model CLI.
+argument-hint: "[pr <number>] [--converse cli[:model]]"
 allowed-tools:
   - Bash
   - Read
@@ -26,6 +27,220 @@ You are running the `/review` workflow. Analyze the current branch's diff agains
 - `/review` — full review of current branch vs main (default)
 - `/review greptile` — include Greptile bot comment triage
 - `/review pr <number>` — review an existing PR by number (fetches diff from GitHub)
+- `/review --converse codex` — adversarial review: Claude reviews, then debates findings with Codex CLI until consensus
+- `/review pr 123 --converse codex` — same but for a PR (posts consensus findings as PR comment)
+- `/review pr 123 --converse codex:o3` — specify adversary model (format: `cli:model`)
+
+---
+
+## Step 0.5: Converse Mode (Adversarial Review)
+
+**If `$ARGUMENTS` contains `--converse <model>`:**
+
+Both models review independently and in parallel — neither sees the other's findings. Then they exchange results and debate disagreements until consensus. The user sees which issues both found (high confidence), which were unique to each, and what got dropped as false positives.
+
+### Parse the adversary argument
+
+The `--converse` value can be `cli` or `cli:model` (e.g., `codex`, `codex:o3`, `claude:sonnet`).
+
+```bash
+# Parse "codex:o3" → CLI="codex", MODEL="o3"
+# Parse "codex"    → CLI="codex", MODEL="" (use CLI default)
+IFS=':' read -r ADVERSARY_CLI ADVERSARY_MODEL <<< "<converse-value>"
+```
+
+### Supported CLIs and model flags
+
+| CLI | Model flag | Default model | Non-interactive invocation |
+|-----|-----------|---------------|---------------------------|
+| `codex` | `-m <model>` | CLI default | `codex exec [-m <model>] -o "$CONVERSE_TMPDIR/file.txt" -` |
+| `gemini` | `-m <model>` | CLI default | `gemini [-m <model>] -p "prompt" > "$CONVERSE_TMPDIR/file.txt"` |
+| `claude` | `--model <model>` | CLI default | `claude [--model <model>] --print "prompt" > "$CONVERSE_TMPDIR/file.txt"` |
+
+Build the model flag:
+```bash
+MODEL_FLAG=""
+if [ -n "$ADVERSARY_MODEL" ]; then
+  case "$ADVERSARY_CLI" in
+    codex)  MODEL_FLAG="-m $ADVERSARY_MODEL" ;;
+    gemini) MODEL_FLAG="-m $ADVERSARY_MODEL" ;;
+    claude) MODEL_FLAG="--model $ADVERSARY_MODEL" ;;
+  esac
+fi
+```
+
+If the CLI is not installed, **STOP**: "CLI `<cli>` not found. Install it first."
+
+Verify the CLI exists:
+```bash
+which $ADVERSARY_CLI || echo "NOT_FOUND"
+```
+
+### Converse workflow
+
+**Phase 1: Both models review in parallel**
+
+Kick off BOTH reviews simultaneously — Claude's review and the adversary's review run at the same time.
+
+**1a. Create a unique temp directory and save the diff:**
+```bash
+CONVERSE_TMPDIR=$(mktemp -d /tmp/converse-XXXXXX)
+
+# PR mode:
+gh pr diff <number> > "$CONVERSE_TMPDIR/diff.txt"
+# Local mode:
+git diff origin/main > "$CONVERSE_TMPDIR/diff.txt"
+```
+
+**1b. Launch the adversary review as a background process:**
+
+Start the other model's independent review in the background BEFORE Claude begins its own review. Pipe the diff and a review prompt via stdin. Use **unquoted** heredoc delimiter so `$(cat ...)` expands:
+
+```bash
+cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/adversary-review.txt" - &
+You are a code reviewer. Below is a diff. Perform a thorough code review.
+
+For each issue found, output:
+- [file:line] SEVERITY (CRITICAL/HIGH/MEDIUM/LOW): description
+  Fix: suggested fix
+
+Look for: security issues, race conditions, logic errors, missing error handling,
+convention violations, silent failures, type safety issues, missing validation,
+resource leaks, and anything that tests wouldn't catch.
+
+DIFF:
+$(cat "$CONVERSE_TMPDIR/diff.txt")
+PROMPT_EOF
+ADVERSARY_PID=$!
+```
+
+**1c. Run Claude's review (Steps 1-5 as normal):**
+
+While the adversary runs in the background, proceed with the full Claude review workflow (Steps 1 through 5). Collect all findings into `CLAUDE_FINDINGS`.
+
+**1d. Wait for the adversary to finish:**
+
+```bash
+wait $ADVERSARY_PID
+```
+
+Read the adversary's independent findings from `$CONVERSE_TMPDIR/adversary-review.txt`. Store as `ADVERSARY_FINDINGS`.
+
+Both reviews are now complete — neither has seen the other's findings.
+
+**Phase 2: Exchange findings and identify disagreements**
+
+Now both models have independent findings. Send BOTH sets to the adversary and ask it to compare:
+
+```bash
+cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/round-1.txt" -
+You previously reviewed a diff and found these issues:
+
+YOUR FINDINGS:
+$(cat "$CONVERSE_TMPDIR/adversary-review.txt")
+
+Another reviewer (Claude) independently found these issues:
+
+CLAUDE'S FINDINGS:
+${CLAUDE_FINDINGS}
+
+Compare both sets of findings. For each item from EITHER reviewer:
+- AGREE: <finding summary> — both reviewers found this or you confirm the other's finding
+- DISAGREE: <finding from Claude> — <why you think it's wrong>
+- UNIQUE_MINE: <your finding Claude missed> — <why it matters>
+- UNIQUE_THEIRS: <Claude's finding you missed> — ACCEPT if valid, REJECT with reason if not
+
+Be honest — if Claude caught something you missed, say so. If you found something they missed, explain why it matters.
+PROMPT_EOF
+```
+
+Claude also independently processes the adversary's findings:
+- For each adversary finding that Claude also found: mark as AGREE
+- For each adversary finding Claude missed: verify against the actual code, ACCEPT or REJECT
+- For each Claude finding the adversary missed: note as UNIQUE_CLAUDE
+
+**Phase 3: Debate disagreements (max 3 rounds)**
+
+Only debate items where the two models DISAGREE. Skip items both agree on.
+
+For each round:
+
+1. Read the adversary's response.
+2. For each DISAGREE item: re-examine the code. Either concede (drop the finding) or defend with evidence (cite specific lines).
+3. For each REJECT from the adversary on Claude's unique findings: defend with code evidence or concede.
+4. Send Claude's responses back to the adversary:
+
+```bash
+cat <<PROMPT_EOF | codex exec $MODEL_FLAG -o "$CONVERSE_TMPDIR/round-N.txt" -
+Continuing the code review debate. Only respond to unresolved items.
+
+For each item, respond:
+- RESOLVED: <finding> — we agree on <outcome: KEEP or DROP>
+- STILL_DISAGREE: <finding> — <new evidence or reasoning>
+
+Stop debating items marked RESOLVED.
+
+PREVIOUS EXCHANGE:
+${PREVIOUS_ROUNDS}
+
+CLAUDE'S RESPONSE:
+${CLAUDE_RESPONSE}
+PROMPT_EOF
+```
+
+**Exit conditions (stop debating when ANY is true):**
+- All items are RESOLVED
+- Max 3 rounds reached
+- Adversary response repeats previous arguments without new evidence
+
+**Phase 4: Build consensus report**
+
+Compile the final findings from the debate:
+
+```markdown
+## Adversarial Review: Claude × <Adversary>
+
+### Both found independently (high confidence)
+1. [file:line] Issue description — severity
+   Found by both reviewers independently — very likely real.
+
+### Claude only → accepted by adversary
+1. [file:line] Issue description — severity
+
+### Adversary only → accepted by Claude
+1. [file:line] Issue description — severity
+
+### Dropped by debate (false positives)
+1. [file:line] Original finding by <reviewer> — dropped because: <reason>
+
+### Unresolved (no consensus after 3 rounds)
+1. [file:line] Finding — Claude says: X, Adversary says: Y
+
+### Review Stats
+- Claude found: N issues | Adversary found: M issues
+- Both found independently: X | Unique to Claude: Y | Unique to adversary: Z
+- Dropped as false positive: W | Unresolved: V
+- Debate rounds: R
+
+### Debate Log
+<Round 1 — Exchange>
+Claude's findings: [summary]
+Adversary's findings: [summary]
+<Round 2 — Disagreements>
+...
+```
+
+**Phase 5: Output**
+
+- **PR mode:** Post the consensus report as a PR comment using `gh pr comment`.
+- **Local mode:** Print the consensus report to the user.
+
+Clean up temp directory:
+```bash
+rm -rf "$CONVERSE_TMPDIR"
+```
+
+**Then STOP.** Do not proceed to Step 7/8 — the converse report replaces the normal summary.
 
 ---
 
@@ -405,3 +620,7 @@ Review complete: BLOCKED | N critical issues need resolution
 - **Confidence scoring filters noise.** Findings below 60 are dropped entirely. Don't lower the threshold to include more — the cutoff exists to prevent false positive fatigue.
 - **Git blame agent may be slow on large files.** It runs `git blame` per changed file — on files with thousands of lines, this takes time. The 5 agents run in parallel so it doesn't block the others.
 - **PR mode (`/review pr <number>`)** fetches the diff from GitHub, not the local branch. The review stamp is NOT written in PR mode (there's no local staged diff to hash).
+- **Converse mode requires the adversary CLI installed.** `codex` needs `npm i -g @openai/codex`, `gemini` needs the Google CLI. The skill checks `which <cli>` and stops early if missing.
+- **Converse mode uses unquoted heredocs** (`<<PROMPT_EOF`, not `<<'PROMPT_EOF'`) so `$(cat ...)` and `${VAR}` expand. The diff content is read from a temp file via `$(cat "$CONVERSE_TMPDIR/diff.txt")` — never passed as a shell argument.
+- **Large diffs may exceed adversary context limits.** If the diff is >5000 lines, consider using `--stat` summary + key files instead of the full diff. The skill doesn't auto-truncate — watch for CLI errors.
+- **Adversary model selection:** Use `cli:model` syntax (e.g., `codex:o3`, `claude:sonnet`). If omitted, the CLI's default model is used.

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -133,6 +133,9 @@ Report to the user:
 - Do not create a `references/` folder with a single tiny file. If all reference content fits in SKILL.md without exceeding ~50 lines, inline it.
 - The `allowed-tools` frontmatter field controls which tools the skill can use. Omitting a needed tool means Claude cannot call it during skill execution. Check the category template for recommended tools.
 - Skill names become slash commands — use lowercase kebab-case, no spaces, no underscores.
+- **Heredoc quoting in shell snippets:** Use unquoted delimiters (`<<EOF`) when the body needs `$(cmd)` or `${VAR}` expansion. Single-quoted (`<<'EOF'`) suppresses ALL expansion — variables are sent as literal text. This is the #1 cause of broken shell in skills.
+- **Background PID capture:** `PID=$!` must come AFTER the heredoc closing delimiter, not inside the body. Everything between open/close delimiters is content, not shell code.
+- **Temp file paths in skills:** Never hardcode `/tmp/foo.txt` — concurrent invocations collide. Use `mktemp -d /tmp/prefix-XXXXXX` and clean up with `rm -rf "$TMPDIR"`.
 
 ## References
 


### PR DESCRIPTION
## Summary
- Added `/review --converse codex` adversarial mode: both models review in parallel, then debate until consensus
- Fixed `/receiving-pr-feedback` to fetch both PR comment APIs (inline + issue-level)
- Added 3 shell gotchas to `/skill-builder` (heredoc quoting, PID capture, temp files)

## How It Works
```mermaid
sequenceDiagram
    participant U as User
    participant C as Claude
    participant A as Adversary (codex/gemini)
    U->>C: /review --converse codex
    par Both review independently
        C->>C: Steps 1-5 (normal review)
        C->>A: Send diff + review prompt
    end
    C->>A: Exchange findings
    A->>C: AGREE/DISAGREE/UNIQUE
    loop Max 3 rounds
        C->>A: Defend or concede
        A->>C: Defend or concede
    end
    C->>U: Consensus report
```

## Important Files
| File | Change |
|------|--------|
| `skills/review/SKILL.md` | Added Step 0.5 converse mode (~200 lines): parallel review, debate, consensus report. CLI table for codex/gemini/claude |
| `skills/receiving-pr-feedback/SKILL.md` | Fetch both `/pulls/.../comments` and `/issues/.../comments` APIs |
| `skills/skill-builder/SKILL.md` | Added 3 shell gotchas for heredoc quoting, PID capture, temp files |

## Test plan
- [ ] Run `/review --converse codex` on a branch with changes — verify parallel review + debate
- [ ] Run `/receiving-pr-feedback <pr>` — verify both inline and issue comments are fetched
- [ ] Verify converse mode stops after max 3 debate rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR feedback loading now collects all comment types (inline reviews, issue/Discussion comments, and review decisions) for more complete review context.
  * Optional --converse flag enables running two reviewers in parallel, debating disagreements for up to three rounds, and producing a single consolidated consensus (posted to PR or printed locally).

* **Documentation**
  * Added skill-authoring gotchas: heredoc usage, background PID placement, and safe temp-file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->