### PR TITLE
chore(ship): extract PR body template into pr-template.md

### DIFF
--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -65,24 +65,7 @@ Use `docs:` for documentation, `chore:` for config/skills, `style:` for formatti
 git push -u origin $(git branch --show-current)
 ```
 
-Create the PR following the standard PR body structure:
-
-```bash
-gh pr create --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
-## Summary
-<bullet points of what changed>
-
-## Important Files
-| File | Change |
-|------|--------|
-| `path/to/file` | description |
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
-
-Skip "How It Works" / Mermaid diagrams, Test Results, Pre-Landing Review, and Doc Completeness sections — they don't apply to lightweight changes.
+Read the PR body template at `.claude/skills/ship/pr-template.md`. Create the PR following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits).
 
 **Output the PR URL** — this should be the final output the user sees, then **STOP**.
 
@@ -257,72 +240,17 @@ git push -u origin $(git branch --show-current)
 
 ## Step 8: Create PR
 
-Construct a rich PR body with these sections, then create the PR using `gh pr create`.
+Read the PR body template at `.claude/skills/ship/pr-template.md` and follow its structure exactly.
 
-### PR Body Structure
+Populate each section:
+- **Summary** — bullet points from CHANGELOG entries (what shipped)
+- **How It Works** — Mermaid diagram for non-trivial PRs (skip for < 50 lines, config-only, docs-only)
+- **Important Files** — table of key files with one-line descriptions
+- **Test Results** — table from Step 3
+- **Pre-Landing Review** — findings from Step 4.5, or "No issues found."
+- **Doc Completeness** — checklist
 
-**1. Summary** — bullet points from CHANGELOG entries (what shipped).
-
-**2. How It Works** (include when the PR has non-trivial logic):
-
-Generate a **Mermaid diagram** showing the key flow introduced or changed. Pick the diagram type that fits best:
-
-- `sequenceDiagram` — for request/response flows, multi-step pipelines, hook execution chains
-- `flowchart TD` — for decision trees, state machines, before/after architecture comparisons
-- `erDiagram` — for schema changes showing new tables/relationships
-
-Keep diagrams focused — show the **new/changed flow only**, not the entire system. 5-15 nodes max. If the PR is small (< 50 lines, config-only, docs-only), skip diagrams entirely.
-
-**3. Important Files** — table of the key files changed with a one-line description of what changed in each:
-
-```markdown
-| File | Change |
-|------|--------|
-| `path/to/file.ts` | Added X handler with Y validation |
-| `path/to/other.ts` | Updated Z to support new field |
-```
-
-Only include files with meaningful logic changes. Skip auto-generated files, lock files, and trivial formatting changes. Group by layer (schema → backend → API → frontend → infra → docs). Max 10-12 rows — if more files changed, summarize the remainder as "N additional files with minor changes".
-
-**4. Test Results** — table from Step 3.
-
-**5. Pre-Landing Review** — findings from Step 4.5, or "No issues found."
-
-**6. Doc Completeness** — checklist.
-
-### Create the PR
-
-```bash
-gh pr create --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
-## Summary
-<bullet points from CHANGELOG>
-
-## How It Works
-<mermaid diagram — or omit section for small/docs-only PRs>
-
-## Important Files
-| File | Change |
-|------|--------|
-| `path/to/file` | description |
-
-## Test Results
-| Suite | Result |
-|-------|--------|
-| <suite> | <pass/fail count> |
-
-## Pre-Landing Review
-<findings from Step 4.5, or "No issues found.">
-
-## Doc Completeness
-- [ ] README updated (if applicable)
-- [ ] CHANGELOG updated
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
-```
-
-**Output the PR URL** — this should be the final output the user sees.
+Create the PR using `gh pr create` with a HEREDOC body. **Output the PR URL.**
 
 ---
 

--- a/skills/ship/pr-template.md
+++ b/skills/ship/pr-template.md
@@ -1,0 +1,99 @@
+# PR Body Template
+
+Shared template for PR creation across skills (`/ship`, `/execute`, parallel agents).
+
+## Title Format
+
+```
+<type>(<scope>): <summary>
+```
+
+- `type`: feat, fix, chore, refactor, docs
+- `scope`: backend, frontend, infra, tooling, etc.
+- `summary`: under 70 characters
+
+## Body Format
+
+```markdown
+## Summary
+<1-5 bullet points describing what shipped — derived from CHANGELOG or commit history>
+
+## How It Works
+<Mermaid diagram showing the key flow introduced or changed>
+
+Pick the diagram type that fits best:
+- `sequenceDiagram` — request/response flows, multi-step pipelines, hook execution chains
+- `flowchart TD` — decision trees, state machines, before/after architecture comparisons
+- `erDiagram` — schema changes showing new tables/relationships
+
+Keep diagrams focused — show the **new/changed flow only**, not the entire system.
+5-15 nodes max. Skip for small PRs (< 50 lines, config-only, docs-only).
+
+## Important Files
+| File | Change |
+|------|--------|
+| `path/to/file.ts` | Added X handler with Y validation |
+| `path/to/other.ts` | Updated Z to support new field |
+
+Only include files with meaningful logic changes. Skip auto-generated files,
+lock files, and trivial formatting changes. Group by layer:
+schema → backend → API → frontend → infra → docs.
+Max 10-12 rows — summarize remainder as "N additional files with minor changes".
+
+## Test Results
+| Suite | Result |
+|-------|--------|
+| Frontend unit | ✅ N passed |
+| Backend unit | ✅ N passed |
+| E2E | ✅ N passed |
+| Lint | ✅ Clean |
+
+Omit suites that weren't run (e.g., no backend changes = no backend tests).
+
+## Pre-Landing Review
+<findings summary, or "No issues found.">
+
+## Doc Completeness
+- [ ] CHANGELOG.md updated
+- [ ] CLAUDE.md updated (if conventions/structure changed)
+- [ ] tasks.md updated (if working on a spec)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## gh pr create Example
+
+```bash
+gh pr create --title "<type>(<scope>): <summary>" --body "$(cat <<'EOF'
+## Summary
+- Added X
+- Fixed Y
+
+## How It Works
+```mermaid
+flowchart TD
+    A[Input] --> B[Process]
+    B --> C[Output]
+```
+
+## Important Files
+| File | Change |
+|------|--------|
+| `src/foo.ts` | Added bar handler |
+
+## Test Results
+| Suite | Result |
+|-------|--------|
+| Frontend unit | ✅ 42 passed |
+| Lint | ✅ Clean |
+
+## Pre-Landing Review
+No issues found.
+
+## Doc Completeness
+- [x] CHANGELOG.md updated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```


### PR DESCRIPTION
## Summary
- Extracted inline PR body structure from `SKILL.md` into a shared `pr-template.md` file
- Updated both full ship mode and pr-only mode to reference the template
- Ported template from verity project with mermaid diagrams, important files table, test results, and doc completeness checklist

## Important Files
| File | Change |
|------|--------|
| `skills/ship/pr-template.md` | New shared PR body template with title format, body sections, and gh example |
| `skills/ship/SKILL.md` | Replaced inline PR body with references to pr-template.md in both modes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced standardized PR template for consistent formatting and structure
  * Streamlined PR creation instructions for PR-only mode with reduced requirements
  * Made architectural diagrams optional for minimal code changes (under 50 lines)
  * Defined clear section structure and formatting guidelines for all PR bodies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->