### PR TITLE
fix(hooks): use __dirname-relative paths in require() calls

### DIFF
--- a/scripts/hooks/ci-monitor.cjs
+++ b/scripts/hooks/ci-monitor.cjs
@@ -8,7 +8,7 @@
 
 const path = require('path');
 const { spawn } = require('child_process');
-const { readStdinJson, log } = require('../lib/utils.cjs');
+const { readStdinJson, log } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   const input = await readStdinJson();

--- a/scripts/hooks/evaluate-session.cjs
+++ b/scripts/hooks/evaluate-session.cjs
@@ -19,7 +19,7 @@ const {
   readFile,
   countInFile,
   log
-} = require('../lib/utils.cjs');
+} = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   // Get script directory to find config

--- a/scripts/hooks/guardian.cjs
+++ b/scripts/hooks/guardian.cjs
@@ -7,7 +7,7 @@
  */
 
 const path = require('path');
-const { readStdinJson, log, getClaudeDir, getSessionIdShort, ensureDir, appendFile, readFile, getDateString } = require('../lib/utils.cjs');
+const { readStdinJson, log, getClaudeDir, getSessionIdShort, ensureDir, appendFile, readFile, getDateString } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 function loadRules() {
   // Check project-local config first, then fall back to co-located config/

--- a/scripts/hooks/lint-gate.js
+++ b/scripts/hooks/lint-gate.js
@@ -11,7 +11,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const { readStdinJson, runCommand, readFile, log } = require('../lib/utils');
+const { readStdinJson, runCommand, readFile, log } = require(path.join(__dirname, '..', 'lib', 'utils'));
 
 function loadAgentRules() {
   // Check project-local config first, then co-located config/

--- a/scripts/hooks/merged-branch-guard.cjs
+++ b/scripts/hooks/merged-branch-guard.cjs
@@ -11,7 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { spawnSync } = require('child_process');
-const { readStdinJson, log, getSessionIdShort } = require('../lib/utils.cjs');
+const { readStdinJson, log, getSessionIdShort } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 

--- a/scripts/hooks/pr-intent-gate.cjs
+++ b/scripts/hooks/pr-intent-gate.cjs
@@ -6,7 +6,8 @@
  * Fail-open: if anything goes wrong, exits 0 (allows).
  */
 
-const { readStdinJson, log } = require('../lib/utils.cjs');
+const path = require('path');
+const { readStdinJson, log } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   const input = await readStdinJson();

--- a/scripts/hooks/pre-compact.cjs
+++ b/scripts/hooks/pre-compact.cjs
@@ -17,7 +17,7 @@ const {
   ensureDir,
   appendFile,
   log
-} = require('../lib/utils.cjs');
+} = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   const sessionsDir = getSessionsDir();

--- a/scripts/hooks/review-gate.cjs
+++ b/scripts/hooks/review-gate.cjs
@@ -9,7 +9,7 @@
 const path = require('path');
 const crypto = require('crypto');
 const { spawnSync } = require('child_process');
-const { readStdinJson, runCommand, readFile, log } = require('../lib/utils.cjs');
+const { readStdinJson, runCommand, readFile, log } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 const REVIEW_FILE = path.join(process.cwd(), '.claude', '.last-review');
 

--- a/scripts/hooks/session-end.cjs
+++ b/scripts/hooks/session-end.cjs
@@ -21,7 +21,7 @@ const {
   findSpecsDir,
   getGitModifiedFiles,
   log
-} = require('../lib/utils.cjs');
+} = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   const sessionsDir = getSessionsDir();

--- a/scripts/hooks/session-start.cjs
+++ b/scripts/hooks/session-start.cjs
@@ -8,6 +8,7 @@
  * files and notifies Claude of available context to load.
  */
 
+const path = require('path');
 const {
   getSessionsDir,
   getLearnedSkillsDir,
@@ -16,9 +17,9 @@ const {
   readFile,
   ensureDir,
   log
-} = require('../lib/utils.cjs');
-const { getPackageManager, getSelectionPrompt } = require('../lib/package-manager.cjs');
-const { listAliases } = require('../lib/session-aliases.cjs');
+} = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
+const { getPackageManager, getSelectionPrompt } = require(path.join(__dirname, '..', 'lib', 'package-manager.cjs'));
+const { listAliases } = require(path.join(__dirname, '..', 'lib', 'session-aliases.cjs'));
 
 async function main() {
   const sessionsDir = getSessionsDir();

--- a/scripts/hooks/skill-usage-tracker.cjs
+++ b/scripts/hooks/skill-usage-tracker.cjs
@@ -10,7 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { readStdinJson } = require('../lib/utils.cjs');
+const { readStdinJson } = require(path.join(__dirname, '..', 'lib', 'utils.cjs'));
 
 async function main() {
   const data = await readStdinJson();


### PR DESCRIPTION
Relative require() paths like ../lib/utils resolve from CWD, not from the script's location. In worktrees the CWD differs from the main repo so Node can't find the lib modules. Using path.join(__dirname, ..) makes resolution independent of CWD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chore**
  * Improved module resolution reliability across build hook scripts to use absolute file paths, enhancing consistency and robustness of the internal build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->