### PR TITLE
feat: add /sweep-issues skill and integrate into /ship

### DIFF
--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec"],
+      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec"],
+      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -67,7 +67,18 @@ git push -u origin $(git branch --show-current)
 
 Read the PR body template at `skills/ship/pr-template.md`. Create the PR following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits).
 
-**Output the PR URL** — this should be the final output the user sees, then **STOP**.
+**Output the PR URL.**
+
+### Step 4: Sweep for Deferred Issues
+
+Invoke `/sweep-issues` using the Skill tool:
+
+```text
+skill: "sweep-issues"
+args: ""
+```
+
+Same as full ship mode — scans the conversation for deferred items and auto-creates GitHub issues.
 
 ---
 
@@ -251,6 +262,22 @@ Populate each section:
 - **Doc Completeness** — checklist
 
 Create the PR using `gh pr create` with a HEREDOC body. **Output the PR URL.**
+
+---
+
+## Step 9: Sweep for Deferred Issues
+
+After the PR is created, invoke `/sweep-issues` using the Skill tool:
+
+```text
+skill: "sweep-issues"
+args: ""
+```
+
+This scans the conversation for deferred items, fast-follows, enhancements, minor bugs, and technical debt identified during development — and auto-creates GitHub issues for each.
+
+**If nothing found:** Continue silently — the PR URL is the final output.
+**If items found:** Create the issues and output the sweep summary. The PR URL remains the last line of output.
 
 ---
 

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: sweep-issues
+version: 1.0.0
+description: |
+  Sweep the current session for deferred items, fast-follows, enhancements,
+  minor bugs, and improvements — then auto-create GitHub issues for each.
+  Runs automatically at the end of /ship, after plans, or manually.
+user-invocable: true
+argument-hint: "[--dry-run]"
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+---
+
+# Sweep Issues: Auto-Create GitHub Issues from Session Work
+
+You are running `/sweep-issues`. Scan the current conversation and recent changes for items that should be tracked as GitHub issues.
+
+## Arguments
+
+- `/sweep-issues` — create issues (default)
+- `/sweep-issues --dry-run` — list what would be created, but don't create anything
+
+## What to Capture
+
+Scan the conversation for ANY of these patterns:
+
+1. **Deferred items** — "we'll do this later", "out of scope for this PR", "deferred to a follow-up", "not in V1", "TODO:", "FIXME:", "HACK:"
+2. **Fast-follows** — "next step would be", "follow-up PR for", "should also add", "nice to have"
+3. **Enhancements** — "could be improved by", "future enhancement", "would be nice to", "stretch goal"
+4. **Minor bugs** — "noticed that X doesn't work when", "edge case:", "workaround:"
+5. **Technical debt** — "this is hacky", "should refactor", "temporary solution", "tech debt"
+6. **Decisions** — "decided not to X because Y" (create issue to revisit if context changes)
+7. **Items from review** — code review findings marked as non-blocking or informational
+
+## What NOT to Capture
+
+- Items that already have a GitHub issue (check with `gh issue list --search "keyword" --limit 5`)
+- Items completed in this session
+- Items that are trivially small (single-line fixes you could do right now)
+- Vague wishes without actionable scope
+
+## Process
+
+### Step 1: Gather Candidates
+
+Review the conversation history and identify candidate items. For each, note:
+- **What**: one-line description
+- **Why**: context from the conversation
+- **Source**: what triggered it (review finding, user comment, edge case discovered, etc.)
+- **Category**: `enhancement` | `bug` | `tech-debt` | `infrastructure`
+
+### Step 2: Deduplicate Against Existing Issues
+
+For each candidate, search existing issues:
+```bash
+gh issue list --search "<keywords>" --limit 5
+```
+
+Skip anything that's already tracked. If an existing issue is related but doesn't cover the new scope, note it as a cross-reference.
+
+### Step 3: Present Candidates
+
+Show the user a numbered list:
+```
+Found N items to create as GitHub issues:
+
+1. [enhancement] Short title — one-line context
+2. [tech-debt] Short title — one-line context
+3. [bug] Short title — one-line context
+```
+
+If `--dry-run`, stop here.
+
+### Step 4: Create Issues
+
+For each item, create a GitHub issue:
+
+```bash
+gh issue create --title "<title>" --label "<label>" --body "$(cat <<'EOF'
+## Summary
+{1-2 sentence description}
+
+## Source
+- Identified during: {PR title / plan name / session context}
+- Related: {any related issues or PRs}
+
+## Requirements
+- [ ] {requirement 1}
+- [ ] {requirement 2}
+- [ ] {requirement 3}
+EOF
+)"
+```
+
+**Label mapping:**
+- `enhancement` → `enhancement`
+- `bug` → `bug`
+- `tech-debt` → `tech-debt`
+- `infrastructure` → `infrastructure`
+
+### Step 5: Report
+
+Output a summary:
+```
+Created N issues:
+- #123 Title
+- #124 Title
+- #125 Title
+
+Skipped M items (already tracked or too small).
+```
+
+## Important Rules
+
+- **Never create duplicate issues.** Always search first.
+- **Never include secrets, credentials, API keys, or tokens in issue bodies.** Redact any sensitive data from conversation context before creating issues.
+- **Keep issues small and focused.** One issue per concern. Don't bundle unrelated items.
+- **Include enough context** that someone reading the issue 3 months from now understands what and why.
+- **Don't over-specify requirements.** 3-5 checklist items is ideal. The implementer will spec the details.
+- **Link related issues** when they exist (use `Related: #NNN` in the body).


### PR DESCRIPTION
## Summary
- Ported `/sweep-issues` skill from verity — auto-creates GitHub issues for deferred items, fast-follows, bugs, and tech debt found during a session
- Generalized labels (removed verity-specific `scoring-pipeline`, `desktop`, `accessibility`)
- Added to `base` and `monorepo-root` profiles in `profiles.json`
- Integrated into `/ship` as final step in both full mode (Step 9) and pr-only mode (Step 4)

## Important Files
| File | Change |
|------|--------|
| `skills/sweep-issues/SKILL.md` | New skill: conversation scanner + GitHub issue creator |
| `config/profiles.json` | Added `sweep-issues` to base and monorepo-root skill lists |
| `skills/ship/SKILL.md` | Added sweep-issues invocation to both ship modes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/sweep-issues` command to scan for deferred items, enhancements, bugs, and technical debt, automatically creating GitHub issues with appropriate labels
  * Supports `--dry-run` flag to preview without creating issues
  * Integrated into PR workflow to auto-create issues after PR creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->