### PR TITLE
fix: address review findings from museli#141

### DIFF
--- a/.claude/scripts/hooks/flow-trace.cjs
+++ b/.claude/scripts/hooks/flow-trace.cjs
@@ -48,8 +48,9 @@ async function main() {
 
   // Sanitize session ID to prevent path traversal
   const sessionId = (process.env.CLAUDE_SESSION_ID || 'unknown').replace(/[^a-zA-Z0-9_-]/g, '_');
+  const projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
   const traceFile = path.join(
-    process.cwd(),
+    projectDir,
     '.claude',
     `flow-trace-${sessionId}.jsonl`
   );

--- a/.claude/scripts/lib/pr-body-parser.cjs
+++ b/.claude/scripts/lib/pr-body-parser.cjs
@@ -65,24 +65,17 @@ function parsePrBody(body) {
 }
 
 /**
- * Ensure non-empty text ends with a trailing newline.
- */
-function ensureTrailingNewline(text) {
-  if (!text || text.endsWith('\n')) {
-    return text || '';
-  }
-  return text + '\n';
-}
-
-/**
  * Reassemble a PR body from a section map.
  * Takes the same structure returned by parsePrBody.
  */
 function assemblePrBody(parsed) {
-  let body = ensureTrailingNewline(parsed.preamble);
+  let body = parsed.preamble || '';
 
   for (const section of parsed.sections) {
-    body += '## ' + section.name + '\n' + ensureTrailingNewline(section.content);
+    if (body && !body.endsWith('\n')) {
+      body += '\n';
+    }
+    body += '## ' + section.name + '\n' + (section.content || '');
   }
 
   return body;

--- a/.claude/scripts/lib/pr-body-parser.cjs
+++ b/.claude/scripts/lib/pr-body-parser.cjs
@@ -65,14 +65,24 @@ function parsePrBody(body) {
 }
 
 /**
+ * Ensure non-empty text ends with a trailing newline.
+ */
+function ensureTrailingNewline(text) {
+  if (!text || text.endsWith('\n')) {
+    return text || '';
+  }
+  return text + '\n';
+}
+
+/**
  * Reassemble a PR body from a section map.
  * Takes the same structure returned by parsePrBody.
  */
 function assemblePrBody(parsed) {
-  let body = parsed.preamble;
+  let body = ensureTrailingNewline(parsed.preamble);
 
   for (const section of parsed.sections) {
-    body += '## ' + section.name + '\n' + section.content;
+    body += '## ' + section.name + '\n' + ensureTrailingNewline(section.content);
   }
 
   return body;

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -219,7 +219,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rm -f .claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
+            "command": "rm -f \"${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl\""
           }
         ],
         "description": "Clean up flow trace files"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -219,7 +219,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rm -f \"${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl\""
+            "command": "rm -f \"${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID:-unknown}.jsonl\""
           }
         ],
         "description": "Clean up flow trace files"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -219,7 +219,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "rm -f .claude/flow-trace-*.jsonl"
+            "command": "rm -f .claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
           }
         ],
         "description": "Clean up flow trace files"

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -21,7 +21,7 @@ You are running the `/flow` skill. Generate a Mermaid diagram showing the develo
 The trace file is at `.claude/flow-trace-{CLAUDE_SESSION_ID}.jsonl` in the project root. The `CLAUDE_SESSION_ID` environment variable identifies the current session.
 
 ```bash
-cat ".claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
+cat "${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
 ```
 
 If the file is missing or empty, respond with:

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -229,10 +229,12 @@ Reassemble the body from the parsed/modified sections, write to a temp file, and
 
 ```bash
 tmp_body_file="$(mktemp)"
+trap 'rm -f "$tmp_body_file"' EXIT
 cat >"$tmp_body_file" <<'EOF'
 <reassembled body>
 EOF
 gh pr edit <number> --body-file "$tmp_body_file"
+trap - EXIT
 rm -f "$tmp_body_file"
 ```
 

--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -225,10 +225,15 @@ Round number = count of existing `**Round N**` entries + 1. Date = today's date.
 
 **f. Update the PR:**
 
-Reassemble the body from the parsed/modified sections and update:
+Reassemble the body from the parsed/modified sections, write to a temp file, and update:
 
 ```bash
-gh pr edit <number> --body "<reassembled body>"
+tmp_body_file="$(mktemp)"
+cat >"$tmp_body_file" <<'EOF'
+<reassembled body>
+EOF
+gh pr edit <number> --body-file "$tmp_body_file"
+rm -f "$tmp_body_file"
 ```
 
 ## Step 5: Summary

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -300,7 +300,7 @@ Read the PR body template at `skills/ship/pr-template.md` and follow its structu
 Before creating the PR, check if a flow trace file exists for this session and is non-empty:
 
 ```bash
-test -s ".claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
+test -s "${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
 ```
 
 If the file exists and is non-empty, parse the JSONL entries and generate a Mermaid `flowchart TD` diagram following the same rules as the `/flow` skill:

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -297,10 +297,10 @@ Read the PR body template at `skills/ship/pr-template.md` and follow its structu
 
 ### Generate Development Flow diagram
 
-Before creating the PR, check if a flow trace file exists for this session:
+Before creating the PR, check if a flow trace file exists for this session and is non-empty:
 
 ```bash
-cat ".claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl" 2>/dev/null
+test -s ".claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
 ```
 
 If the file exists and is non-empty, parse the JSONL entries and generate a Mermaid `flowchart TD` diagram following the same rules as the `/flow` skill:


### PR DESCRIPTION
## Summary
- Apply 5 fixes from ckallum/museli#141 review comments back to source skills/hooks
- **pr-body-parser.cjs**: separator-only newline insertion before headers (round-trip safe)
- **settings.json**: scoped SessionEnd cleanup to current session, using `${CLAUDE_PROJECT_DIR:-.}`
- **flow-trace.cjs**: prefer `CLAUDE_PROJECT_DIR` env var over `process.cwd()` for correct trace path
- **ship/SKILL.md** + **flow/SKILL.md**: use `test -s` with `${CLAUDE_PROJECT_DIR:-.}` prefix for trace paths
- **receiving-pr-feedback/SKILL.md**: use `--body-file` with temp file + trap for robust cleanup

## Test plan
- [x] Verify `assemblePrBody(parsePrBody(body))` round-trips correctly with sections missing trailing newlines
- [ ] Verify SessionEnd hook only removes current session's trace file
- [ ] Verify flow-trace hook writes to correct location when `CLAUDE_PROJECT_DIR` is set

## Revision History

**Round 1** (2026-04-04):
- Accepted: 3 comments — round-trip safe assembly, CLAUDE_PROJECT_DIR in cleanup/skill paths, trap for temp file
- Pushed back: 0 comments
- Questions answered: 0 comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Make flow trace paths project-configurable via an optional project directory variable.
  * Scope session cleanup to a single session-specific trace file instead of wildcard removal.
  * Ensure flow checks verify the trace file exists and is non-empty before use.
  * Use a temporary file when updating PR descriptions to avoid inline body issues.
  * Improve PR body assembly to tolerate missing preamble/content and normalize newlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->