### PR TITLE
feat: add /simplify step to execute skill

### DIFF
--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -182,7 +182,11 @@ description: "Quality review: <task title>"
 
 **If critical issues found:** Fix them (or dispatch implementer to fix). Re-review.
 
-### 3d: Mark task complete
+### 3d: Simplify
+
+After quality review passes, run `/simplify` to clean up the changed code — reuse opportunities, clarity, consistency. This ensures the final code is polished before marking the task complete.
+
+### 3e: Mark task complete
 
 - **SPEC mode:** Update `tasks.md` — check off the completed task.
 - **ISSUE/RAW mode:** Track completion internally (no tasks.md to update).


### PR DESCRIPTION
## Summary
- Adds `/simplify` as Step 3d in the execute skill's task loop, between quality review and marking complete
- Aligns execute with `/ship` which already runs `/simplify` before review

## Test plan
- [ ] Run `/execute` on a spec — verify `/simplify` runs after quality review passes
- [ ] Confirm task completion flow still works (3a → 3b → 3c → 3d → 3e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow sequence by introducing a new simplification step following quality review. Users are now instructed to run the `/simplify` command to optimize code before marking tasks complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->