### PR TITLE
fix: update stale Projects/claude paths to Projects/calsuite

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/guardian.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/guardian.cjs\""
           }
         ],
         "description": "Guardian: evaluate tool call risk and block dangerous operations"
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/pr-intent-gate.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pr-intent-gate.cjs\""
           }
         ],
         "description": "PR Intent Gate: require ## Why section in PR body"
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/merged-branch-guard.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/merged-branch-guard.cjs\""
           }
         ],
         "description": "Merged Branch Guard: block operations on branches with merged PRs"
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/review-gate.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/review-gate.cjs\""
           }
         ],
         "description": "Review gate: require code review before commits"
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/lint-gate.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/lint-gate.cjs\""
           }
         ],
         "description": "Lint gate: check structural lint rules before commits"
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/skill-usage-tracker.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/skill-usage-tracker.cjs\""
           }
         ],
         "description": "Track skill invocations for usage analytics"
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/skills/strategic-compact/scripts/suggest-compact.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/skills/strategic-compact/scripts/suggest-compact.cjs\""
           }
         ],
         "description": "Suggest manual compaction at logical intervals"
@@ -87,7 +87,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/flow-trace.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/flow-trace.cjs\""
           }
         ],
         "description": "Trace skill and agent invocations for /flow diagrams"
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/pre-compact.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pre-compact.cjs\""
           }
         ],
         "description": "Save state before context compaction"
@@ -111,7 +111,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/session-start.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/session-start.cjs\""
           }
         ],
         "description": "Load previous context and detect package manager on new session"
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/pr-url-logger.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pr-url-logger.cjs\""
           }
         ],
         "description": "Log PR URL and provide review command after PR creation"
@@ -133,7 +133,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/ci-monitor.cjs\"",
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/ci-monitor.cjs\"",
             "async": true,
             "timeout": 30
           }
@@ -145,7 +145,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/prettier-format.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/prettier-format.cjs\""
           }
         ],
         "description": "Auto-format JS/TS files with Prettier after edits"
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/typescript-check.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/typescript-check.cjs\""
           }
         ],
         "description": "TypeScript check after editing .ts/.tsx files"
@@ -165,7 +165,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/console-log-warn.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/console-log-warn.cjs\""
           }
         ],
         "description": "Warn about console.log statements after edits"
@@ -175,7 +175,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/eslint-check.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/eslint-check.cjs\""
           }
         ],
         "description": "ESLint check: report violations after JS/TS edits for agent self-correction"
@@ -187,7 +187,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/check-console-log.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/check-console-log.cjs\""
           }
         ],
         "description": "Check for console.log in modified files after each response"
@@ -199,7 +199,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/session-end.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/session-end.cjs\""
           }
         ],
         "description": "Persist session state on end"
@@ -209,7 +209,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/claude/.claude/scripts/hooks/evaluate-session.cjs\""
+            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/evaluate-session.cjs\""
           }
         ],
         "description": "Evaluate session for extractable patterns"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/guardian.cjs\""
+            "command": "node \".claude/scripts/hooks/guardian.cjs\""
           }
         ],
         "description": "Guardian: evaluate tool call risk and block dangerous operations"
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pr-intent-gate.cjs\""
+            "command": "node \".claude/scripts/hooks/pr-intent-gate.cjs\""
           }
         ],
         "description": "PR Intent Gate: require ## Why section in PR body"
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/merged-branch-guard.cjs\""
+            "command": "node \".claude/scripts/hooks/merged-branch-guard.cjs\""
           }
         ],
         "description": "Merged Branch Guard: block operations on branches with merged PRs"
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/review-gate.cjs\""
+            "command": "node \".claude/scripts/hooks/review-gate.cjs\""
           }
         ],
         "description": "Review gate: require code review before commits"
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/lint-gate.cjs\""
+            "command": "node \".claude/scripts/hooks/lint-gate.cjs\""
           }
         ],
         "description": "Lint gate: check structural lint rules before commits"
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/skill-usage-tracker.cjs\""
+            "command": "node \".claude/scripts/hooks/skill-usage-tracker.cjs\""
           }
         ],
         "description": "Track skill invocations for usage analytics"
@@ -77,7 +77,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/skills/strategic-compact/scripts/suggest-compact.cjs\""
+            "command": "node \".claude/skills/strategic-compact/scripts/suggest-compact.cjs\""
           }
         ],
         "description": "Suggest manual compaction at logical intervals"
@@ -87,7 +87,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/flow-trace.cjs\""
+            "command": "node \".claude/scripts/hooks/flow-trace.cjs\""
           }
         ],
         "description": "Trace skill and agent invocations for /flow diagrams"
@@ -99,7 +99,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pre-compact.cjs\""
+            "command": "node \".claude/scripts/hooks/pre-compact.cjs\""
           }
         ],
         "description": "Save state before context compaction"
@@ -111,7 +111,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/session-start.cjs\""
+            "command": "node \".claude/scripts/hooks/session-start.cjs\""
           }
         ],
         "description": "Load previous context and detect package manager on new session"
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/pr-url-logger.cjs\""
+            "command": "node \".claude/scripts/hooks/pr-url-logger.cjs\""
           }
         ],
         "description": "Log PR URL and provide review command after PR creation"
@@ -133,7 +133,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/ci-monitor.cjs\"",
+            "command": "node \".claude/scripts/hooks/ci-monitor.cjs\"",
             "async": true,
             "timeout": 30
           }
@@ -145,7 +145,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/prettier-format.cjs\""
+            "command": "node \".claude/scripts/hooks/prettier-format.cjs\""
           }
         ],
         "description": "Auto-format JS/TS files with Prettier after edits"
@@ -155,7 +155,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/typescript-check.cjs\""
+            "command": "node \".claude/scripts/hooks/typescript-check.cjs\""
           }
         ],
         "description": "TypeScript check after editing .ts/.tsx files"
@@ -165,7 +165,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/console-log-warn.cjs\""
+            "command": "node \".claude/scripts/hooks/console-log-warn.cjs\""
           }
         ],
         "description": "Warn about console.log statements after edits"
@@ -175,7 +175,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/eslint-check.cjs\""
+            "command": "node \".claude/scripts/hooks/eslint-check.cjs\""
           }
         ],
         "description": "ESLint check: report violations after JS/TS edits for agent self-correction"
@@ -187,7 +187,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/check-console-log.cjs\""
+            "command": "node \".claude/scripts/hooks/check-console-log.cjs\""
           }
         ],
         "description": "Check for console.log in modified files after each response"
@@ -199,7 +199,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/session-end.cjs\""
+            "command": "node \".claude/scripts/hooks/session-end.cjs\""
           }
         ],
         "description": "Persist session state on end"
@@ -209,7 +209,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"/Users/callumke/Projects/calsuite/.claude/scripts/hooks/evaluate-session.cjs\""
+            "command": "node \".claude/scripts/hooks/evaluate-session.cjs\""
           }
         ],
         "description": "Evaluate session for extractable patterns"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ templates/   # Spec, doc, and changelog templates (never overwritten on re-insta
 - Plugins can be enabled at global (`~/.claude/settings.json`) OR project scope (`.claude/settings.json`) — check both
 - `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths
 - `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`
-- Git repo lives at `Projects/claude/`, NOT at parent `Projects/` — was migrated in this session
+- Git repo lives at `Projects/calsuite/`, NOT at parent `Projects/` — was migrated in this session
 - Profiles in `profiles.json` with an explicit `skills` array override (not merge with) the parent — when adding a new skill to `base`, also add it to `monorepo-root` and any other profile that declares its own `skills`
 - `config/global-settings.json` stores empty placeholders for API keys (e.g., `CONTEXT7_API_KEY: ""`); actual keys go in `~/.mcp.json` only — never commit real keys to the manifest
 - When writing MCP skills, verify tool names against the live server or latest README — tool names change across versions (e.g., Context7 renamed `get-library-docs` → `query-docs`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-config
+# calsuite
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 

--- a/skills/configure-claude/SKILL.md
+++ b/skills/configure-claude/SKILL.md
@@ -18,16 +18,16 @@ Install all Claude Code configs from this repository into a project's `.claude/`
 
 When this skill is invoked:
 
-1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/claude`), ask the user which project to configure. Otherwise, use the current working directory.
+1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/calsuite`), ask the user which project to configure. Otherwise, use the current working directory.
 
 2. Run the installer script:
    ```bash
-   node /Users/callumke/Projects/claude/scripts/configure-claude.js <target-directory>
+   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js <target-directory>
    ```
 
 3. Review the output and report what was installed to the user, including any global settings warnings.
 
 4. If ccstatusline config is missing or outdated, offer to install it:
    ```bash
-   node /Users/callumke/Projects/claude/scripts/configure-claude.js --install-ccstatusline
+   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js --install-ccstatusline
    ```


### PR DESCRIPTION
## Summary
- Renamed directory broke all hook paths in `.claude/settings.json` (MODULE_NOT_FOUND on every tool call)
- Updated 19 hook command paths plus stale references in `CLAUDE.md`, `README.md`, and `skills/configure-claude/SKILL.md`

## Test plan
- [ ] Hooks execute without MODULE_NOT_FOUND errors on tool calls
- [ ] `grep -r "Projects/claude" .` returns no matches (excluding .git)

🤖 Generated with [Claude Code](https://claude.com/claude-code)