### PR TITLE
feat: /learn skill, retro learning loop, slim CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this repository.
+
+Current version: **2.3**
+
+## [2.3] — 2026-04-15
+
+### Added
+- `/learn` skill — manage cross-session learnings (patterns, pitfalls, preferences). Review, search, prune, export. Stored at `.context/learnings/` per project.
+- CLAUDE.md "Routing" section — intent → file pointer table so sessions don't re-read the whole file.
+- CLAUDE.md "Codify on repeat" rule — propose a skill the second time a request shape repeats.
+- `/retro` Step 14 — reads `~/.claude/analytics/skill-usage.jsonl` and surfaces skills used heavily / abandoned / never used.
+- `/retro` Step 15 — learning loop: for each "Improve" item, propose a concrete rule update to the responsible skill file.
+
+### Changed
+- CLAUDE.md slimmed to a routing document; full changelog moved here.
+
+## [2.2]
+
+Flow trace and ship sweep-fix: `flow-trace.cjs` PreToolUse hook captures Skill/Agent invocations to per-session JSONL, `/flow` skill generates Mermaid workflow diagrams, `/ship` embeds Development Flow in PR body, `/ship` Step 8 now triages swept issues and fixes minor items inline before PR creation.
+
+## [2.1]
+
+Lint-directed agents: ESLint config auto-install, `agent-rules.json` structural lint rules, `lint-gate.js` pre-commit hook, `eslint-check.js` post-edit hook, `/lint-rule-gen` skill, Guardian architectural boundary rules (cross-layer imports, test colocation, file placement).
+
+## [2.0]
+
+Consolidated skills: `/plan` (interview + brainstorm + review), `/plan-ceo` (founder-mode plan review), `/ship` (automated test + review + PR pipeline), `/retro` (weekly engineering retrospective with trend tracking).
+
+## [1.9]
+
+Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits.
+
+## [1.8]
+
+Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions.
+
+## [1.7]
+
+Context7 MCP server and `/context7` skill for current library documentation lookup.
+
+## [1.6]
+
+`@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix.
+
+## [1.5]
+
+Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks.
+
+## [1.4]
+
+Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array.
+
+## [1.3]
+
+Added `configure-claude.js` installer script, `config/global-settings.json` manifest; skill now invokes the script directly.
+
+## [1.2]
+
+Added `configure-claude` skill: installs hooks and scripts into any project's `.claude/` directory.
+
+## [1.1]
+
+Added hooks system: hooks.json config, 6 hook scripts (session lifecycle, console.log checks, compact suggestions), lib utilities (utils, package-manager, session-aliases, session-manager).
+
+## [1.0]
+
+Initial setup: repo structure, CLAUDE.md, README.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,73 +1,69 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-## What this repo is
+**Version: 2.3** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
-Personal Claude Code configuration repository (dotfiles-style). Stores hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
+## Routing
+
+When the user's intent matches, read the pointed file *before* doing anything else:
+
+| Intent | Read |
+|---|---|
+| Modify installer / profiles | `scripts/configure-claude.js`, `config/profiles.json`, `config/global-settings.json` |
+| Add/change a hook | `hooks/hooks.json`, `scripts/hooks/<name>.cjs`, `scripts/lib/utils.cjs` |
+| Add/change a skill | `skills/<name>/SKILL.md` (skills are parameterized — document args in a `## Arguments` section) |
+| Add/change an agent | `agents/<name>.md` (YAML frontmatter) |
+| MCP server changes | `config/global-settings.json` (empty placeholder keys only) + `~/.mcp.json` (real keys, never committed) |
+| Spec/doc templates | `templates/` — never overwritten on re-install |
+
+## Codify on repeat
+
+If the user asks for the same *shape* of thing a second time, propose a skill. The third time is too late. Skill files live at `skills/<name>/SKILL.md` and are auto-registered via the installer.
+
+Record durable learnings (patterns, pitfalls, preferences) via `/learn save` — they persist across sessions in `.context/learnings/`.
 
 ## Structure
 
 ```
-hooks/       # Custom hooks (shell commands triggered by Claude Code events)
-commands/    # Custom slash commands
-scripts/     # Standalone utility scripts + configure-claude installer
-config/      # Global settings manifest + profiles.json (profile→plugin/skill/agent mappings)
+hooks/       # hooks.json (shell commands triggered by Claude Code events)
+commands/    # custom slash commands
+scripts/     # utility scripts + configure-claude installer, scripts/hooks/*.cjs
+config/      # global-settings.json (manifest), profiles.json (profile→plugin mapping)
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian, /plan, /plan-ceo, /ship, /retro)
-agents/      # Agent .md files with YAML frontmatter (@context-loader, @doc-updater, @browser, @code-reviewer)
-templates/   # Spec, doc, and changelog templates (never overwritten on re-install)
+skills/      # parameterized slash-commands (SKILL.md each)
+agents/      # agent .md files with YAML frontmatter
+templates/   # spec / doc / changelog templates
 ```
 
 ## Key file locations
 
-- `~/.claude/settings.json` — global settings; `enabledPlugins` is `{ "name@marketplace": true }`
-- `~/.claude/settings.local.json` — local settings; `enabledMcpjsonServers` is an array of names
+- `~/.claude/settings.json` — global; `enabledPlugins` is `{ "name@marketplace": true }`
+- `~/.claude/settings.local.json` — local; `enabledMcpjsonServers` is an array of names
 - `~/.claude/plugins/known_marketplaces.json` — object keyed by marketplace name (not an array)
-- `~/.config/ccstatusline/settings.json` — ccstatusline layout config
-- `~/.mcp.json` — global MCP server configs; installer auto-adds missing servers from manifest
-- `config/global-settings.json` — this repo's manifest of expected global state; `mcpServers` is an object of server configs (not a name array)
-- `config/profiles.json` — profile detection signals and profile→plugin/skill/agent mappings
+- `~/.claude/analytics/skill-usage.jsonl` — skill invocations (written by `skill-usage-tracker.cjs`, read by `/retro`)
+- `~/.config/ccstatusline/settings.json` — ccstatusline layout
+- `~/.mcp.json` — global MCP server configs (installer adds missing servers from manifest)
 
 ## Gotchas
 
-- `known_marketplaces.json` is an object keyed by name, not an array — use `Object.keys()` to get names
-- Plugins can be enabled at global (`~/.claude/settings.json`) OR project scope (`.claude/settings.json`) — check both
-- `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths
-- `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`
-- Git repo lives at `Projects/calsuite/`, NOT at parent `Projects/` — was migrated in this session
-- Profiles in `profiles.json` with an explicit `skills` array override (not merge with) the parent — when adding a new skill to `base`, also add it to `monorepo-root` and any other profile that declares its own `skills`
-- `config/global-settings.json` stores empty placeholders for API keys (e.g., `CONTEXT7_API_KEY: ""`); actual keys go in `~/.mcp.json` only — never commit real keys to the manifest
-- When writing MCP skills, verify tool names against the live server or latest README — tool names change across versions (e.g., Context7 renamed `get-library-docs` → `query-docs`)
-- Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"` — `"url"` fails schema validation
-- Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]` in commit message, `docs:`/`chore:`/`style:` prefix, or md-only changes
+- `known_marketplaces.json` is an object keyed by name — use `Object.keys()`.
+- Plugins can be enabled at global OR project scope — check both.
+- `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths.
+- `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`.
+- Git repo lives at `Projects/calsuite/`, NOT parent `Projects/`.
+- Profiles with an explicit `skills` array **override** (not merge with) parent — when adding a skill to `base`, also add to `monorepo-root` and any other profile declaring its own `skills`.
+- `global-settings.json` stores empty placeholders for API keys; real keys go in `~/.mcp.json` only.
+- MCP tool names change across versions (e.g. Context7 `get-library-docs` → `query-docs`) — verify against the live server.
+- Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"`.
+- Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]`, `docs:`/`chore:`/`style:` prefix, or md-only changes.
 
 ## Testing configure-claude.js
 
-- `node scripts/configure-claude.js /tmp/test-project` — full integration test against temp dir
+- `node scripts/configure-claude.js /tmp/test-project` — full integration test
 - `--install-ccstatusline` flag for standalone ccstatusline install
 - Always `rm -rf /tmp/test-project` after testing
 
 ## Versioning
 
-Current version: **2.2**
-
-When making changes to this repo:
-1. Bump the version in both CLAUDE.md and README.md
-2. Add a line item to the changelog below
-
-## Changelog
-
-- **2.2** — Flow trace and ship sweep-fix: `flow-trace.cjs` PreToolUse hook captures Skill/Agent invocations to per-session JSONL, `/flow` skill generates Mermaid workflow diagrams, `/ship` embeds Development Flow in PR body, `/ship` Step 8 now triages swept issues and fixes minor items inline before PR creation
-- **2.1** — Lint-directed agents: ESLint config auto-install, `agent-rules.json` structural lint rules, `lint-gate.js` pre-commit hook, `eslint-check.js` post-edit hook, `/lint-rule-gen` skill, Guardian architectural boundary rules (cross-layer imports, test colocation, file placement)
-- **2.0** — Consolidated skills: `/plan` (interview + brainstorm + review), `/plan-ceo` (founder-mode plan review), `/ship` (automated test + review + PR pipeline), `/retro` (weekly engineering retrospective with trend tracking)
-- **1.9** — Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits
-- **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
-- **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
-- **1.6** — `@browser` agent (agent-browser CLI), Excalidraw MCP integration for `@doc-updater` diagrams, MCP auto-installation in configure script, monorepo workspace plugin check fix
-- **1.5** — Mono-repo support + spec-driven development: profile-based installer (`config/profiles.json`), spec/doc templates, `@context-loader` and `@doc-updater` agents, `/update-docs` skill, spec-aware session hooks
-- **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
-- **1.3** — Added `configure-claude.js` installer script, `config/global-settings.json` manifest; skill now invokes the script directly
-- **1.2** — Added `configure-claude` skill: installs hooks and scripts into any project's `.claude/` directory
-- **1.1** — Added hooks system: hooks.json config, 6 hook scripts (session lifecycle, console.log checks, compact suggestions), lib utilities (utils, package-manager, session-aliases, session-manager)
-- **1.0** — Initial setup: repo structure, CLAUDE.md, README.md
+When making changes: bump version in `CLAUDE.md` + `README.md` + top of `CHANGELOG.md`, and add an entry to `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.2**
+**Version: 2.3**
 
 ## Getting started
 
@@ -60,14 +60,4 @@ Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.js
 
 ## Changelog
 
-- **2.1** — Lint-directed agents: ESLint config auto-install, `agent-rules.json` structural lint rules, `lint-gate.js` pre-commit hook, `eslint-check.js` post-edit hook, `/lint-rule-gen` skill, Guardian architectural boundary rules
-- **1.9** — Pre-commit review gate: `review-gate.js` hook + `@code-reviewer` agent for convention-aware code reviews before commits
-- **1.8** — Guardian autonomous approval system: smart PreToolUse hook with configurable deny/warn rules, audit logging, and mode-based permissions
-- **1.7** — Context7 MCP server and `/context7` skill for current library documentation lookup
-- **1.6** — `@browser` agent, Excalidraw MCP integration for `@doc-updater`, MCP auto-installation, monorepo workspace plugin check fix
-- **1.5** — Mono-repo support + spec-driven development: profile-based installer, agents, templates, spec-aware hooks
-- **1.4** — Added marketplace checks to `configure-claude.js`; manifest now includes `marketplaces` array
-- **1.3** — Added `configure-claude.js` installer script + `config/global-settings.json` manifest
-- **1.2** — Added `configure-claude` skill for installing configs into projects
-- **1.1** — Added hooks system: hooks.json config, hook scripts, lib utilities
-- **1.0** — Initial setup: repo structure, CLAUDE.md, README.md
+See [CHANGELOG.md](./CHANGELOG.md).

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow"],
+      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow"],
+      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: learn
+version: 1.0.0
+description: |
+  save learning, remember this, note this pattern, record pitfall, capture preference,
+  learn from this, review learnings, what have I learned, search learnings, prune learnings.
+  Manage durable, project-specific learnings across sessions — patterns, pitfalls,
+  preferences. Learnings compound across sessions so Claude gets smarter on your
+  codebase over time.
+argument-hint: [save | list | search <query> | prune | export]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+---
+
+# /learn — Cross-Session Learnings
+
+Durable memory for *this project*. Unlike `memory/` (which is about the user), `.context/learnings/` is about the *codebase* — patterns that worked, pitfalls encountered, preferences confirmed. Claude reads these at session start (via `/session-start`) and appends to them whenever something non-obvious surfaces.
+
+## Storage
+
+Per-project: `.context/learnings/` (in the current repo, gitignored or committed — user choice).
+
+Each learning is one file: `.context/learnings/<kebab-slug>.md`
+
+```markdown
+---
+id: <kebab-slug>
+type: pattern | pitfall | preference
+tags: [tag1, tag2]
+created: 2026-04-15
+last_seen: 2026-04-15
+hits: 1
+---
+
+# <Title>
+
+**Context:** when this applies.
+**Rule:** what to do / avoid.
+**Why:** evidence — incident, PR link, commit SHA, conversation quote.
+```
+
+An index file `.context/learnings/INDEX.md` lists all learnings, one line each: `- [title](slug.md) — type — one-line hook`. Keep under 200 lines; older items get pruned.
+
+## Arguments
+
+- `/learn save` — capture a learning from the current conversation (default when argument looks like a statement)
+- `/learn list` — show the index, grouped by type
+- `/learn search <query>` — grep across learnings
+- `/learn prune` — find stale learnings (no `last_seen` hit in 90+ days, or contradicted by current code)
+- `/learn export` — concat all learnings to stdout for piping
+
+If no argument is given, default to `save` using the most recent non-obvious fact from the conversation.
+
+---
+
+## save mode
+
+**Goal:** capture one durable fact that will be useful in *future* sessions.
+
+### Step 1: Identify the learning
+
+Scan the current conversation for the most recent exchange where:
+- The user corrected a mistaken assumption, OR
+- A non-obvious fact about this codebase surfaced (invariant, constraint, historical decision), OR
+- The user confirmed a non-default approach ("yes, exactly that")
+
+If nothing qualifies, say "Nothing worth saving surfaced. Skipping." and stop.
+
+### Step 2: Classify
+
+- **pattern** — a positive rule ("always do X in situation Y")
+- **pitfall** — a negative rule ("don't do X — it breaks Y")
+- **preference** — a project-specific taste call confirmed by the user
+
+### Step 3: Check for duplicates
+
+```bash
+ls .context/learnings/*.md 2>/dev/null
+```
+
+Grep titles and tags for overlap. If a similar learning exists, **update it** (bump `hits`, update `last_seen`, append context) rather than creating a new one.
+
+### Step 4: Write the file
+
+Pick a kebab-slug from the title. Write with the frontmatter template above. Keep the body under 12 lines — learnings are reference cards, not essays.
+
+### Step 5: Update the index
+
+Append one line to `.context/learnings/INDEX.md`:
+```
+- [title](slug.md) — pitfall — one-line hook
+```
+
+If INDEX.md doesn't exist, create it with a header:
+```markdown
+# Project Learnings
+
+Cross-session durable facts about this codebase. Read at session start.
+
+```
+
+### Step 6: Confirm
+
+Output a 2-line confirmation: what was saved + file path.
+
+---
+
+## list mode
+
+Read `.context/learnings/INDEX.md`. Print grouped by type (patterns, pitfalls, preferences). If empty, print "No learnings recorded yet. Use `/learn save` after a non-obvious fact surfaces."
+
+## search mode
+
+`grep -l -i "<query>"` across `.context/learnings/*.md`. For each match, print the title and the first matching line with context.
+
+## prune mode
+
+For each learning file:
+1. Check `last_seen` — if older than 90 days, flag as stale.
+2. For learnings referencing specific files/functions/flags, verify they still exist (`grep` / `ls`). If not, flag as potentially obsolete.
+3. Ask the user (with AskUserQuestion) which flagged items to delete, keep, or refresh.
+
+Update INDEX.md after deletions.
+
+## export mode
+
+`cat .context/learnings/*.md` to stdout. Useful for piping into another tool or a prompt.
+
+---
+
+## When Claude should auto-invoke this
+
+You (Claude) should suggest `/learn save` — not run it silently — whenever:
+- The user corrects you on a project-specific fact you'd want to remember next session
+- A non-obvious constraint surfaces that isn't already in CLAUDE.md or a learning
+- The user confirms a non-default approach with language like "yes exactly that", "keep doing that"
+
+Ask: *"That's worth saving as a learning — run `/learn save`?"* Don't save without confirmation; learnings have lasting weight.
+
+## Gotchas
+
+- **Learnings are per-repo, not global.** User-level preferences go in memory (`memory/`), not here.
+- **INDEX.md is the fast-path.** Keep it tight; full bodies live in the per-learning files.
+- **Don't duplicate CLAUDE.md content.** If a rule belongs in CLAUDE.md, put it there instead — CLAUDE.md is always loaded.
+- **Evidence matters.** A learning without a `Why:` line is noise. Always anchor to a PR, commit, incident, or user quote.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -272,7 +272,39 @@ Save JSON snapshot with this schema:
 }
 ```
 
-### Step 13: Write the Narrative
+### Step 13: Skill Usage Telemetry
+
+Read `~/.claude/analytics/skill-usage.jsonl` (written by `skill-usage-tracker.cjs`). Filter entries by timestamp within the retro window. Skip this step silently if the file doesn't exist.
+
+Compute:
+- **Top skills by invocation count** (top 5)
+- **Skills invoked but session was abandoned mid-flow** — heuristic: a skill invocation followed by no commits in the next 2 hours on the same session
+- **Skills declared in profile but never invoked in window** — cross-reference against `config/profiles.json` for the current profile
+- **Heavy-use candidates for cron/scheduling** — any skill invoked 5+ times in the window
+
+Output a short section:
+```
+### Skill Usage
+Top 5: /ship (12), /review (8), /debug (5), /plan (4), /context7 (3)
+Heavy use → consider automating: /babysit-pr (7× — run via /loop?)
+Never used in window: /plan-ceo, /retro — keep or drop from profile?
+```
+
+### Step 14: Learning Loop
+
+For each item in **3 Things to Improve** (Step 13's narrative), propose one concrete rule update to the most likely-responsible skill file. Format:
+
+```
+### Proposed Skill Updates
+- Improve: "XL PRs slipped through unsplit"
+  → Edit skills/ship/SKILL.md Step 6: add hard rule — abort if diff > 1500 LOC without explicit override.
+- Improve: "Fix-ratio 60% on auth module"
+  → Edit skills/review/SKILL.md: add auth-module checklist (regression tests required).
+```
+
+Do **not** apply the edits automatically. Print the proposals and ask (AskUserQuestion) whether to apply each one. Learning loop is opt-in — this is where the skills self-improve from lived evidence.
+
+### Step 15: Write the Narrative
 
 **Tweetable summary** (first line):
 ```
@@ -320,6 +352,12 @@ Small, practical, realistic. Each takes <5 minutes to adopt.
 
 ### Week-over-Week Trends
 (if applicable, from Step 9)
+
+### Skill Usage
+(from Step 13)
+
+### Proposed Skill Updates
+(from Step 14 — opt-in)
 
 ---
 


### PR DESCRIPTION
## Summary
- Slim CLAUDE.md to a routing table (intent → file); full history moved to CHANGELOG.md
- Add \"codify on repeat\" rule — propose a skill the second time a request shape repeats
- New /learn skill for cross-session project learnings (patterns/pitfalls/preferences) stored in .context/learnings/
- /retro now reads ~/.claude/analytics/skill-usage.jsonl to surface top/abandoned/unused/heavy-use skills (Step 13)
- /retro proposes concrete skill file edits for each \"Improve\" item, opt-in via AskUserQuestion (Step 14) — closes the learning loop
- Version bump to 2.3

## Test plan
- [ ] /learn save — captures a learning into .context/learnings/ with frontmatter + INDEX entry
- [ ] /learn list — prints grouped by type
- [ ] /learn search <query> — greps across files
- [ ] /retro — new Skill Usage + Proposed Skill Updates sections render
- [ ] configure-claude installer picks up /learn in base + monorepo-root profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)