### PR TITLE
fix(installer): stop copying skills and agents per-target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ Current version: **2.5**
 ## [2.5] — 2026-04-18
 
 ### Changed
-- Skills are no longer copied into each target's `.claude/skills/` — targets now rely solely on the symlinks at `~/Projects/.claude/skills/` created by `syncParentAssets()`. Previously, `installForProfile()` ran `copyDirSync` on every `--sync`, which unconditionally overwrote any local edits downstream made to their skill files. The per-target copy provided no real isolation (profiles barely differed) and was a silent-data-loss footgun.
-- `--only <skill>` remains the escape hatch for a one-off per-target skill install when a project genuinely needs a local copy.
+- Skills and agents are no longer copied into each target's `.claude/` — targets now rely solely on the symlinks at `~/Projects/.claude/skills/` and `~/Projects/.claude/agents/` created by `syncParentAssets()`. Previously, `installForProfile()` ran `copyDirSync`/`copyFileSync` on every `--sync`, which unconditionally overwrote any local edits downstream made to these files. The per-target copy provided no real isolation (skills profiles barely differed; agent profile filtering is not load-bearing since agents only activate when invoked) and was a silent-data-loss footgun.
+- `--only <skill>` / `--only-agents <name>` remain the escape hatches for one-off per-target installs when a project genuinely needs a local copy.
 
 ## [2.4] — 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this repository.
 
-Current version: **2.4**
+Current version: **2.5**
+
+## [2.5] — 2026-04-18
+
+### Changed
+- Skills are no longer copied into each target's `.claude/skills/` — targets now rely solely on the symlinks at `~/Projects/.claude/skills/` created by `syncParentAssets()`. Previously, `installForProfile()` ran `copyDirSync` on every `--sync`, which unconditionally overwrote any local edits downstream made to their skill files. The per-target copy provided no real isolation (profiles barely differed) and was a silent-data-loss footgun.
+- `--only <skill>` remains the escape hatch for a one-off per-target skill install when a project genuinely needs a local copy.
 
 ## [2.4] — 2026-04-16
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ templates/   # spec / doc / changelog templates
 - Hook entries in `hooks.json` MUST have `"_origin": "calsuite"` — the installer uses this to merge without overwriting project-specific hooks.
 - Hook scripts are symlinked (not copied) — editing them in calsuite edits them everywhere. Use `--copy` flag for portability.
 - `symlinkDirSync` skips non-symlink files in dest — project-specific hook scripts are preserved.
-- Skills are **not** copied into each target's `.claude/skills/` — they inherit from `~/Projects/.claude/skills/` (parent-level symlinks). Prevents `copyDirSync` from clobbering local downstream edits on every `--sync`. Use `--only <skill>` for a one-off per-target install.
+- Skills and agents are **not** copied into each target's `.claude/` — they inherit from `~/Projects/.claude/skills/` and `~/Projects/.claude/agents/` (parent-level symlinks). Prevents `copyDirSync` from clobbering local downstream edits on every `--sync`. Use `--only <skill>` / `--only-agents <name>` for a one-off per-target install.
 - Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"`.
 - Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]`, `docs:`/`chore:`/`style:` prefix, or md-only changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.4** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.5** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 
@@ -62,6 +62,7 @@ templates/   # spec / doc / changelog templates
 - Hook entries in `hooks.json` MUST have `"_origin": "calsuite"` — the installer uses this to merge without overwriting project-specific hooks.
 - Hook scripts are symlinked (not copied) — editing them in calsuite edits them everywhere. Use `--copy` flag for portability.
 - `symlinkDirSync` skips non-symlink files in dest — project-specific hook scripts are preserved.
+- Skills are **not** copied into each target's `.claude/skills/` — they inherit from `~/Projects/.claude/skills/` (parent-level symlinks). Prevents `copyDirSync` from clobbering local downstream edits on every `--sync`. Use `--only <skill>` for a one-off per-target install.
 - Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"`.
 - Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]`, `docs:`/`chore:`/`style:` prefix, or md-only changes.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,55 @@ agents/      # Agent definitions (@context-loader, @doc-updater, @browser, @code
 templates/   # Spec, doc, and changelog templates
 ```
 
+## Distribution model
+
+Calsuite is the single source of truth. Assets flow out to three tiers — each with a mechanism tuned to how the asset is meant to be edited downstream.
+
+```mermaid
+flowchart LR
+    subgraph SRC["calsuite/ (source of truth)"]
+        direction TB
+        C1["scripts/hooks/*<br/>scripts/lib/*"]
+        C2["skills/*<br/>agents/*"]
+        C3["hooks/hooks.json"]
+        C4["config/*.json<br/>config/lint-configs/*<br/>templates/specs/"]
+        C5["config/global-settings.json"]
+    end
+
+    subgraph SHARED["~/Projects/.claude/ (user-wide)"]
+        P1["skills/<br/>agents/"]
+    end
+
+    subgraph TGT["~/Projects/&lt;repo&gt;/.claude/ (per target)"]
+        T1["scripts/hooks/<br/>scripts/lib/"]
+        T2["settings.json"]
+        T3["config/, specs/<br/>root: .eslintrc.json"]
+    end
+
+    subgraph GBL["~/.claude/ (per user)"]
+        G1["settings.json<br/>~/.mcp.json"]
+    end
+
+    C1 ==>|symlink| T1
+    C2 ==>|symlink| P1
+    C3 ==>|merge by _origin| T2
+    C4 ==>|copy, no-overwrite| T3
+    C5 ==>|merge| G1
+
+    P1 -.->|Claude Code config hierarchy<br/>parent dir → child repo| TGT
+```
+
+| Asset | Mechanism | Landing zone | Local override |
+|---|---|---|---|
+| Skills, agents | Symlink once into parent | `~/Projects/.claude/skills/`, `agents/` | `--only <skill>` / `--only-agents <name>` writes a per-target copy |
+| Hook scripts, lib scripts | Symlink into each target | `.claude/scripts/` per target | `--copy` flag forces real copies |
+| Hook config | Merge by `_origin: calsuite` tag | `.claude/settings.json` per target | Project hook entries without `_origin` are preserved |
+| Configs, templates, lint, MCP | Copy (no-overwrite) / merge | `.claude/config/`, `.eslintrc.json`, `.claude/specs/`, `~/.claude/settings.json`, `~/.mcp.json` | Existing files are never touched |
+
+**Why three tiers?** Skills and agents live once at the parent `~/Projects/.claude/` and every repo under it inherits them via Claude Code's config hierarchy — so editing a skill in calsuite propagates instantly, and no per-target copy can be accidentally clobbered on re-sync. Hook scripts need a path-stable `.claude/scripts/` inside each project, so they're symlinked per-target (still live, just scoped). Configs and templates are copied because projects are expected to diverge (e.g. a project's own ESLint overrides). `hooks.json` is a merge file, so entries are tagged `_origin: calsuite` to let `mergeHooks()` replace upstream entries while preserving project-local ones.
+
+**Propagation.** The repo's `.git/hooks/post-commit` auto-runs `configure-claude.js --sync` whenever a commit touches `hooks/`, `skills/`, `agents/`, `scripts/`, or `config/`, so targets listed in `config/targets.json` pick up changes without manual intervention.
+
 ## Mono-repo Support
 
 The installer auto-detects project type via `config/profiles.json`:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.4**
+**Version: 2.5**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -351,20 +351,11 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   //    a one-off per-target install.
   console.log(`  ✓ Skills inherited from parent .claude/ (not copied per-target)`);
 
-  // 4. Copy agents (only those in resolved profile)
-  if (resolvedProfile.agents.length > 0) {
-    const destAgents = path.join(claudeDir, 'agents');
-    fs.mkdirSync(destAgents, { recursive: true });
-    let agentCount = 0;
-    for (const agentName of resolvedProfile.agents) {
-      const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
-      if (fs.existsSync(srcAgent)) {
-        fs.copyFileSync(srcAgent, path.join(destAgents, `${agentName}.md`));
-        agentCount++;
-      }
-    }
-    console.log(`  ✓ Copied ${agentCount} agent(s) → ${destAgents}`);
-  }
+  // 4. Agents are inherited from ~/Projects/.claude/agents/ (symlinked by syncParentAssets).
+  //    Per-target copies are intentionally not written — same reasoning as skills above.
+  //    Profile filtering is not load-bearing: agents only activate when invoked, so extras
+  //    are invisible. Use `--only-agents <name>` for a one-off per-target install.
+  console.log(`  ✓ Agents inherited from parent .claude/ (not copied per-target)`);
 
   // 5. Copy templates (never overwrite existing)
   if (resolvedProfile.templates.includes('specs')) {

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -345,18 +345,11 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
     console.log(`  ✓ ESLint config already exists (skipped)`);
   }
 
-  // 3. Copy skills (only those in resolved profile)
-  const destSkills = path.join(claudeDir, 'skills');
-  let skillCount = 0;
-  for (const skillName of resolvedProfile.skills) {
-    if (INTERNAL_SKILLS.has(skillName)) continue;
-    const srcSkill = path.join(SKILLS_DIR, skillName);
-    if (fs.existsSync(srcSkill) && fs.statSync(srcSkill).isDirectory()) {
-      copyDirSync(srcSkill, path.join(destSkills, skillName));
-      skillCount++;
-    }
-  }
-  console.log(`  ✓ Copied ${skillCount} skill(s) → ${destSkills}`);
+  // 3. Skills are inherited from ~/Projects/.claude/skills/ (symlinked by syncParentAssets).
+  //    Per-target copies are intentionally not written — they would clobber local edits
+  //    on every --sync (copyDirSync is unconditional-overwrite). Use `--only <skill>` for
+  //    a one-off per-target install.
+  console.log(`  ✓ Skills inherited from parent .claude/ (not copied per-target)`);
 
   // 4. Copy agents (only those in resolved profile)
   if (resolvedProfile.agents.length > 0) {


### PR DESCRIPTION
## Summary
- Removes the per-target `copyDirSync(skills)` and `copyFileSync(agents)` calls in `installForProfile()`. Targets now rely solely on `~/Projects/.claude/skills/` and `~/Projects/.claude/agents/` symlinks created by `syncParentAssets()`.
- Fixes silent-data-loss footgun: every `--sync` was unconditionally overwriting local downstream edits to skill and agent files.
- `--only <skill>` / `--only-agents <name>` remain for explicit one-off per-target installs.

## Why

Assets flowed through two layers:
1. Parent symlinks at `~/Projects/.claude/skills/` and `~/Projects/.claude/agents/` → calsuite's source (shared across all repos via hierarchical config).
2. Per-target copies at each repo's `.claude/skills/` and `.claude/agents/` (written by `installForProfile()`).

The post-commit hook fires `--sync` on any calsuite commit touching `skills/`, `agents/`, etc. Each sync re-ran `copyDirSync` / `copyFileSync`, which do a blind overwrite — no merge, no "is dest newer" check, no `_origin` protocol like `hooks.json` has. Local edits downstream were silently clobbered on every commit.

**Why inheritance-only works for both:**
- **Skills**: profile filtering was near-nominal (`base` and `monorepo-root` had nearly identical skill lists), and parent symlinks already expose every non-internal skill everywhere.
- **Agents**: profile filtering does curate (frontend gets `browser`, monorepo gets `context-loader`+`doc-updater`), but that filtering is not load-bearing. Agents only activate when invoked by a skill or `@mention`, so "seeing" an extra agent in a project that doesn't need it costs nothing — the only real failure mode is the opposite (needing an agent profile filtering hid from you).

The `_origin` merge protocol used by `hooks.json` doesn't apply here because hooks.json is a single merge file where calsuite and project entries coexist. Skill and agent files are one-per-file, so project-local additions are already safe — the only issue was `copyDirSync` overwriting calsuite-origin files a user had edited.

## How It Works

```mermaid
flowchart TD
    Source[calsuite/skills + calsuite/agents] -->|symlink once via syncParentAssets| Parent[~/Projects/.claude/skills + agents]
    Parent -->|Claude Code config hierarchy| TargetA[~/Projects/verity]
    Parent -->|Claude Code config hierarchy| TargetB[~/Projects/timeline]
    OnlyFlags[--only / --only-agents] -.->|explicit one-off| LocalCopy[target/.claude/skills or agents]
```

## Important Files
| File | Change |
|------|--------|
| `scripts/configure-claude.js` | Removed skill-copy and agent-copy blocks in `installForProfile()`; replaced with log lines documenting the inheritance model |
| `CLAUDE.md` | Added gotcha covering both skills and agents |
| `CHANGELOG.md`, `README.md`, `CLAUDE.md` | Version bump 2.4 → 2.5 |

## Test Results
| Suite | Result |
|-------|--------|
| Integration: fresh install into `/tmp/test-project` | ✅ neither `.claude/skills/` nor `.claude/agents/` created |
| Smoke: parent symlinks still resolve | ✅ `~/Projects/.claude/skills/ship` and `~/Projects/.claude/agents/code-reviewer.md` intact |
| Post-commit sync on this branch | ✅ ran; target skill/agent dirs left untouched (mtimes unchanged) |

## Pre-Landing Review
No issues found. Note: existing stale copies in each target's `.claude/skills/` and `.claude/agents/` are not auto-deleted — they remain as orphaned files until a target owner removes them. Intentional to avoid aggressive cleanup; a follow-up `--prune-stale` flag could add opt-in cleanup.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md gotcha added + version bumped

## Coordination note
[PR #38](https://github.com/ckallum/calsuite/pull/38) (upstream skill improvements) is rebased onto this branch and bumps to 2.6. Merge this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)