### PR TITLE
refactor(installer): personal-harness distribution — hooks to settings.local.json, _origin protocol for skills/agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Expected first-sync output for a target with local edits:
 - `syncParentAssets()` and `PARENT_CLAUDE_DIR` — they created symlinks at `~/Projects/.claude/` under the assumption that Claude Code inherits skills from parent-directory `.claude/` dirs. Per the [official docs](https://code.claude.com/docs/en/skills), only enterprise/personal/project/plugin levels are discovered — parent-dir inheritance is not a supported feature.
 - `resolveHookPaths()` — pre-resolving `${CLAUDE_CONFIG_DIR}` into an absolute path inside `settings.json` was exactly the bug that broke collaborators' checkouts.
 - `symlinkDirSync` and `symlinkOrSkip` helpers — no longer referenced (scripts no longer symlinked into targets).
-- `--copy` flag kept parseable but documented as a deprecated no-op (its only effect was toggling script symlink-vs-copy, and scripts are no longer copied into targets at all).
+- `--copy` flag — removed entirely. Its only effect was toggling script symlink-vs-copy, and scripts are no longer copied into targets at all. Now errors with "Unknown flag" instead of silently no-opping.
 
 ## [2.5] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ Expected first-sync output for a target with local edits:
 - `hooks/hooks.json` placeholder renamed from `${CLAUDE_CONFIG_DIR}` to `${CALSUITE_DIR}` to match the actual semantic (18 occurrences).
 - `settings.json` now only carries `enabledPlugins` and `permissions` — both portable across machines.
 
+### Fixed
+
+- `--only <skill>` mode (`installOnly`) now routes through the `_origin` safe-overwrite protocol. Previously it used `copyDirSync` / `copyFileSync` directly, bypassing the whole point of the refactor — an explicit `--only review` would silently clobber local edits.
+- `currentCalsuiteSha` throws on git failure instead of returning the sentinel string `'unknown'`. The old fallback would have stamped every file with `_origin: calsuite@unknown`, permanently breaking future `contentAtSha` lookups.
+- `contentAtSha` distinguishes benign "path not in git at that sha" from infra failures (git not installed, shallow-clone pruning, corrupt repo). Only the former returns null; anything else throws with a clear message.
+- `readJsonSync` throws on `SyntaxError` (malformed JSON) instead of silently returning null. The `|| {}` idiom at callsites would otherwise rebuild broken `settings.json` from scratch, wiping user hooks/plugins/permissions silently. ENOENT still returns null (benign).
+- `--force-adopt` prompts for confirmation before overwriting; `--yes` / `-y` flag skips the prompt for non-interactive use. Aligns with the design spec's explicit "one-line confirmation prompt; `--yes` to skip" requirement.
+- `stampOrigin` uses a function replacer instead of a string replacement — defends against `$` sequences in `originValue` (e.g. target basenames in unusual directories).
+- `skip-exists` counter separated from `skip-claimed` so log lines don't mislabel non-markdown-file no-overwrites as "user-claimed".
+- `guardian-rules.json` and `agent-rules.json` are now copy-no-overwrite (per design spec S4 row). Previously they were unconditionally overwritten on every install, clobbering any local tuning.
+- Top-level `try/catch` in `main()` prints clean error messages for thrown exceptions (no Node stack traces for user-facing failures).
+
 ### Removed
 
 - `syncParentAssets()` and `PARENT_CLAUDE_DIR` — they created symlinks at `~/Projects/.claude/` under the assumption that Claude Code inherits skills from parent-directory `.claude/` dirs. Per the [official docs](https://code.claude.com/docs/en/skills), only enterprise/personal/project/plugin levels are discovered — parent-dir inheritance is not a supported feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,79 @@
 
 All notable changes to this repository.
 
-Current version: **2.5**
+Current version: **2.6**
+
+## [2.6] — 2026-04-19
+
+### Breaking / migration notes
+
+Calsuite no longer writes per-machine paths into a target's committed
+`.claude/settings.json`, and no longer clobbers local skill/agent edits on
+re-sync. See [specs/personal-harness-refactor/design.md](./specs/personal-harness-refactor/design.md) for the full rationale.
+
+**First `--sync` after upgrading will behave differently:**
+
+- Calsuite hook wiring (previously merged into `.claude/settings.json`) now
+  lives in `.claude/settings.local.json` (gitignored). Any legacy
+  `_origin=calsuite` hook entries already in `settings.json` are stripped
+  on first sync. Project-specific hook entries (no `_origin` tag) are
+  preserved.
+- `.claude/scripts/hooks/` and `.claude/scripts/lib/` that previously held
+  symlinks into calsuite are auto-removed if every entry is still a
+  calsuite-pointing symlink. User-added scripts or foreign symlinks
+  short-circuit the cleanup.
+- `.gitignore` gets a `.claude/settings.local.json` line added (root and
+  every detected monorepo workspace) if not already present.
+- Every distributed skill/agent `.md` file gets an `_origin: calsuite@<sha>`
+  frontmatter marker. Existing pristine copies (byte-identical to calsuite's
+  current version) auto-migrate silently. Locally-edited copies are skipped
+  and flagged — resolve with `--force-adopt <path>` (take calsuite's),
+  `--claim <path>` (keep local, mark user-owned), or wait for
+  `--reconcile <path>` ([issue #42](https://github.com/ckallum/calsuite/issues/42)).
+
+Expected first-sync output for a target with local edits:
+
+```
+  ✓ Removed stale pre-refactor scripts/hooks, scripts/lib dir(s)
+  ✓ Added .claude/settings.local.json to .gitignore
+  ✓ Skills: 24 written, 2 skipped
+  ✓ Wrote 19 calsuite hook(s) to settings.local.json (preserved 3 project hook(s))
+  ✓ Removed 19 legacy calsuite hook(s) from settings.json
+
+  ─────────────────────────────────────────────────
+  2 file(s) skipped pending reconciliation:
+    • <target>/.claude/skills/ship/SKILL.md
+      skip-diverged: user-modified since a49a827
+    ...
+  Resolve with: --force-adopt / --claim / --reconcile
+  ─────────────────────────────────────────────────
+```
+
+### Added
+
+- `scripts/lib/origin-protocol.cjs` — safe-overwrite utilities: `parseFrontmatter`, `readOrigin`, `stampOrigin`, `normalizeForCompare`, `contentAtSha` (via `git show`), `currentCalsuiteSha`, `decideFileAction` (the full matrix from the design doc).
+- `--force-adopt <path>` flag — overwrite a target skill/agent file with calsuite's current version, stamping fresh `_origin`.
+- `--claim <path>` flag — mark a target skill/agent file as user-owned (`_origin: <target-name>`), preserved across future syncs.
+- End-of-sync divergence summary — lists every `skip-diverged` and `skip-unknown` file plus the three resolution commands.
+- `resolveCalsuiteDir()` — `$CALSUITE_DIR` env var → `~/Projects/calsuite` → installer-relative fallback.
+- `substituteCalsuiteDir()` — pre-resolves the `${CALSUITE_DIR}` placeholder in `hooks/hooks.json` to a literal absolute path before writing.
+- Auto `.gitignore` management — adds `.claude/settings.local.json` to target root and each detected monorepo workspace.
+- Auto-cleanup of pre-refactor `.claude/scripts/{hooks,lib}/` dirs when every entry is still a calsuite-pointing symlink.
+- Design spec at `specs/personal-harness-refactor/design.md` documenting the whole model, decisions, and risk matrix.
+
+### Changed
+
+- Hook wiring migrated from `.claude/settings.json` (team-shared, committed) to `.claude/settings.local.json` (per-user, gitignored). Calsuite writes literal absolute `$CALSUITE_DIR/...` paths there; the Claude Code hook runner doesn't shell-expand command strings, so paths have to be pre-resolved but not committed.
+- Skill/agent distribution moved from unconditional `copyDirSync` / `copyFileSync` to the `_origin` safe-overwrite protocol (see origin-protocol module).
+- `hooks/hooks.json` placeholder renamed from `${CLAUDE_CONFIG_DIR}` to `${CALSUITE_DIR}` to match the actual semantic (18 occurrences).
+- `settings.json` now only carries `enabledPlugins` and `permissions` — both portable across machines.
+
+### Removed
+
+- `syncParentAssets()` and `PARENT_CLAUDE_DIR` — they created symlinks at `~/Projects/.claude/` under the assumption that Claude Code inherits skills from parent-directory `.claude/` dirs. Per the [official docs](https://code.claude.com/docs/en/skills), only enterprise/personal/project/plugin levels are discovered — parent-dir inheritance is not a supported feature.
+- `resolveHookPaths()` — pre-resolving `${CLAUDE_CONFIG_DIR}` into an absolute path inside `settings.json` was exactly the bug that broke collaborators' checkouts.
+- `symlinkDirSync` and `symlinkOrSkip` helpers — no longer referenced (scripts no longer symlinked into targets).
+- `--copy` flag kept parseable but documented as a deprecated no-op (its only effect was toggling script symlink-vs-copy, and scripts are no longer copied into targets at all).
 
 ## [2.5] — 2026-04-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.5** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.6** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 
@@ -38,32 +38,49 @@ templates/   # spec / doc / changelog templates
 
 ## Key file locations
 
-- `~/.claude/settings.json` — global; `enabledPlugins` is `{ "name@marketplace": true }`
-- `~/.claude/settings.local.json` — local; `enabledMcpjsonServers` is an array of names
+- `~/.claude/settings.json` — user-global; `enabledPlugins` is `{ "name@marketplace": true }`
+- `~/.claude/settings.local.json` — user-local; `enabledMcpjsonServers` is an array of names
 - `~/.claude/plugins/known_marketplaces.json` — object keyed by marketplace name (not an array)
 - `~/.claude/analytics/skill-usage.jsonl` — skill invocations (written by `skill-usage-tracker.cjs`, read by `/retro`)
 - `~/.config/ccstatusline/settings.json` — ccstatusline layout
-- `~/.mcp.json` — global MCP server configs (installer adds missing servers from manifest)
-- `~/Projects/.claude/skills/` — shared skills (symlinked from calsuite, inherited by all repos)
-- `~/Projects/.claude/agents/` — shared agents (symlinked from calsuite, inherited by all repos)
+- `~/.mcp.json` — user-global MCP server configs (installer adds missing servers from manifest)
+- `<target>/.claude/settings.json` — **team-shared** (committed). Installer writes `enabledPlugins` and `permissions` here. Never hooks, never paths.
+- `<target>/.claude/settings.local.json` — **per-user** (gitignored by the installer). Installer writes calsuite hook wiring here with literal resolved `$CALSUITE_DIR` paths.
 - `config/targets.json` — repos that `--sync` installs to
 - `.git/hooks/post-commit` — auto-syncs on commit when hooks/skills/agents/scripts/config change
 
 ## Gotchas
 
+### Installer + distribution
+- Hooks live in **`settings.local.json`** (gitignored), not `settings.json`. Writing calsuite paths into committed `settings.json` breaks every collaborator and CI.
+- Hook scripts are **not** copied or symlinked into target repos. Hook commands in `settings.local.json` reference `$CALSUITE_DIR/scripts/hooks/*.cjs` directly. `$CALSUITE_DIR` is resolved **at install time** into an absolute path — Claude Code's hook runner does NOT shell-expand hook commands at runtime.
+- `hooks/hooks.json` template uses `${CALSUITE_DIR}` placeholder. Installer substitutes via `substituteCalsuiteDir()` in `scripts/configure-claude.js`.
+- Calsuite location resolves in this order: `$CALSUITE_DIR` env var → `~/Projects/calsuite` default → installer's own parent dir.
+- Skills and agents use the `_origin` safe-overwrite protocol — frontmatter marker `_origin: calsuite@<short-sha>`. Decision matrix lives in `scripts/lib/origin-protocol.cjs` (`decideFileAction`). Migration for pre-protocol files happens automatically per-file (byte-identical → auto-stamp, differs → skip + log).
+- Content comparison is LF-normalized and strips the `_origin` line from both sides. Source files never carry `_origin`; target files always do once stamped. Comparing raw bytes would false-positive every time.
+- `_origin` protocol applies **only to markdown** under `skills/` and `agents/`. Non-markdown files (rare; e.g. `skills/strategic-compact/scripts/suggest-compact.cjs`) are copy-no-overwrite. JSON configs stay on copy-no-overwrite (can't host frontmatter).
+- Auto-frontmatter: supporting markdown files that lack a YAML block (e.g. `skills/review/checklist.md`, `skills/ship/pr-template.md`) get one prepended with just `_origin:` on first install.
+
+### Runtime mechanics
 - `known_marketplaces.json` is an object keyed by name — use `Object.keys()`.
 - Plugins can be enabled at global OR project scope — check both.
 - `String.prototype.replace` with a string replacement interprets `$` sequences — use a function replacer `() => value` for literal paths.
-- `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs to `resolveHookPaths`.
+- `JSON.stringify(undefined)` returns `undefined` (not a string) — guard inputs before passing to it.
 - Git repo lives at `Projects/calsuite/`, NOT parent `Projects/`.
 - Profiles with an explicit `skills` array **override** (not merge with) parent — when adding a skill to `base`, also add to `monorepo-root` and any other profile declaring its own `skills`.
 - `global-settings.json` stores empty placeholders for API keys; real keys go in `~/.mcp.json` only.
 - MCP tool names change across versions (e.g. Context7 `get-library-docs` → `query-docs`) — verify against the live server.
 - Hook entries in `hooks.json` MUST have `"_origin": "calsuite"` — the installer uses this to merge without overwriting project-specific hooks.
-- Hook scripts are symlinked (not copied) — editing them in calsuite edits them everywhere. Use `--copy` flag for portability.
-- `symlinkDirSync` skips non-symlink files in dest — project-specific hook scripts are preserved.
 - Claude Code MCP schema uses `"type": "http"` for remote servers, NOT `"type": "url"`.
+- Claude Code's skill hierarchy is enterprise > personal (`~/.claude/`) > project (CWD's `.claude/`) > plugin. Parent-directory `.claude/skills/` is **not** discovered automatically.
 - Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]`, `docs:`/`chore:`/`style:` prefix, or md-only changes.
+
+### Divergence resolution
+
+When `--sync` reports files skipped pending reconciliation, three commands resolve them:
+- `--force-adopt <path>` — take calsuite's current version. Destroys local edits.
+- `--claim <path>` — stamp `_origin: <target-name>`, keep local content. Future syncs skip silently.
+- `--reconcile <path>` — **issue [#42](https://github.com/ckallum/calsuite/issues/42)**, not yet implemented — three-way merge with `$EDITOR`.
 
 ## Testing configure-claude.js
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,79 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.5**
+**Version: 2.6**
 
 ## Getting started
 
-Clone this repo and symlink or copy the relevant directories into your project's `.claude/` directory, or reference them from your global Claude Code settings.
+Clone this repo. By default, place it at `~/Projects/calsuite`; if you keep it elsewhere, export `CALSUITE_DIR=/your/path` in your shell profile before running the installer.
+
+```bash
+node scripts/configure-claude.js /path/to/target-repo
+```
+
+Repo layout:
 
 ```
 hooks/       # Shell commands triggered by Claude Code events
 commands/    # Custom slash commands
-scripts/     # Standalone utility scripts + configure-claude installer
-config/      # Global settings manifest + profiles.json
+scripts/     # configure-claude installer, scripts/hooks/*.cjs, scripts/lib/*.cjs
+config/      # global-settings.json (manifest), profiles.json, targets.json
 plugins/     # Claude Code plugins
-skills/      # Custom skills (/configure-claude, /strategic-compact, /spec-interview, /update-docs, /context7, /guardian)
-agents/      # Agent definitions (@context-loader, @doc-updater, @browser, @code-reviewer)
-templates/   # Spec, doc, and changelog templates
+skills/      # Markdown skills (invoked as /skill-name)
+agents/      # Agent definitions (invoked as @agent-name)
+templates/   # Spec, doc, and changelog templates (for target projects)
+specs/       # Calsuite's own spec docs
 ```
+
+## Distribution model
+
+Calsuite is a personal harness. The installer keeps **machine-specific state out of the target's tracked files** and **respects your local edits** across resyncs.
+
+```mermaid
+flowchart LR
+    subgraph SRC["calsuite/ (source of truth)"]
+        direction TB
+        S1["scripts/hooks/*.cjs<br/>scripts/lib/*.cjs"]
+        S2["hooks/hooks.json<br/>(template, \${CALSUITE_DIR})"]
+        S3["skills/*/*.md<br/>agents/*.md"]
+        S4["config/*.json<br/>config/lint-configs/*<br/>templates/specs/"]
+    end
+
+    subgraph TGT_LOCAL["target/.claude/settings.local.json (gitignored)"]
+        L1["Hook wiring<br/>literal absolute paths"]
+    end
+
+    subgraph TGT_SHARED["target/.claude/* (committed)"]
+        T1["skills/<name>/*.md<br/>agents/*.md<br/>(with _origin: calsuite@<sha>)"]
+        T2["config/*.json<br/>.eslintrc.json<br/>specs/<br/>(copied, no-overwrite)"]
+        T3["settings.json<br/>(plugins + permissions only)"]
+    end
+
+    subgraph HOOKS["Claude Code hook runner"]
+        H1["reads command string literally<br/>(no shell expansion)"]
+    end
+
+    S1 -.->|referenced at runtime| H1
+    S2 -->|installer resolves \${CALSUITE_DIR}| L1
+    S3 -->|copy + _origin stamp<br/>safe-overwrite protocol| T1
+    S4 -->|copy-no-overwrite| T2
+    L1 -->|hook runs| H1
+```
+
+| Asset | Mechanism | Lives in | Local override |
+|---|---|---|---|
+| Hook wiring (`hooks/hooks.json`) | Installer resolves `${CALSUITE_DIR}` and merges into target's `settings.local.json` (gitignored). Hook runner reads literal absolute paths. | `<target>/.claude/settings.local.json` (per-user) | Edit freely; merge preserves `_origin=calsuite` tags and project-specific entries |
+| Hook scripts (`scripts/hooks/*.cjs`) | Not copied, not symlinked. Referenced directly from `$CALSUITE_DIR`. | `<calsuite>/scripts/hooks/` | Edit calsuite — changes propagate instantly |
+| Skills, agents | Copied with `_origin: calsuite@<sha>` frontmatter. Re-syncs safely overwrite pristine files; skip locally-edited files; never touch user-claimed ones. | `<target>/.claude/skills/`, `agents/` (committed) | `--claim <path>` to keep local, `--force-adopt <path>` to take calsuite's version |
+| Configs, templates, ESLint | Copy-no-overwrite. Seeded once, never refreshed. | `<target>/.claude/config/`, `.eslintrc.json`, `.claude/specs/` | Just edit — the installer never overwrites |
+| Plugins, permissions | Merged into `settings.json` (portable strings, no paths). | `<target>/.claude/settings.json` (committed) | Edit; re-install preserves additions |
+| MCP servers (`config/global-settings.json`) | Installer adds missing entries to `~/.mcp.json` + user settings. | `~/.claude/` and `~/.mcp.json` (per-user global) | Edit either file; installer only adds missing |
+
+**When a sync flags divergence** — e.g. you've edited `<target>/.claude/skills/ship/SKILL.md` locally — the installer skips that file and logs it. Resolve with:
+
+- `node scripts/configure-claude.js --force-adopt <path>` — take calsuite's current version.
+- `node scripts/configure-claude.js --claim <path>` — stamp `_origin: <target>`, keep local content. Sync never touches it again.
+- `node scripts/configure-claude.js --reconcile <path>` — (issue [#42](https://github.com/ckallum/calsuite/issues/42), planned) three-way merge in `$EDITOR`.
 
 ## Mono-repo Support
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/guardian.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/guardian.cjs\""
           }
         ],
         "description": "Guardian: evaluate tool call risk and block dangerous operations",
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/pr-intent-gate.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/pr-intent-gate.cjs\""
           }
         ],
         "description": "PR Intent Gate: require ## Why section in PR body",
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/merged-branch-guard.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/merged-branch-guard.cjs\""
           }
         ],
         "description": "Merged Branch Guard: block operations on branches with merged PRs",
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/review-gate.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/review-gate.cjs\""
           }
         ],
         "description": "Review gate: require code review before commits",
@@ -51,7 +51,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/lint-gate.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/lint-gate.cjs\""
           }
         ],
         "description": "Lint gate: check structural lint rules before commits",
@@ -73,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/skill-usage-tracker.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/skill-usage-tracker.cjs\""
           }
         ],
         "description": "Track skill invocations for usage analytics",
@@ -84,7 +84,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/skills/strategic-compact/scripts/suggest-compact.cjs\""
+            "command": "node \"${CALSUITE_DIR}/skills/strategic-compact/scripts/suggest-compact.cjs\""
           }
         ],
         "description": "Suggest manual compaction at logical intervals",
@@ -97,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/pre-compact.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/pre-compact.cjs\""
           }
         ],
         "description": "Save state before context compaction",
@@ -110,7 +110,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/session-start.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/session-start.cjs\""
           }
         ],
         "description": "Load previous context and detect package manager on new session",
@@ -123,7 +123,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/pr-url-logger.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/pr-url-logger.cjs\""
           }
         ],
         "description": "Log PR URL and provide review command after PR creation",
@@ -134,7 +134,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/ci-monitor.cjs\"",
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/ci-monitor.cjs\"",
             "async": true,
             "timeout": 30
           }
@@ -147,7 +147,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/prettier-format.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/prettier-format.cjs\""
           }
         ],
         "description": "Auto-format JS/TS files with Prettier after edits",
@@ -158,7 +158,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/typescript-check.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/typescript-check.cjs\""
           }
         ],
         "description": "TypeScript check after editing .ts/.tsx files",
@@ -169,7 +169,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/console-log-warn.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/console-log-warn.cjs\""
           }
         ],
         "description": "Warn about console.log statements after edits",
@@ -180,7 +180,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/eslint-check.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/eslint-check.cjs\""
           }
         ],
         "description": "ESLint check: report violations after JS/TS edits for agent self-correction",
@@ -193,7 +193,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/check-console-log.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/check-console-log.cjs\""
           }
         ],
         "description": "Check for console.log in modified files after each response",
@@ -206,7 +206,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/session-end.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/session-end.cjs\""
           }
         ],
         "description": "Persist session state on end",
@@ -217,7 +217,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_CONFIG_DIR}/scripts/hooks/evaluate-session.cjs\""
+            "command": "node \"${CALSUITE_DIR}/scripts/hooks/evaluate-session.cjs\""
           }
         ],
         "description": "Evaluate session for extractable patterns",

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -74,6 +74,33 @@ function substituteCalsuiteDir(hooksObj, calsuiteDir) {
   return JSON.parse(json.replace(/\$\{CALSUITE_DIR\}/g, () => safeDir));
 }
 
+// Actions that should result in (re)writing the destination file.
+const WRITE_ACTIONS = new Set(['write-new', 'write-update', 'migrate']);
+// Actions that indicate a file was skipped and needs user reconciliation.
+const BLOCKING_SKIP_ACTIONS = new Set(['skip-diverged', 'skip-unknown']);
+
+// Fresh counters for every action installProtectedFile can emit.
+function makeInstallStats() {
+  return {
+    'write-new': 0,
+    'write-update': 0,
+    'migrate': 0,
+    'skip-diverged': 0,
+    'skip-unknown': 0,
+    'skip-claimed': 0,
+    'skip-exists': 0,
+  };
+}
+
+// Aggregate a stats object into the three numbers used in log lines.
+function summarizeInstallStats(stats) {
+  return {
+    written: stats['write-new'] + stats['write-update'] + stats['migrate'],
+    skipped: stats['skip-diverged'] + stats['skip-unknown'],
+    preserved: stats['skip-claimed'] + stats['skip-exists'],
+  };
+}
+
 /**
  * Install one calsuite-managed file into a target, respecting the
  * `_origin` safe-overwrite protocol for markdown files. Non-markdown
@@ -93,7 +120,7 @@ function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stat
     // apply). A pre-existing file at dest means "leave alone" — this is
     // not the same as user-claimed; separate counter to avoid confusing logs.
     if (fs.existsSync(destFile)) {
-      stats['skip-exists'] = (stats['skip-exists'] || 0) + 1;
+      stats['skip-exists']++;
       return;
     }
     fs.copyFileSync(srcFile, destFile);
@@ -103,16 +130,16 @@ function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stat
 
   const calsuiteRelPath = path.relative(calsuiteDir, srcFile);
   const decision = originProtocol.decideFileAction(destFile, calsuiteRelPath, calsuiteDir);
-  stats[decision.action] = (stats[decision.action] || 0) + 1;
+  stats[decision.action]++;
 
-  if (decision.action === 'write-new' || decision.action === 'write-update' || decision.action === 'migrate') {
+  if (WRITE_ACTIONS.has(decision.action)) {
     const srcContent = fs.readFileSync(srcFile, 'utf8');
     const stamped = originProtocol.stampOrigin(srcContent, `calsuite@${currentSha}`);
     fs.writeFileSync(destFile, stamped);
     return;
   }
 
-  if (decision.action === 'skip-diverged' || decision.action === 'skip-unknown') {
+  if (BLOCKING_SKIP_ACTIONS.has(decision.action)) {
     divergences.push({ destPath: destFile, action: decision.action, reason: decision.reason });
   }
 }
@@ -181,7 +208,7 @@ function ensureGitignoreEntry(dir) {
  * as designed (user-owned files).
  */
 function printDivergenceSummary(divergences) {
-  const blocking = divergences.filter(d => d.action === 'skip-diverged' || d.action === 'skip-unknown');
+  const blocking = divergences.filter(d => BLOCKING_SKIP_ACTIONS.has(d.action));
   if (blocking.length === 0) return;
   console.log('');
   console.log('  ───────────────────────────────────────────────────────────────');
@@ -527,7 +554,7 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   //    with `_origin: calsuite@<sha>` stamped into its frontmatter.
   //    Existing files with local edits are detected and preserved.
   const destSkills = path.join(claudeDir, 'skills');
-  const skillStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
+  const skillStats = makeInstallStats();
   const divergences = opts.divergences || [];
   for (const skillName of resolvedProfile.skills) {
     if (INTERNAL_SKILLS.has(skillName)) continue;
@@ -539,27 +566,24 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
       installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stats: skillStats, divergences });
     }
   }
-  const written = skillStats['write-new'] + skillStats['write-update'] + skillStats['migrate'];
-  const skipped = skillStats['skip-diverged'] + skillStats['skip-unknown'];
-  const preserved = skillStats['skip-claimed'] + skillStats['skip-exists'];
+  const skillSummary = summarizeInstallStats(skillStats);
   const preservedBreakdown = [];
   if (skillStats['skip-claimed']) preservedBreakdown.push(`${skillStats['skip-claimed']} user-claimed`);
   if (skillStats['skip-exists']) preservedBreakdown.push(`${skillStats['skip-exists']} non-md kept`);
-  console.log(`  ✓ Skills: ${written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skipped} skipped${preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
+  console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
 
   // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
     const destAgents = path.join(claudeDir, 'agents');
-    const agentStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
+    const agentStats = makeInstallStats();
     for (const agentName of resolvedProfile.agents) {
       const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
       if (!fs.existsSync(srcAgent)) continue;
       const destAgent = path.join(destAgents, `${agentName}.md`);
       installProtectedFile({ srcFile: srcAgent, destFile: destAgent, calsuiteDir, currentSha, stats: agentStats, divergences });
     }
-    const aWritten = agentStats['write-new'] + agentStats['write-update'] + agentStats['migrate'];
-    const aSkipped = agentStats['skip-diverged'] + agentStats['skip-unknown'];
-    console.log(`  ✓ Agents: ${aWritten} written, ${aSkipped} skipped${agentStats['skip-claimed'] ? `, ${agentStats['skip-claimed']} user-claimed` : ''}`);
+    const agentSummary = summarizeInstallStats(agentStats);
+    console.log(`  ✓ Agents: ${agentSummary.written} written, ${agentSummary.skipped} skipped${agentStats['skip-claimed'] ? `, ${agentStats['skip-claimed']} user-claimed` : ''}`);
   }
 
   // 5. Copy templates (never overwrite existing)
@@ -716,7 +740,7 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
   // protocol so explicit --only installs never silently clobber local edits).
   if (onlySkills.length > 0) {
     const destSkills = path.join(claudeDir, 'skills');
-    const stats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
+    const stats = makeInstallStats();
     let count = 0;
     for (const skillName of onlySkills) {
       if (INTERNAL_SKILLS.has(skillName)) {
@@ -737,15 +761,14 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
         missing.push(`skill:${skillName}`);
       }
     }
-    const written = stats['write-new'] + stats['write-update'] + stats['migrate'];
-    const skipped = stats['skip-diverged'] + stats['skip-unknown'];
-    console.log(`  → ${count} skill(s): ${written} files written, ${skipped} skipped, ${stats['skip-claimed'] + stats['skip-exists']} preserved`);
+    const summary = summarizeInstallStats(stats);
+    console.log(`  → ${count} skill(s): ${summary.written} files written, ${summary.skipped} skipped, ${summary.preserved} preserved`);
   }
 
   // Install specified agents through the same protocol.
   if (onlyAgents.length > 0) {
     const destAgents = path.join(claudeDir, 'agents');
-    const stats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
+    const stats = makeInstallStats();
     let count = 0;
     for (const agentName of onlyAgents) {
       const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
@@ -759,9 +782,8 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
         missing.push(`agent:${agentName}`);
       }
     }
-    const written = stats['write-new'] + stats['write-update'] + stats['migrate'];
-    const skipped = stats['skip-diverged'] + stats['skip-unknown'];
-    console.log(`  → ${count} agent(s): ${written} written, ${skipped} skipped`);
+    const summary = summarizeInstallStats(stats);
+    console.log(`  → ${count} agent(s): ${summary.written} written, ${summary.skipped} skipped`);
   }
 
   // Also install into workspaces if monorepo
@@ -835,7 +857,8 @@ function destToCalsuiteRel(destPath) {
   const afterClaude = destPath.slice(idx + marker.length);
   const first = afterClaude.split(path.sep)[0];
   if (first === 'skills' || first === 'agents') {
-    return afterClaude.replace(new RegExp('\\' + path.sep, 'g'), '/');
+    // Normalize to forward-slashes so the path matches calsuite's git-tracked layout on Windows too.
+    return afterClaude.split(path.sep).join('/');
   }
   return null;
 }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -21,6 +21,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const originProtocol = require('./lib/origin-protocol.cjs');
 
 const CONFIG_REPO = path.resolve(__dirname, '..');
 const HOOKS_JSON = path.join(CONFIG_REPO, 'hooks', 'hooks.json');
@@ -63,6 +64,64 @@ function substituteCalsuiteDir(hooksObj, calsuiteDir) {
   const json = JSON.stringify(hooksObj);
   const safeDir = calsuiteDir.replace(/\\/g, '\\\\');
   return JSON.parse(json.replace(/\$\{CALSUITE_DIR\}/g, () => safeDir));
+}
+
+/**
+ * Install one calsuite-managed file into a target, respecting the
+ * `_origin` safe-overwrite protocol for markdown files. Non-markdown
+ * files use copy-no-overwrite semantics (simpler; can be promoted to
+ * sidecar-`.origin` tracking later if it matters).
+ *
+ * Mutates `stats` (an object with per-action counters) and `divergences`
+ * (an array of { destPath, action, reason }) so the caller can aggregate
+ * across many files.
+ */
+function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stats, divergences }) {
+  fs.mkdirSync(path.dirname(destFile), { recursive: true });
+
+  if (!srcFile.endsWith('.md')) {
+    if (fs.existsSync(destFile)) {
+      stats['skip-claimed']++;
+      return;
+    }
+    fs.copyFileSync(srcFile, destFile);
+    stats['write-new']++;
+    return;
+  }
+
+  const calsuiteRelPath = path.relative(calsuiteDir, srcFile);
+  const decision = originProtocol.decideFileAction(destFile, calsuiteRelPath, calsuiteDir);
+  stats[decision.action] = (stats[decision.action] || 0) + 1;
+
+  if (decision.action === 'write-new' || decision.action === 'write-update' || decision.action === 'migrate') {
+    const srcContent = fs.readFileSync(srcFile, 'utf8');
+    const stamped = originProtocol.stampOrigin(srcContent, `calsuite@${currentSha}`);
+    fs.writeFileSync(destFile, stamped);
+    return;
+  }
+
+  if (decision.action === 'skip-diverged' || decision.action === 'skip-unknown') {
+    divergences.push({ destPath: destFile, action: decision.action, reason: decision.reason });
+  }
+}
+
+/**
+ * Recursively list every file under a directory as absolute paths.
+ * Skips `.claude/` and any dot-prefixed directories.
+ */
+function listFilesRecursive(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...listFilesRecursive(full));
+    } else if (entry.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
 }
 
 function copyDirSync(src, dest) {
@@ -262,6 +321,8 @@ function findWorkspaces(targetDir) {
 function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   const claudeDir = path.join(targetDir, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.json');
+  const calsuiteDir = resolveCalsuiteDir();
+  const currentSha = originProtocol.currentCalsuiteSha(calsuiteDir);
 
   console.log(`\n--- Installing: ${label} (${targetDir}) ---\n`);
 
@@ -320,32 +381,40 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
     console.log(`  ✓ ESLint config already exists (skipped)`);
   }
 
-  // 3. Copy skills (only those in resolved profile)
+  // 3. Install skills via the _origin safe-overwrite protocol.
+  //    Every markdown file under each profile-listed skill dir is copied
+  //    with `_origin: calsuite@<sha>` stamped into its frontmatter.
+  //    Existing files with local edits are detected and preserved.
   const destSkills = path.join(claudeDir, 'skills');
-  let skillCount = 0;
+  const skillStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0 };
+  const divergences = opts.divergences || [];
   for (const skillName of resolvedProfile.skills) {
     if (INTERNAL_SKILLS.has(skillName)) continue;
     const srcSkill = path.join(SKILLS_DIR, skillName);
-    if (fs.existsSync(srcSkill) && fs.statSync(srcSkill).isDirectory()) {
-      copyDirSync(srcSkill, path.join(destSkills, skillName));
-      skillCount++;
+    if (!fs.existsSync(srcSkill) || !fs.statSync(srcSkill).isDirectory()) continue;
+    for (const srcFile of listFilesRecursive(srcSkill)) {
+      const relFromSkills = path.relative(SKILLS_DIR, srcFile);
+      const destFile = path.join(destSkills, relFromSkills);
+      installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stats: skillStats, divergences });
     }
   }
-  console.log(`  ✓ Copied ${skillCount} skill(s) → ${destSkills}`);
+  const written = skillStats['write-new'] + skillStats['write-update'] + skillStats['migrate'];
+  const skipped = skillStats['skip-diverged'] + skillStats['skip-unknown'];
+  console.log(`  ✓ Skills: ${written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skipped} skipped${skillStats['skip-claimed'] ? `, ${skillStats['skip-claimed']} user-claimed` : ''}`);
 
-  // 4. Copy agents (only those in resolved profile)
+  // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
     const destAgents = path.join(claudeDir, 'agents');
-    fs.mkdirSync(destAgents, { recursive: true });
-    let agentCount = 0;
+    const agentStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0 };
     for (const agentName of resolvedProfile.agents) {
       const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
-      if (fs.existsSync(srcAgent)) {
-        fs.copyFileSync(srcAgent, path.join(destAgents, `${agentName}.md`));
-        agentCount++;
-      }
+      if (!fs.existsSync(srcAgent)) continue;
+      const destAgent = path.join(destAgents, `${agentName}.md`);
+      installProtectedFile({ srcFile: srcAgent, destFile: destAgent, calsuiteDir, currentSha, stats: agentStats, divergences });
     }
-    console.log(`  ✓ Copied ${agentCount} agent(s) → ${destAgents}`);
+    const aWritten = agentStats['write-new'] + agentStats['write-update'] + agentStats['migrate'];
+    const aSkipped = agentStats['skip-diverged'] + agentStats['skip-unknown'];
+    console.log(`  ✓ Agents: ${aWritten} written, ${aSkipped} skipped${agentStats['skip-claimed'] ? `, ${agentStats['skip-claimed']} user-claimed` : ''}`);
   }
 
   // 5. Copy templates (never overwrite existing)
@@ -391,7 +460,6 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   // Substitute ${CALSUITE_DIR} with the literal absolute path. Claude Code's
   // hook runner does not shell-expand command strings, so $VAR syntax cannot
   // resolve at runtime — the installer must resolve it now.
-  const calsuiteDir = resolveCalsuiteDir();
   const resolvedHooks = substituteCalsuiteDir(hooksConfig.hooks, calsuiteDir);
 
   // 7. Write calsuite hooks into settings.local.json (gitignored, per-user).

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -17,10 +17,12 @@
  *   --sync                       Re-run install against all targets in config/targets.json
  *   --force-adopt <path>         Overwrite a target skill/agent file with calsuite's
  *                                current version. Discards local edits. Stamps fresh
- *                                `_origin: calsuite@<sha>`.
+ *                                `_origin: calsuite@<sha>`. Prompts for confirmation;
+ *                                pass --yes (or -y) to skip the prompt.
  *   --claim <path>               Mark a target skill/agent file as user-owned. Stamps
  *                                `_origin: <target-name>` in frontmatter, preserves
  *                                content. Subsequent syncs never touch it.
+ *   --yes, -y                    Skip confirmation prompts for destructive operations.
  *   --copy                       (deprecated, no-op) formerly toggled script copy vs symlink;
  *                                hook scripts are now referenced directly from $CALSUITE_DIR
  */
@@ -86,8 +88,12 @@ function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stat
   fs.mkdirSync(path.dirname(destFile), { recursive: true });
 
   if (!srcFile.endsWith('.md')) {
+    // Non-markdown files inside a skill dir use copy-no-overwrite semantics
+    // (they can't host YAML frontmatter, so the _origin protocol doesn't
+    // apply). A pre-existing file at dest means "leave alone" — this is
+    // not the same as user-claimed; separate counter to avoid confusing logs.
     if (fs.existsSync(destFile)) {
-      stats['skip-claimed']++;
+      stats['skip-exists'] = (stats['skip-exists'] || 0) + 1;
       return;
     }
     fs.copyFileSync(srcFile, destFile);
@@ -257,11 +263,27 @@ function mergeHooks(existingHooks, newHooks) {
   return merged;
 }
 
+/**
+ * Read and parse a JSON file. Returns null if the file is missing (ENOENT)
+ * — a common and benign case — so callers can idiom `readJsonSync(...) || {}`.
+ * THROWS on parse errors; silently returning null for malformed JSON would
+ * let the installer rebuild the file from scratch, wiping user content.
+ */
 function readJsonSync(filePath) {
+  let raw;
   try {
-    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
-    return null;
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if (err.code === 'ENOENT') return null;
+    throw new Error(`Failed to read ${filePath}: ${err.message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `${filePath} is not valid JSON (${err.message}).\n` +
+      `Refusing to overwrite — fix or delete the file manually, then re-run the installer.`
+    );
   }
 }
 
@@ -505,7 +527,7 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   //    with `_origin: calsuite@<sha>` stamped into its frontmatter.
   //    Existing files with local edits are detected and preserved.
   const destSkills = path.join(claudeDir, 'skills');
-  const skillStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0 };
+  const skillStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
   const divergences = opts.divergences || [];
   for (const skillName of resolvedProfile.skills) {
     if (INTERNAL_SKILLS.has(skillName)) continue;
@@ -519,12 +541,16 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   }
   const written = skillStats['write-new'] + skillStats['write-update'] + skillStats['migrate'];
   const skipped = skillStats['skip-diverged'] + skillStats['skip-unknown'];
-  console.log(`  ✓ Skills: ${written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skipped} skipped${skillStats['skip-claimed'] ? `, ${skillStats['skip-claimed']} user-claimed` : ''}`);
+  const preserved = skillStats['skip-claimed'] + skillStats['skip-exists'];
+  const preservedBreakdown = [];
+  if (skillStats['skip-claimed']) preservedBreakdown.push(`${skillStats['skip-claimed']} user-claimed`);
+  if (skillStats['skip-exists']) preservedBreakdown.push(`${skillStats['skip-exists']} non-md kept`);
+  console.log(`  ✓ Skills: ${written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skipped} skipped${preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
 
   // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
     const destAgents = path.join(claudeDir, 'agents');
-    const agentStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0 };
+    const agentStats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
     for (const agentName of resolvedProfile.agents) {
       const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
       if (!fs.existsSync(srcAgent)) continue;
@@ -678,14 +704,19 @@ function installCcstatuslineConfig(manifest) {
  * Usage: node configure-claude.js <target> --only review,qa,ship
  *        node configure-claude.js <target> --only review,qa --agents code-reviewer
  */
-function installOnly(targetDir, onlySkills, onlyAgents) {
+function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null) {
   const claudeDir = path.join(targetDir, '.claude');
   fs.mkdirSync(claudeDir, { recursive: true });
+  const calsuiteDir = resolveCalsuiteDir();
+  const currentSha = originProtocol.currentCalsuiteSha(calsuiteDir);
   const missing = [];
+  const divergences = outerDivergences || [];
 
-  // Install specified skills
+  // Install specified skills (routed through the _origin safe-overwrite
+  // protocol so explicit --only installs never silently clobber local edits).
   if (onlySkills.length > 0) {
     const destSkills = path.join(claudeDir, 'skills');
+    const stats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
     let count = 0;
     for (const skillName of onlySkills) {
       if (INTERNAL_SKILLS.has(skillName)) {
@@ -694,34 +725,43 @@ function installOnly(targetDir, onlySkills, onlyAgents) {
       }
       const srcSkill = path.join(SKILLS_DIR, skillName);
       if (fs.existsSync(srcSkill) && fs.statSync(srcSkill).isDirectory()) {
-        copyDirSync(srcSkill, path.join(destSkills, skillName));
+        for (const srcFile of listFilesRecursive(srcSkill)) {
+          const relFromSkills = path.relative(SKILLS_DIR, srcFile);
+          const destFile = path.join(destSkills, relFromSkills);
+          installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stats, divergences });
+        }
         count++;
-        console.log(`  ✓ Installed skill: ${skillName}`);
+        console.log(`  ✓ Processed skill: ${skillName}`);
       } else {
         console.log(`  ✗ Skill not found: ${skillName}`);
         missing.push(`skill:${skillName}`);
       }
     }
-    console.log(`  → ${count} skill(s) installed to ${destSkills}`);
+    const written = stats['write-new'] + stats['write-update'] + stats['migrate'];
+    const skipped = stats['skip-diverged'] + stats['skip-unknown'];
+    console.log(`  → ${count} skill(s): ${written} files written, ${skipped} skipped, ${stats['skip-claimed'] + stats['skip-exists']} preserved`);
   }
 
-  // Install specified agents
+  // Install specified agents through the same protocol.
   if (onlyAgents.length > 0) {
     const destAgents = path.join(claudeDir, 'agents');
-    fs.mkdirSync(destAgents, { recursive: true });
+    const stats = { 'write-new': 0, 'write-update': 0, 'migrate': 0, 'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0, 'skip-exists': 0 };
     let count = 0;
     for (const agentName of onlyAgents) {
       const srcAgent = path.join(AGENTS_DIR, `${agentName}.md`);
       if (fs.existsSync(srcAgent)) {
-        fs.copyFileSync(srcAgent, path.join(destAgents, `${agentName}.md`));
+        const destAgent = path.join(destAgents, `${agentName}.md`);
+        installProtectedFile({ srcFile: srcAgent, destFile: destAgent, calsuiteDir, currentSha, stats, divergences });
         count++;
-        console.log(`  ✓ Installed agent: ${agentName}`);
+        console.log(`  ✓ Processed agent: ${agentName}`);
       } else {
         console.log(`  ✗ Agent not found: ${agentName}`);
         missing.push(`agent:${agentName}`);
       }
     }
-    console.log(`  → ${count} agent(s) installed to ${destAgents}`);
+    const written = stats['write-new'] + stats['write-update'] + stats['migrate'];
+    const skipped = stats['skip-diverged'] + stats['skip-unknown'];
+    console.log(`  → ${count} agent(s): ${written} written, ${skipped} skipped`);
   }
 
   // Also install into workspaces if monorepo
@@ -730,11 +770,16 @@ function installOnly(targetDir, onlySkills, onlyAgents) {
     const workspaces = findWorkspaces(targetDir);
     for (const ws of workspaces) {
       console.log(`\n  Workspace: ${ws.name}`);
-      const wsMissing = installOnly(ws.path, onlySkills, onlyAgents);
+      const wsMissing = installOnly(ws.path, onlySkills, onlyAgents, divergences);
       missing.push(...wsMissing);
     }
   }
 
+  // Top-level callers print the divergence summary once; if invoked without an
+  // outer list we're the top-level — print here.
+  if (!outerDivergences) {
+    printDivergenceSummary(divergences);
+  }
   return missing;
 }
 
@@ -803,7 +848,23 @@ function deriveTargetName(destPath) {
   return path.basename(targetDir);
 }
 
-function handleForceAdopt(targetPath) {
+function promptYesNo(question) {
+  // Sync stdin read — no readline dep. Returns true iff the user typed y/yes.
+  // Non-TTY stdin (scripts, CI) returns false unless `--yes` already bypassed this.
+  if (!process.stdin.isTTY) return false;
+  process.stdout.write(`${question} [y/N] `);
+  const buf = Buffer.alloc(16);
+  let bytesRead = 0;
+  try {
+    bytesRead = fs.readSync(0, buf, 0, 16, null);
+  } catch {
+    return false;
+  }
+  const answer = buf.slice(0, bytesRead).toString('utf8').trim().toLowerCase();
+  return answer === 'y' || answer === 'yes';
+}
+
+function handleForceAdopt(targetPath, { assumeYes = false } = {}) {
   const destPath = path.resolve(targetPath);
   const calsuiteRel = destToCalsuiteRel(destPath);
   if (!calsuiteRel) {
@@ -816,6 +877,18 @@ function handleForceAdopt(targetPath) {
     console.error(`  ✗ Calsuite has no matching source file: ${srcFile}`);
     process.exit(1);
   }
+
+  if (!assumeYes) {
+    const destExists = fs.existsSync(destPath);
+    const warning = destExists
+      ? `Overwrite ${destPath} with calsuite's current version? Any local edits will be lost.`
+      : `Write calsuite's current content to ${destPath}?`;
+    if (!promptYesNo(warning)) {
+      console.log('  ⊘ Aborted. Re-run with --yes to skip the prompt.');
+      process.exit(1);
+    }
+  }
+
   const currentSha = originProtocol.currentCalsuiteSha(calsuiteDir);
   const content = fs.readFileSync(srcFile, 'utf8');
   const stamped = originProtocol.stampOrigin(content, `calsuite@${currentSha}`);
@@ -864,6 +937,8 @@ function parseArgv() {
       flags.sync = true;
     } else if (args[i] === '--copy') {
       flags.copy = true;
+    } else if (args[i] === '--yes' || args[i] === '-y') {
+      flags.yes = true;
     } else if (args[i] === '--force-adopt') {
       const next = args[i + 1];
       if (!next || next.startsWith('--')) {
@@ -902,7 +977,7 @@ function main() {
   // Handle --force-adopt and --claim early — they touch a single file
   // and shouldn't trigger a full install.
   if (flags.forceAdopt) {
-    handleForceAdopt(flags.forceAdopt);
+    handleForceAdopt(flags.forceAdopt, { assumeYes: flags.yes });
     return;
   }
   if (flags.claim) {
@@ -1130,4 +1205,11 @@ function checkGlobalSettings(manifest, projectSettingsPaths) {
   }
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  // Errors thrown by origin-protocol utilities carry user-facing messages
+  // already. Print cleanly, exit non-zero, skip the noisy Node stack trace.
+  console.error(`\n  ✗ ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -32,7 +32,6 @@ const AGENTS_DIR = path.join(CONFIG_REPO, 'agents');
 const TEMPLATES_DIR = path.join(CONFIG_REPO, 'templates');
 const LINT_CONFIGS_DIR = path.join(CONFIG_REPO, 'config', 'lint-configs');
 const TARGETS_JSON = path.join(CONFIG_REPO, 'config', 'targets.json');
-const PARENT_CLAUDE_DIR = path.join(CONFIG_REPO, '..', '.claude');
 const HOME_DIR = require('os').homedir();
 const HOME_SETTINGS = path.join(HOME_DIR, '.claude', 'settings.json');
 const HOME_SETTINGS_LOCAL = path.join(HOME_DIR, '.claude', 'settings.local.json');
@@ -543,39 +542,6 @@ function installOnly(targetDir, onlySkills, onlyAgents) {
   return missing;
 }
 
-function syncParentAssets() {
-  if (!fs.existsSync(PARENT_CLAUDE_DIR)) {
-    console.log(`  ⚠ Parent .claude dir not found at ${PARENT_CLAUDE_DIR} — skipping shared asset sync`);
-    return;
-  }
-
-  const parentSkillsDir = path.join(PARENT_CLAUDE_DIR, 'skills');
-  const parentAgentsDir = path.join(PARENT_CLAUDE_DIR, 'agents');
-
-  fs.mkdirSync(parentSkillsDir, { recursive: true });
-  fs.mkdirSync(parentAgentsDir, { recursive: true });
-
-  // Symlink shared skills
-  let skillCount = 0;
-  for (const entry of fs.readdirSync(SKILLS_DIR, { withFileTypes: true })) {
-    if (!entry.isDirectory() || INTERNAL_SKILLS.has(entry.name) || entry.name.startsWith('.')) continue;
-    if (symlinkOrSkip(path.join(SKILLS_DIR, entry.name), path.join(parentSkillsDir, entry.name))) {
-      skillCount++;
-    }
-  }
-  console.log(`  ✓ Symlinked ${skillCount} shared skill(s) → ${parentSkillsDir}`);
-
-  // Symlink shared agents
-  let agentCount = 0;
-  for (const entry of fs.readdirSync(AGENTS_DIR, { withFileTypes: true })) {
-    if (!entry.isFile()) continue;
-    if (symlinkOrSkip(path.join(AGENTS_DIR, entry.name), path.join(parentAgentsDir, entry.name))) {
-      agentCount++;
-    }
-  }
-  console.log(`  ✓ Symlinked ${agentCount} shared agent(s) → ${parentAgentsDir}`);
-}
-
 function installTarget(targetDir, profilesConfig, opts = {}) {
   const detectedProfiles = detectProfiles(targetDir);
   if (opts.logProfiles) {
@@ -686,9 +652,6 @@ function main() {
       console.error('  ✗ Could not read profiles.json');
       process.exit(1);
     }
-
-    // Also sync shared skills/agents to parent .claude/
-    syncParentAssets();
 
     for (const target of targets.targets) {
       const targetPath = path.resolve(target.path.replace(/^~/, HOME_DIR));

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -23,8 +23,6 @@
  *                                `_origin: <target-name>` in frontmatter, preserves
  *                                content. Subsequent syncs never touch it.
  *   --yes, -y                    Skip confirmation prompts for destructive operations.
- *   --copy                       (deprecated, no-op) formerly toggled script copy vs symlink;
- *                                hook scripts are now referenced directly from $CALSUITE_DIR
  */
 
 const fs = require('fs');
@@ -958,8 +956,6 @@ function parseArgv() {
       flags.installCcstatusline = true;
     } else if (args[i] === '--sync') {
       flags.sync = true;
-    } else if (args[i] === '--copy') {
-      flags.copy = true;
     } else if (args[i] === '--yes' || args[i] === '-y') {
       flags.yes = true;
     } else if (args[i] === '--force-adopt') {
@@ -1042,7 +1038,7 @@ function main() {
         console.log(`  ⚠ Skipping ${target.path} (not found)`);
         continue;
       }
-      installTarget(targetPath, profilesConfig, { copy: flags.copy, divergences });
+      installTarget(targetPath, profilesConfig, { divergences });
     }
 
     console.log('\nSync complete!\n');
@@ -1076,7 +1072,6 @@ function main() {
   const divergences = [];
 
   const { isMonorepo } = installTarget(targetDir, profilesConfig, {
-    copy: flags.copy,
     logProfiles: true,
     copyWorkspaceDocs: true,
     divergences,

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -15,6 +15,12 @@
  *   --agents agent1,agent2,...   Install only specific agents (use with --only)
  *   --install-ccstatusline       Install ccstatusline config only
  *   --sync                       Re-run install against all targets in config/targets.json
+ *   --force-adopt <path>         Overwrite a target skill/agent file with calsuite's
+ *                                current version. Discards local edits. Stamps fresh
+ *                                `_origin: calsuite@<sha>`.
+ *   --claim <path>               Mark a target skill/agent file as user-owned. Stamps
+ *                                `_origin: <target-name>` in frontmatter, preserves
+ *                                content. Subsequent syncs never touch it.
  *   --copy                       (deprecated, no-op) formerly toggled script copy vs symlink;
  *                                hook scripts are now referenced directly from $CALSUITE_DIR
  */
@@ -427,14 +433,17 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
     }
   }
 
-  // 0b. Ensure `.claude/settings.local.json` is gitignored in the target.
+
+  // 1. Create .claude/ directory (and targetDir itself if missing)
+  fs.mkdirSync(claudeDir, { recursive: true });
+  console.log(`  ✓ Ensured ${claudeDir} exists`);
+
+  // 1b. Ensure `.claude/settings.local.json` is gitignored in the target.
+  //     Has to run after targetDir exists (the .claude mkdir above creates it
+  //     via { recursive: true }).
   if (ensureGitignoreEntry(targetDir)) {
     console.log(`  ✓ Added .claude/settings.local.json to ${path.join(targetDir, '.gitignore')}`);
   }
-
-  // 1. Create .claude/ directory
-  fs.mkdirSync(claudeDir, { recursive: true });
-  console.log(`  ✓ Ensured ${claudeDir} exists`);
 
   // 2. Hook scripts (scripts/hooks/, scripts/lib/) are NOT copied or symlinked
   //    into target/.claude/. Hook commands in settings.local.json reference them
@@ -764,6 +773,67 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
   return { detectedProfiles, isMonorepo };
 }
 
+/**
+ * Given a destination file inside a target's .claude/skills or .claude/agents,
+ * return the calsuite-relative path to the same file (skills/<name>/...
+ * or agents/<name>.md). Returns null if the path isn't under a recognized
+ * managed dir.
+ */
+function destToCalsuiteRel(destPath) {
+  const marker = path.sep + '.claude' + path.sep;
+  const idx = destPath.indexOf(marker);
+  if (idx === -1) return null;
+  const afterClaude = destPath.slice(idx + marker.length);
+  const first = afterClaude.split(path.sep)[0];
+  if (first === 'skills' || first === 'agents') {
+    return afterClaude.replace(new RegExp('\\' + path.sep, 'g'), '/');
+  }
+  return null;
+}
+
+function deriveTargetName(destPath) {
+  const marker = path.sep + '.claude' + path.sep;
+  const idx = destPath.indexOf(marker);
+  if (idx === -1) return 'local';
+  const targetDir = destPath.slice(0, idx);
+  return path.basename(targetDir);
+}
+
+function handleForceAdopt(targetPath) {
+  const destPath = path.resolve(targetPath);
+  const calsuiteRel = destToCalsuiteRel(destPath);
+  if (!calsuiteRel) {
+    console.error(`  ✗ ${destPath} is not under a target's .claude/skills or .claude/agents`);
+    process.exit(1);
+  }
+  const calsuiteDir = resolveCalsuiteDir();
+  const srcFile = path.join(calsuiteDir, calsuiteRel);
+  if (!fs.existsSync(srcFile)) {
+    console.error(`  ✗ Calsuite has no matching source file: ${srcFile}`);
+    process.exit(1);
+  }
+  const currentSha = originProtocol.currentCalsuiteSha(calsuiteDir);
+  const content = fs.readFileSync(srcFile, 'utf8');
+  const stamped = originProtocol.stampOrigin(content, `calsuite@${currentSha}`);
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
+  fs.writeFileSync(destPath, stamped);
+  console.log(`  ✓ Force-adopted ${destPath} ← calsuite@${currentSha}`);
+}
+
+function handleClaim(targetPath) {
+  const destPath = path.resolve(targetPath);
+  if (!fs.existsSync(destPath)) {
+    console.error(`  ✗ ${destPath} does not exist`);
+    process.exit(1);
+  }
+  const targetName = deriveTargetName(destPath);
+  const content = fs.readFileSync(destPath, 'utf8');
+  const stamped = originProtocol.stampOrigin(content, targetName);
+  fs.writeFileSync(destPath, stamped);
+  console.log(`  ✓ Claimed ${destPath} → _origin: ${targetName}`);
+  console.log(`    Subsequent --sync will leave this file alone.`);
+}
+
 function parseArgv() {
   const args = process.argv.slice(2);
   const flags = {};
@@ -790,6 +860,22 @@ function parseArgv() {
       flags.sync = true;
     } else if (args[i] === '--copy') {
       flags.copy = true;
+    } else if (args[i] === '--force-adopt') {
+      const next = args[i + 1];
+      if (!next || next.startsWith('--')) {
+        console.error('  ✗ --force-adopt requires a path argument');
+        process.exit(1);
+      }
+      flags.forceAdopt = next;
+      i++;
+    } else if (args[i] === '--claim') {
+      const next = args[i + 1];
+      if (!next || next.startsWith('--')) {
+        console.error('  ✗ --claim requires a path argument');
+        process.exit(1);
+      }
+      flags.claim = next;
+      i++;
     } else if (args[i].startsWith('--')) {
       console.error(`  ✗ Unknown flag: ${args[i]}`);
       process.exit(1);
@@ -808,6 +894,17 @@ function parseArgv() {
 
 function main() {
   const { flags, positional } = parseArgv();
+
+  // Handle --force-adopt and --claim early — they touch a single file
+  // and shouldn't trigger a full install.
+  if (flags.forceAdopt) {
+    handleForceAdopt(flags.forceAdopt);
+    return;
+  }
+  if (flags.claim) {
+    handleClaim(flags.claim);
+    return;
+  }
 
   // Handle --install-ccstatusline flag
   if (flags.installCcstatusline) {

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -106,6 +106,87 @@ function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stat
 }
 
 /**
+ * If a directory exists and every entry in it is a symbolic link whose target
+ * lives inside `calsuiteDir`, remove the whole directory. No-op otherwise —
+ * any real file or symlink-to-elsewhere signals user content to preserve.
+ *
+ * Cleans up the pre-refactor installer's `.claude/scripts/hooks/` and
+ * `.claude/scripts/lib/` dirs. Those directories are no longer populated;
+ * hook commands in settings.local.json reference calsuite directly.
+ */
+function removeIfAllCalsuiteSymlinks(dir, calsuiteDir) {
+  if (!fs.existsSync(dir)) return false;
+  const stat = fs.lstatSync(dir);
+  if (!stat.isDirectory()) return false;
+
+  const entries = fs.readdirSync(dir);
+  if (entries.length === 0) {
+    fs.rmdirSync(dir);
+    return true;
+  }
+
+  for (const name of entries) {
+    const entryPath = path.join(dir, name);
+    const entryStat = fs.lstatSync(entryPath);
+    if (!entryStat.isSymbolicLink()) return false;
+    const linkTarget = fs.readlinkSync(entryPath);
+    const resolved = path.resolve(dir, linkTarget);
+    if (!resolved.startsWith(calsuiteDir + path.sep) && resolved !== calsuiteDir) {
+      return false;
+    }
+  }
+
+  for (const name of entries) {
+    fs.unlinkSync(path.join(dir, name));
+  }
+  fs.rmdirSync(dir);
+  return true;
+}
+
+/**
+ * Ensure a `.gitignore` file in `dir` contains `.claude/settings.local.json`.
+ * Additive only — preserves any existing content and never removes entries.
+ * Returns true if the file was modified, false if the entry was already there.
+ */
+function ensureGitignoreEntry(dir) {
+  const gitignorePath = path.join(dir, '.gitignore');
+  const entry = '.claude/settings.local.json';
+  let existing = '';
+  if (fs.existsSync(gitignorePath)) {
+    existing = fs.readFileSync(gitignorePath, 'utf8');
+    const lines = existing.split(/\r?\n/).map(l => l.trim());
+    if (lines.includes(entry)) return false;
+  }
+  const prefix = existing && !existing.endsWith('\n') ? '\n' : '';
+  const block = `${prefix}\n# calsuite (personal harness) — never commit\n${entry}\n`;
+  fs.writeFileSync(gitignorePath, existing + block);
+  return true;
+}
+
+/**
+ * Print a one-block end-of-sync summary of files that couldn't be safely
+ * auto-updated. skip-claimed entries aren't included — those are working
+ * as designed (user-owned files).
+ */
+function printDivergenceSummary(divergences) {
+  const blocking = divergences.filter(d => d.action === 'skip-diverged' || d.action === 'skip-unknown');
+  if (blocking.length === 0) return;
+  console.log('');
+  console.log('  ───────────────────────────────────────────────────────────────');
+  console.log(`  ${blocking.length} file(s) skipped pending reconciliation:`);
+  for (const d of blocking) {
+    console.log(`    • ${d.destPath}`);
+    console.log(`      ${d.action}: ${d.reason}`);
+  }
+  console.log('');
+  console.log('  Resolve with:');
+  console.log('    node scripts/configure-claude.js --force-adopt <path>   # overwrite with calsuite current');
+  console.log('    node scripts/configure-claude.js --claim <path>         # stamp _origin=<target>, keep local');
+  console.log('    node scripts/configure-claude.js --reconcile <path>     # (issue #42) three-way merge');
+  console.log('  ───────────────────────────────────────────────────────────────');
+}
+
+/**
  * Recursively list every file under a directory as absolute paths.
  * Skips `.claude/` and any dot-prefixed directories.
  */
@@ -325,6 +406,31 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   const currentSha = originProtocol.currentCalsuiteSha(calsuiteDir);
 
   console.log(`\n--- Installing: ${label} (${targetDir}) ---\n`);
+
+  // 0. Clean up pre-refactor stale dirs: .claude/scripts/hooks and .claude/scripts/lib.
+  //    These were populated with symlinks to calsuite before the hook-refactor.
+  //    Safe to remove iff every entry is still a calsuite symlink (user-added
+  //    scripts are preserved).
+  const staleHooks = path.join(claudeDir, 'scripts', 'hooks');
+  const staleLib = path.join(claudeDir, 'scripts', 'lib');
+  const removedHooks = removeIfAllCalsuiteSymlinks(staleHooks, calsuiteDir);
+  const removedLib = removeIfAllCalsuiteSymlinks(staleLib, calsuiteDir);
+  if (removedHooks || removedLib) {
+    const parts = [];
+    if (removedHooks) parts.push('scripts/hooks');
+    if (removedLib) parts.push('scripts/lib');
+    console.log(`  ✓ Removed stale pre-refactor ${parts.join(', ')} dir(s) (were all calsuite symlinks)`);
+    // Remove the now-empty scripts dir too if nothing else is in it
+    const scriptsDir = path.join(claudeDir, 'scripts');
+    if (fs.existsSync(scriptsDir) && fs.readdirSync(scriptsDir).length === 0) {
+      fs.rmdirSync(scriptsDir);
+    }
+  }
+
+  // 0b. Ensure `.claude/settings.local.json` is gitignored in the target.
+  if (ensureGitignoreEntry(targetDir)) {
+    console.log(`  ✓ Added .claude/settings.local.json to ${path.join(targetDir, '.gitignore')}`);
+  }
 
   // 1. Create .claude/ directory
   fs.mkdirSync(claudeDir, { recursive: true });
@@ -730,16 +836,18 @@ function main() {
       process.exit(1);
     }
 
+    const divergences = [];
     for (const target of targets.targets) {
       const targetPath = path.resolve(target.path.replace(/^~/, HOME_DIR));
       if (!fs.existsSync(targetPath)) {
         console.log(`  ⚠ Skipping ${target.path} (not found)`);
         continue;
       }
-      installTarget(targetPath, profilesConfig, { copy: flags.copy });
+      installTarget(targetPath, profilesConfig, { copy: flags.copy, divergences });
     }
 
     console.log('\nSync complete!\n');
+    printDivergenceSummary(divergences);
     return;
   }
 
@@ -766,11 +874,13 @@ function main() {
   }
 
   console.log(`\nConfiguring Claude Code for: ${targetDir}\n`);
+  const divergences = [];
 
   const { isMonorepo } = installTarget(targetDir, profilesConfig, {
     copy: flags.copy,
     logProfiles: true,
     copyWorkspaceDocs: true,
+    divergences,
   });
 
   // Global settings check
@@ -790,6 +900,7 @@ function main() {
   }
 
   console.log('\nDone!\n');
+  printDivergenceSummary(divergences);
 }
 
 function checkGlobalSettings(manifest, projectSettingsPaths) {

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -924,6 +924,15 @@ function handleClaim(targetPath) {
     console.error(`  ✗ ${destPath} does not exist`);
     process.exit(1);
   }
+  // Guard: stampOrigin unconditionally prepends YAML frontmatter, which would
+  // corrupt JSON/non-markdown files. Match the scope handleForceAdopt enforces
+  // and the scope the --claim docblock advertises: skill/agent markdown only.
+  const calsuiteRel = destToCalsuiteRel(destPath);
+  if (!calsuiteRel || !destPath.endsWith('.md')) {
+    console.error(`  ✗ --claim only supports markdown files under a target's .claude/skills or .claude/agents`);
+    console.error(`    got: ${destPath}`);
+    process.exit(1);
+  }
   const targetName = deriveTargetName(destPath);
   const content = fs.readFileSync(destPath, 'utf8');
   const stamped = originProtocol.stampOrigin(content, targetName);

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -15,7 +15,8 @@
  *   --agents agent1,agent2,...   Install only specific agents (use with --only)
  *   --install-ccstatusline       Install ccstatusline config only
  *   --sync                       Re-run install against all targets in config/targets.json
- *   --copy                       Copy scripts instead of symlinking (for portability)
+ *   --copy                       (deprecated, no-op) formerly toggled script copy vs symlink;
+ *                                hook scripts are now referenced directly from $CALSUITE_DIR
  */
 
 const fs = require('fs');
@@ -25,8 +26,6 @@ const CONFIG_REPO = path.resolve(__dirname, '..');
 const HOOKS_JSON = path.join(CONFIG_REPO, 'hooks', 'hooks.json');
 const GLOBAL_MANIFEST = path.join(CONFIG_REPO, 'config', 'global-settings.json');
 const PROFILES_JSON = path.join(CONFIG_REPO, 'config', 'profiles.json');
-const SCRIPTS_HOOKS = path.join(CONFIG_REPO, 'scripts', 'hooks');
-const SCRIPTS_LIB = path.join(CONFIG_REPO, 'scripts', 'lib');
 const SKILLS_DIR = path.join(CONFIG_REPO, 'skills');
 const AGENTS_DIR = path.join(CONFIG_REPO, 'agents');
 const TEMPLATES_DIR = path.join(CONFIG_REPO, 'templates');
@@ -39,6 +38,32 @@ const HOME_MCP_JSON = path.join(HOME_DIR, '.mcp.json');
 const KNOWN_MARKETPLACES = path.join(HOME_DIR, '.claude', 'plugins', 'known_marketplaces.json');
 // Skills that only make sense in the config repo itself — never export to target repos
 const INTERNAL_SKILLS = new Set(['configure-claude', 'skill-builder']);
+
+/**
+ * Resolve the absolute path to the calsuite checkout on this machine.
+ * Order: $CALSUITE_DIR env var → ~/Projects/calsuite → installer's parent.
+ * The resolved path is written literally into target's settings.local.json —
+ * Claude Code's hook runner does not shell-expand hook commands, so embedded
+ * $VAR syntax would not work at runtime.
+ */
+function resolveCalsuiteDir() {
+  if (process.env.CALSUITE_DIR) return path.resolve(process.env.CALSUITE_DIR);
+  const defaultPath = path.join(HOME_DIR, 'Projects', 'calsuite');
+  if (fs.existsSync(defaultPath)) return defaultPath;
+  return CONFIG_REPO;
+}
+
+/**
+ * Substitute every occurrence of the ${CALSUITE_DIR} placeholder in a
+ * parsed hooks config with the resolved absolute path. Operates on the
+ * JSON-stringified form so it catches the placeholder regardless of which
+ * nested field it appears in.
+ */
+function substituteCalsuiteDir(hooksObj, calsuiteDir) {
+  const json = JSON.stringify(hooksObj);
+  const safeDir = calsuiteDir.replace(/\\/g, '\\\\');
+  return JSON.parse(json.replace(/\$\{CALSUITE_DIR\}/g, () => safeDir));
+}
 
 function copyDirSync(src, dest) {
   fs.mkdirSync(dest, { recursive: true });
@@ -70,36 +95,6 @@ function copyDirSyncNoOverwrite(src, dest) {
   }
 }
 
-function symlinkDirSync(src, dest) {
-  fs.mkdirSync(dest, { recursive: true });
-  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
-    const srcPath = path.join(src, entry.name);
-    const destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      symlinkDirSync(srcPath, destPath);
-    } else {
-      symlinkOrSkip(srcPath, destPath);
-    }
-  }
-}
-
-/**
- * Create or refresh a symlink. Replaces existing symlinks, skips real files/dirs.
- * Returns true if the symlink was created, false if skipped.
- */
-function symlinkOrSkip(srcPath, destPath) {
-  if (fs.existsSync(destPath)) {
-    const stat = fs.lstatSync(destPath);
-    if (stat.isSymbolicLink()) {
-      fs.unlinkSync(destPath);
-    } else {
-      return false; // Real file/directory — project-specific, skip
-    }
-  }
-  fs.symlinkSync(path.resolve(srcPath), destPath);
-  return true;
-}
-
 function mergeHooks(existingHooks, newHooks) {
   const merged = {};
   const allEvents = new Set([...Object.keys(existingHooks || {}), ...Object.keys(newHooks || {})]);
@@ -122,12 +117,6 @@ function readJsonSync(filePath) {
   } catch {
     return null;
   }
-}
-
-function resolveHookPaths(obj, claudeConfigDir) {
-  const json = JSON.stringify(obj);
-  const safeDir = claudeConfigDir.replace(/\\/g, '\\\\');
-  return JSON.parse(json.replace(/\$\{CLAUDE_CONFIG_DIR\}/g, () => safeDir));
 }
 
 // --- Profile detection ---
@@ -271,7 +260,6 @@ function findWorkspaces(targetDir) {
 // --- Installation ---
 
 function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
-  const useCopy = opts.copy || false;
   const claudeDir = path.join(targetDir, '.claude');
   const settingsPath = path.join(claudeDir, 'settings.json');
 
@@ -281,21 +269,9 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   fs.mkdirSync(claudeDir, { recursive: true });
   console.log(`  ✓ Ensured ${claudeDir} exists`);
 
-  // 2. Symlink (or copy) scripts/hooks/ and scripts/lib/
-  const destHooks = path.join(claudeDir, 'scripts', 'hooks');
-  const destLib = path.join(claudeDir, 'scripts', 'lib');
-
-  if (useCopy) {
-    copyDirSync(SCRIPTS_HOOKS, destHooks);
-    console.log(`  ✓ Copied hook scripts → ${destHooks}`);
-    copyDirSync(SCRIPTS_LIB, destLib);
-    console.log(`  ✓ Copied lib scripts  → ${destLib}`);
-  } else {
-    symlinkDirSync(SCRIPTS_HOOKS, destHooks);
-    console.log(`  ✓ Symlinked hook scripts → ${destHooks}`);
-    symlinkDirSync(SCRIPTS_LIB, destLib);
-    console.log(`  ✓ Symlinked lib scripts  → ${destLib}`);
-  }
+  // 2. Hook scripts (scripts/hooks/, scripts/lib/) are NOT copied or symlinked
+  //    into target/.claude/. Hook commands in settings.local.json reference them
+  //    directly from $CALSUITE_DIR, so there's no target-side footprint to manage.
 
   // 2b. Copy guardian rules config
   const guardianSrc = path.join(CONFIG_REPO, 'config', 'guardian-rules.json');
@@ -411,27 +387,69 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
     console.error('  ✗ hooks.json is missing "hooks" key');
     process.exit(1);
   }
-  const resolvedHooks = resolveHookPaths(hooksConfig.hooks, claudeDir);
 
-  // 7. Merge hooks and plugins into target settings.json
-  //    Uses _origin tags to replace only calsuite-managed hooks, preserving project-specific ones
+  // Substitute ${CALSUITE_DIR} with the literal absolute path. Claude Code's
+  // hook runner does not shell-expand command strings, so $VAR syntax cannot
+  // resolve at runtime — the installer must resolve it now.
+  const calsuiteDir = resolveCalsuiteDir();
+  const resolvedHooks = substituteCalsuiteDir(hooksConfig.hooks, calsuiteDir);
+
+  // 7. Write calsuite hooks into settings.local.json (gitignored, per-user).
+  //    settings.json is team-shared and must never contain per-machine paths.
+  const settingsLocalPath = path.join(claudeDir, 'settings.local.json');
+  const existingLocal = readJsonSync(settingsLocalPath) || {};
+  const mergedLocalHooks = mergeHooks(existingLocal.hooks, resolvedHooks);
+  const projectHookCount = Object.values(mergedLocalHooks)
+    .flat()
+    .filter(h => !h._origin || h._origin !== 'calsuite').length;
+  const calsuiteHookCount = Object.values(mergedLocalHooks)
+    .flat()
+    .filter(h => h._origin === 'calsuite').length;
+  const mergedLocal = {
+    ...existingLocal,
+    hooks: mergedLocalHooks,
+  };
+  fs.writeFileSync(settingsLocalPath, JSON.stringify(mergedLocal, null, 2) + '\n');
+  console.log(`  ✓ Wrote ${calsuiteHookCount} calsuite hook(s) to ${settingsLocalPath}${projectHookCount > 0 ? ` (preserved ${projectHookCount} project-specific hook(s))` : ''}`);
+
+  // 8. Update target settings.json with plugins + guardian permissions only.
+  //    Migration: strip any legacy calsuite-origin hooks that earlier versions
+  //    of this installer wrote into settings.json; those now belong in
+  //    settings.local.json and would otherwise be duplicated.
   const existingSettings = readJsonSync(settingsPath) || {};
+  const legacyHooks = existingSettings.hooks || {};
+  const cleanedHooks = {};
+  let migratedCount = 0;
+  for (const [event, entries] of Object.entries(legacyHooks)) {
+    const kept = Array.isArray(entries)
+      ? entries.filter(e => e._origin !== 'calsuite')
+      : entries;
+    if (Array.isArray(entries)) {
+      migratedCount += entries.length - kept.length;
+    }
+    if (!Array.isArray(entries) || kept.length > 0) {
+      cleanedHooks[event] = kept;
+    }
+  }
+  if (migratedCount > 0) {
+    console.log(`  ✓ Removed ${migratedCount} legacy calsuite hook(s) from ${settingsPath} (now in settings.local.json)`);
+  }
+
   const pluginsToEnable = {};
   for (const plugin of resolvedProfile.plugins) {
     pluginsToEnable[plugin] = true;
   }
 
-  const mergedHooks = mergeHooks(existingSettings.hooks, resolvedHooks);
-  const projectHookCount = Object.values(mergedHooks)
-    .flat()
-    .filter(h => !h._origin || h._origin !== 'calsuite').length;
-
   const merged = {
     ...existingSettings,
     ...(hooksConfig.$schema ? { $schema: hooksConfig.$schema } : {}),
-    hooks: mergedHooks,
     enabledPlugins: { ...existingSettings.enabledPlugins, ...pluginsToEnable },
   };
+  if (Object.keys(cleanedHooks).length > 0) {
+    merged.hooks = cleanedHooks;
+  } else {
+    delete merged.hooks;
+  }
 
   // Derive permissions from guardian-rules.json (single source of truth).
   // On re-install, this replaces the entire allow list to prevent drift.
@@ -449,16 +467,7 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   }
 
   fs.writeFileSync(settingsPath, JSON.stringify(merged, null, 2) + '\n');
-  console.log(`  ✓ Merged hooks into ${settingsPath}${projectHookCount > 0 ? ` (preserved ${projectHookCount} project-specific hook(s))` : ''}`);
-  console.log(`  ✓ Enabled ${resolvedProfile.plugins.length} plugin(s) in project settings`);
-
-  // Verify no unresolved placeholders remain
-  const written = fs.readFileSync(settingsPath, 'utf8');
-  if (written.includes('${CLAUDE_CONFIG_DIR}')) {
-    console.error('  ✗ WARNING: Unresolved ${CLAUDE_CONFIG_DIR} found in settings.json');
-  } else {
-    console.log('  ✓ All hook paths resolved (no ${CLAUDE_CONFIG_DIR} remaining)');
-  }
+  console.log(`  ✓ Updated ${settingsPath} (plugins + permissions; no hooks/paths)`);
 }
 
 function installCcstatuslineConfig(manifest) {

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -454,17 +454,21 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   const guardianDest = path.join(claudeDir, 'config', 'guardian-rules.json');
   if (fs.existsSync(guardianSrc)) {
     fs.mkdirSync(path.join(claudeDir, 'config'), { recursive: true });
-    fs.copyFileSync(guardianSrc, guardianDest);
-    console.log(`  ✓ Copied guardian rules → ${guardianDest}`);
+    if (!fs.existsSync(guardianDest)) {
+      fs.copyFileSync(guardianSrc, guardianDest);
+      console.log(`  ✓ Seeded guardian rules → ${guardianDest}`);
+    }
   }
 
-  // 2c. Copy agent lint rules config
+  // 2c. Copy agent lint rules config (no-overwrite — user is expected to tune)
   const agentRulesSrc = path.join(LINT_CONFIGS_DIR, 'agent-rules.json');
   const agentRulesDest = path.join(claudeDir, 'config', 'agent-rules.json');
   if (fs.existsSync(agentRulesSrc)) {
     fs.mkdirSync(path.join(claudeDir, 'config'), { recursive: true });
-    fs.copyFileSync(agentRulesSrc, agentRulesDest);
-    console.log(`  ✓ Copied agent lint rules → ${agentRulesDest}`);
+    if (!fs.existsSync(agentRulesDest)) {
+      fs.copyFileSync(agentRulesSrc, agentRulesDest);
+      console.log(`  ✓ Seeded agent lint rules → ${agentRulesDest}`);
+    }
   }
 
   // 2d. Copy ESLint base configs (no-overwrite — respect existing project configs)

--- a/scripts/lib/origin-protocol.cjs
+++ b/scripts/lib/origin-protocol.cjs
@@ -1,0 +1,162 @@
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+const ORIGIN_LINE_RE = /^_origin:\s*(.+?)\s*$/m;
+
+function parseFrontmatter(content) {
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) return { frontmatter: {}, body: content, hasFrontmatter: false, raw: '' };
+  const fm = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (kv) fm[kv[1]] = kv[2].trim();
+  }
+  return {
+    frontmatter: fm,
+    body: content.slice(match[0].length),
+    hasFrontmatter: true,
+    raw: match[0],
+    rawBody: match[1],
+  };
+}
+
+function readOrigin(content) {
+  return parseFrontmatter(content).frontmatter._origin || null;
+}
+
+/**
+ * Stamp `_origin: <value>` into the file. Adds a new frontmatter block if
+ * none exists; otherwise replaces or prepends within the existing block.
+ */
+function stampOrigin(content, originValue) {
+  const parsed = parseFrontmatter(content);
+  if (!parsed.hasFrontmatter) {
+    return `---\n_origin: ${originValue}\n---\n\n${content}`;
+  }
+  let newBody;
+  if (ORIGIN_LINE_RE.test(parsed.rawBody)) {
+    newBody = parsed.rawBody.replace(ORIGIN_LINE_RE, `_origin: ${originValue}`);
+  } else {
+    newBody = `_origin: ${originValue}\n${parsed.rawBody}`;
+  }
+  return `---\n${newBody}\n---\n${parsed.body.startsWith('\n') ? '' : '\n'}${parsed.body}`;
+}
+
+/**
+ * Normalize content for byte-equality comparison. Used on both sides of
+ * dest-vs-calsuite-content diffs so the comparison only flags *intentional*
+ * divergence, not superficial things like:
+ * - `_origin:` lines present on one side but not the other
+ * - CRLF vs LF line endings
+ * - The leading blank line that appears below a frontmatter block that
+ *   becomes empty after `_origin` stripping
+ * - Trailing whitespace
+ *
+ * Calsuite source files never carry `_origin`; target files do once stamped.
+ */
+function normalizeForCompare(content) {
+  const parsed = parseFrontmatter(content);
+  let body;
+  let fm;
+  if (parsed.hasFrontmatter) {
+    const kept = parsed.rawBody
+      .split(/\r?\n/)
+      .filter(line => !ORIGIN_LINE_RE.test(line))
+      .join('\n')
+      .trim();
+    fm = kept ? `---\n${kept}\n---\n` : '';
+    body = parsed.body;
+  } else {
+    fm = '';
+    body = content;
+  }
+  return (fm + body)
+    .replace(/\r\n/g, '\n')
+    .replace(/^\n+/, '')
+    .replace(/\s+$/, '');
+}
+
+/**
+ * Read the content a file had at a given git sha inside calsuite. Returns
+ * null if the path didn't exist at that sha (or git isn't available).
+ */
+function contentAtSha(calsuiteRelPath, sha, calsuiteDir) {
+  try {
+    return execFileSync('git', ['show', `${sha}:${calsuiteRelPath}`], {
+      cwd: calsuiteDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function currentCalsuiteSha(calsuiteDir) {
+  try {
+    return execFileSync('git', ['rev-parse', '--short=7', 'HEAD'], {
+      cwd: calsuiteDir,
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Decide what to do with a single calsuite-managed file during sync.
+ * Returns one of:
+ *   'write-new'     dest missing — fresh write + stamp
+ *   'write-update'  dest calsuite-managed and unchanged since install — safe overwrite
+ *   'migrate'       dest has no _origin but content matches calsuite current — stamp in place
+ *   'skip-diverged' dest calsuite-managed but user edited — skip, flag
+ *   'skip-unknown'  dest has no _origin and content differs — pre-protocol edit or stale, skip, flag
+ *   'skip-claimed'  dest has _origin pointing somewhere other than calsuite — user-owned, skip silently
+ */
+function decideFileAction(destPath, calsuiteRelPath, calsuiteDir) {
+  if (!fs.existsSync(destPath)) {
+    return { action: 'write-new' };
+  }
+
+  const destContent = fs.readFileSync(destPath, 'utf8');
+  const origin = readOrigin(destContent);
+
+  const calsuiteAbsPath = path.join(calsuiteDir, calsuiteRelPath);
+  const calsuiteCurrent = fs.existsSync(calsuiteAbsPath)
+    ? fs.readFileSync(calsuiteAbsPath, 'utf8')
+    : null;
+
+  if (origin && origin.startsWith('calsuite@')) {
+    const installSha = origin.slice('calsuite@'.length);
+    const atSha = contentAtSha(calsuiteRelPath, installSha, calsuiteDir);
+    if (atSha === null) {
+      return { action: 'skip-unknown', reason: `origin sha ${installSha} has no record of ${calsuiteRelPath}` };
+    }
+    if (normalizeForCompare(destContent) === normalizeForCompare(atSha)) {
+      return { action: 'write-update' };
+    }
+    return { action: 'skip-diverged', reason: `user-modified since ${installSha}` };
+  }
+
+  if (origin) {
+    return { action: 'skip-claimed', reason: `claimed as ${origin}` };
+  }
+
+  if (calsuiteCurrent !== null &&
+      normalizeForCompare(destContent) === normalizeForCompare(calsuiteCurrent)) {
+    return { action: 'migrate' };
+  }
+  return { action: 'skip-unknown', reason: 'no _origin marker and content diverges from current calsuite' };
+}
+
+module.exports = {
+  parseFrontmatter,
+  readOrigin,
+  stampOrigin,
+  normalizeForCompare,
+  contentAtSha,
+  currentCalsuiteSha,
+  decideFileAction,
+};

--- a/scripts/lib/origin-protocol.cjs
+++ b/scripts/lib/origin-protocol.cjs
@@ -37,7 +37,9 @@ function stampOrigin(content, originValue) {
   }
   let newBody;
   if (ORIGIN_LINE_RE.test(parsed.rawBody)) {
-    newBody = parsed.rawBody.replace(ORIGIN_LINE_RE, `_origin: ${originValue}`);
+    // Function replacer — string form would interpret `$1`/`$&` sequences
+    // if originValue ever contained them (target basenames in exotic dirs).
+    newBody = parsed.rawBody.replace(ORIGIN_LINE_RE, () => `_origin: ${originValue}`);
   } else {
     newBody = `_origin: ${originValue}\n${parsed.rawBody}`;
   }
@@ -79,29 +81,61 @@ function normalizeForCompare(content) {
 }
 
 /**
- * Read the content a file had at a given git sha inside calsuite. Returns
- * null if the path didn't exist at that sha (or git isn't available).
+ * Read the content a file had at a given git sha inside calsuite.
+ *
+ * Returns null ONLY when git reports the path/sha is unknown to the repo
+ * (benign: "file didn't exist at that commit"). Any other failure — git not
+ * installed, shallow-clone pruning, repo corruption — throws, because the
+ * caller's `skip-unknown` path would otherwise silently route every managed
+ * file to the divergence queue on every sync.
  */
 function contentAtSha(calsuiteRelPath, sha, calsuiteDir) {
   try {
     return execFileSync('git', ['show', `${sha}:${calsuiteRelPath}`], {
       cwd: calsuiteDir,
       encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
+      stdio: ['ignore', 'pipe', 'pipe'],
     });
-  } catch {
-    return null;
+  } catch (err) {
+    const stderr = err.stderr ? err.stderr.toString() : '';
+    const benignMissing =
+      /fatal: invalid object name/i.test(stderr) ||
+      /fatal: bad revision/i.test(stderr) ||
+      /path .* does not exist in/i.test(stderr) ||
+      /exists on disk, but not in/i.test(stderr);
+    if (benignMissing) return null;
+
+    throw new Error(
+      `git show ${sha}:${calsuiteRelPath} failed unexpectedly in ${calsuiteDir}.\n` +
+      `This is not a "path didn't exist at that sha" error — the _origin protocol ` +
+      `cannot proceed without historical content comparison.\n` +
+      `Git reported: ${stderr.trim() || err.message}`
+    );
   }
 }
 
+/**
+ * Return calsuite's current HEAD sha (7-char). Throws on failure rather
+ * than returning a fallback string — stamping every file with
+ * `_origin: calsuite@<fallback>` would break future syncs permanently,
+ * because `contentAtSha(..., <fallback>, ...)` would return null for
+ * every file and route them all to skip-unknown.
+ */
 function currentCalsuiteSha(calsuiteDir) {
   try {
     return execFileSync('git', ['rev-parse', '--short=7', 'HEAD'], {
       cwd: calsuiteDir,
       encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
     }).trim();
-  } catch {
-    return 'unknown';
+  } catch (err) {
+    const stderr = err.stderr ? err.stderr.toString() : '';
+    throw new Error(
+      `Unable to determine calsuite HEAD sha via 'git rev-parse' in ${calsuiteDir}.\n` +
+      `The _origin protocol requires a real sha to stamp into every distributed file.\n` +
+      `Git reported: ${stderr.trim() || err.message}\n` +
+      `Fix: ensure calsuite is a git checkout with an accessible HEAD (not detached, not shallow-pruned, git binary on PATH).`
+    );
   }
 }
 

--- a/specs/personal-harness-refactor/design.md
+++ b/specs/personal-harness-refactor/design.md
@@ -1,0 +1,157 @@
+# Design: Personal Harness Distribution Refactor
+
+## Context
+
+Calsuite is a personal dotfiles-style config harness. Its assets (hooks, skills, agents, configs) are installed into per-user target repos under `~/Projects/`. The current installer conflates three distinct distribution problems into one mechanism, which leaks machine-specific paths into committed files and silently overwrites downstream edits.
+
+Downstream review (verity, PR #453) surfaced the critical symptom: committing `.claude/settings.json` populated by calsuite produces 24 occurrences of `/Users/callumke/Projects/verity/.claude/...` absolute paths, breaking every other collaborator's checkout and CI. Earlier in the same conversation we also confirmed that the `copyDirSync`-based skill distribution unconditionally clobbered local target edits on every `--sync`.
+
+## Goals
+
+1. **Nothing calsuite writes into a target repo's tracked files should break another collaborator's checkout.** Machine-specific state (absolute paths, symlinks to calsuite, any personal tooling) lives in gitignored paths only.
+2. **Shared content (skills, agents, review checklists) can still be committed and team-visible** — but the installer must never silently overwrite a target's local edits to that content.
+3. **First-time and upgrading targets both work.** Targets onboarded before any given protocol change must migrate without data loss and without a manual big-bang command.
+
+## Non-goals
+
+- LLM-mediated sync. Mechanical sync is the baseline; `/reconcile-targets` (agentic) is a separate follow-up skill.
+- Profile curation for skills. Every non-internal skill flows to every target; invocation-time descriptions govern what Claude actually uses.
+- Supporting calsuite being checked out at arbitrary paths. We require it on the user's machine, but the location is configurable via `$CALSUITE_DIR` (default `~/Projects/calsuite`).
+
+## Architecture
+
+Three distribution tiers, each sized to the portability requirement of the asset it carries.
+
+```mermaid
+flowchart LR
+    subgraph SRC["calsuite/ (source of truth)"]
+        direction TB
+        S1["scripts/hooks/*.cjs<br/>scripts/lib/*.cjs"]
+        S2["hooks/hooks.json<br/>(template w/ $CALSUITE_DIR)"]
+        S3["skills/*<br/>agents/*<br/>review checklist, templates"]
+        S4["config/*.json<br/>config/lint-configs/*<br/>templates/specs/"]
+    end
+
+    subgraph PERSONAL["target/.claude/settings.local.json (gitignored)"]
+        P1["Hook wiring<br/>absolute paths via $CALSUITE_DIR"]
+    end
+
+    subgraph SHARED["target/.claude/* (committed, team-visible)"]
+        T1["skills/<name>/SKILL.md<br/>agents/<name>.md<br/>(with _origin: calsuite@sha frontmatter)"]
+        T2["config/guardian-rules.json<br/>config/agent-rules.json<br/>.eslintrc.json<br/>(copied, no-overwrite)"]
+    end
+
+    subgraph RUNTIME["$CALSUITE_DIR (user's local checkout)"]
+        R1["scripts/hooks/ and scripts/lib/<br/>(invoked directly from calsuite — no symlinks)"]
+    end
+
+    S1 -.->|resolved at runtime<br/>from settings.local.json| R1
+    S2 -->|installer<br/>$CALSUITE_DIR-templated| P1
+    S3 -->|installer<br/>copy + _origin + skip-on-divergence| T1
+    S4 -->|installer<br/>copy-no-overwrite| T2
+```
+
+**Key shift from current state:**
+
+| Asset | Current | New |
+|---|---|---|
+| Hook scripts | Symlinked into `target/.claude/scripts/hooks/` (absolute filesystem symlinks) | Not copied or symlinked — hook commands in `settings.local.json` reference `$CALSUITE_DIR/scripts/hooks/*.cjs` directly. `.claude/scripts/` is no longer populated by the installer. |
+| Hook wiring (JSON) | `resolveHookPaths()` pre-resolves `${CLAUDE_CONFIG_DIR}` to an absolute path, written into `settings.json` (committed) | Written to `settings.local.json` (gitignored) with `$CALSUITE_DIR` absolute paths. `resolveHookPaths` deleted. |
+| Skills and agents | `copyDirSync`/`copyFileSync` → unconditional overwrite on every `--sync` | Copied with `_origin: calsuite@<sha>` frontmatter, safe-overwrite protocol (see below) |
+| Parent-level symlinks | `syncParentAssets()` creates `~/Projects/.claude/skills/` and `agents/` — load-bearing for the (never-supported) parent-dir inheritance model | Removed. `syncParentAssets()` + `PARENT_CLAUDE_DIR` are deleted as dead code. |
+
+## The `_origin` safe-overwrite protocol
+
+Every calsuite-distributed skill / agent file carries a frontmatter marker stamped at install time:
+
+```yaml
+---
+_origin: calsuite@a49a827
+...
+---
+```
+
+`a49a827` is calsuite's HEAD commit sha at the moment the file was written into the target.
+
+On every `--sync`, the installer decides what to do with each dest file by running through this matrix:
+
+| Dest file state | Action |
+|---|---|
+| Does not exist | Write calsuite's current content, stamp `_origin: calsuite@<current-sha>`. |
+| Has `_origin: calsuite@<sha>`, content matches calsuite's content at `<sha>` | Safe to overwrite — stamp with `<current-sha>`. |
+| Has `_origin: calsuite@<sha>`, content differs from calsuite's content at `<sha>` | User edited after install — skip. Log: `skills/ship/SKILL.md: user-modified, skipped. Use --reconcile to resolve.` |
+| Has `_origin: <anything-else>` (e.g. `_origin: verity`) | User claimed ownership — never touch. |
+| No `_origin` marker, content byte-identical to calsuite's **current** version | Pristine pre-protocol file — stamp `_origin: calsuite@<current-sha>` in place, no content change. Auto-migrates silently. |
+| No `_origin` marker, content differs from calsuite's current | Pre-protocol edit **or** stale old version — can't tell which. Skip. Log prominently: `skills/ship/SKILL.md: no _origin marker and content diverges. Skipped. Run --reconcile skills/ship to resolve.` |
+
+**Migration semantics** — the matrix auto-handles existing targets without a separate migration command:
+- Targets onboarded after this lands get `_origin` from day one.
+- Targets onboarded before this lands have no `_origin`. If they never diverged from what calsuite shipped, they fall into the fifth row (byte-identical → auto-stamp). If they did diverge or are stale, they fall into the sixth row (skip + flag).
+- In either case: **no data loss**.
+
+**Content-at-sha lookup** — calsuite is a git repo on the user's machine. To compare dest against calsuite's content at `<sha>`, the installer runs `git show <sha>:<path>` inside `$CALSUITE_DIR`. No separate manifest to maintain.
+
+**Frontmatter-only diffs** — comparing dest content against calsuite content must exclude the `_origin` line itself (since calsuite's source never has `_origin` but dest always does once stamped). Simplest implementation: strip any `_origin:` line from both sides before diffing.
+
+## The gitignore layer
+
+The installer manages gitignore entries in every target repo (root + detected monorepo workspaces):
+
+```
+# calsuite (personal harness) — never commit
+.claude/settings.local.json
+```
+
+That single line is sufficient **given** the architecture above — hook scripts are no longer placed under `.claude/scripts/`, so there's nothing else machine-specific to ignore.
+
+Installer behavior:
+- On install, read target's `.gitignore`. If the calsuite line is missing, append it under a `# calsuite (personal harness)` comment header.
+- In monorepos, do the same in each detected workspace (`backend/.gitignore`, `frontend/.gitignore`, etc.).
+- Never remove entries the user has added. Only additive.
+
+## `$CALSUITE_DIR` resolution
+
+The installer resolves calsuite's location in this order:
+1. `$CALSUITE_DIR` env var, if set.
+2. Default: `~/Projects/calsuite` (resolved via `os.homedir()`).
+3. Fallback: `path.resolve(__dirname, '..')` (the installer is always inside calsuite).
+
+The resolved value is written as a literal absolute path into target's `settings.local.json`. Users who keep calsuite elsewhere set `CALSUITE_DIR=/path/to/theirs` in their shell profile before running the installer.
+
+Each collaborator runs the installer themselves — there is no expectation that `settings.local.json` is portable across developers.
+
+## Key Decisions
+
+| Decision | Options Considered | Choice | Rationale |
+|----------|-------------------|--------|-----------|
+| Where hook wiring lives | `settings.json` (committed) · `settings.local.json` (gitignored) · `~/.claude/settings.json` (user-global) | `settings.local.json` | Hooks are personal tooling but reference per-project `$CALSUITE_DIR` paths. User-global loses project scoping. Committed version breaks every collaborator. |
+| Hook scripts distribution | Symlink into target's `.claude/scripts/` · Copy into target · Reference calsuite directly via `$CALSUITE_DIR` | Reference directly | Symlinks broke for non-Callum checkouts; copies added machine-state to the tracked tree. Direct reference keeps `.claude/scripts/` out of the picture entirely. |
+| Skill/agent distribution | Inherit from `~/Projects/.claude/` (docs-confirmed broken) · Symlink per-target (edits leak upstream) · Copy with `_origin` (this) | Copy with `_origin` | User explicitly picked this in conversation. Preserves local divergence and doesn't require a load-bearing undocumented hierarchy. |
+| Migration strategy | Big-bang `--migrate` command · Stamp-on-first-write with content-hash check (this) · Assume all pre-protocol files are managed | Stamp with content check | Auto-handles the common case (unchanged file → auto-stamp) without forcing users through a migration flow. Safely skips divergent files for explicit reconciliation. |
+| Content comparison method | Stored hash manifest · `git show <sha>:path` (this) | `git show` | Calsuite is already a git repo; no manifest to maintain. Bounded I/O per file. |
+| Keep `syncParentAssets()`? | Keep (dormant) · Delete | Delete | Dead code under the real hierarchy rules. Its symlinks at `~/Projects/.claude/` do nothing today and create stale state tomorrow. |
+| Precedence of target `settings.json` | Touched by installer · Untouched (this) | Untouched | Team-shared settings are the team's to own. Calsuite has no business writing there. |
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Target has a pre-protocol file that's been edited locally; installer sees divergence and skips. User doesn't notice the log line and the file stays stale. | Medium | Medium — user keeps running old skill behavior | Log divergences prominently at the top of `--sync` output (not just per-file). Include a `--reconcile <path>` helper that interactively prompts to keep local, adopt calsuite's version, or three-way merge. |
+| `$CALSUITE_DIR` resolution depends on shell env; editor or CI run of Claude Code may not inherit it | Low | Low — hooks fail to fire | Default fallback (`~/Projects/calsuite`) covers the common case. Hook commands that fail gracefully (early-exit on missing file) keep the runtime robust. |
+| Content comparison excludes `_origin:` line — if the line is malformed (e.g. hand-edited to break YAML) the parse step could fail and the file gets skipped incorrectly | Low | Low | Tolerant parse: if frontmatter is invalid YAML, treat as "no `_origin`" and fall into the migration path. |
+| User adds a new skill directly in target's `.claude/skills/` without `_origin`; calsuite has a skill with the same name. First sync auto-migrates by filename match, clobbering the user's skill. | Low | High — silent data loss | Auto-stamp only when dest content is **byte-identical** to calsuite's current version. Different content → skip + flag. Filename collision alone does NOT trigger overwrite. |
+| Monorepo workspace detection misses a workspace, so its gitignore doesn't get the calsuite line; a collaborator checks out and sees `settings.local.json` | Low | Medium — embarrassment, not data loss | Detection is already exercised by the existing per-workspace install flow. Regression test: `/tmp/test-monorepo` fixture with detectable backend/frontend dirs. |
+| Stale `~/Projects/.claude/` dirs from the old `syncParentAssets()` model linger after this refactor ships | Certain | Low — cosmetic only | Call this out in the CHANGELOG migration note. Optionally add a `--prune-stale` flag for opt-in cleanup. |
+
+## Dependencies
+
+- Calsuite must be a reachable git repo on the user's machine (required for `git show <sha>:<path>` lookups).
+- Target repos use `.claude/settings.local.json` as defined by Claude Code's native precedence — no custom patching of Claude Code.
+- `$CALSUITE_DIR` (optional) in user's shell profile if calsuite lives outside `~/Projects/calsuite`.
+
+## Out of scope / future work
+
+- `/reconcile-targets` agentic skill — on-demand LLM-mediated review of flagged divergences, upstream/cross-port decisions, PR opening. Second-layer on top of this mechanical sync.
+- `--prune-stale` flag — opt-in cleanup of orphaned dirs/files left over from prior distribution models (old `.claude/skills/`, old `~/Projects/.claude/*`).
+- `--reconcile <path>` interactive helper for individual file divergences.
+- Hash manifest vs. `git show` — revisit if `git show` performance becomes a bottleneck with many targets.

--- a/specs/personal-harness-refactor/design.md
+++ b/specs/personal-harness-refactor/design.md
@@ -151,7 +151,12 @@ Each collaborator runs the installer themselves — there is no expectation that
 
 ## Out of scope / future work
 
-- `/reconcile-targets` agentic skill — on-demand LLM-mediated review of flagged divergences, upstream/cross-port decisions, PR opening. Second-layer on top of this mechanical sync.
-- `--prune-stale` flag — opt-in cleanup of orphaned dirs/files left over from prior distribution models (old `.claude/skills/`, old `~/Projects/.claude/*`).
-- `--reconcile <path>` interactive helper for individual file divergences.
-- Hash manifest vs. `git show` — revisit if `git show` performance becomes a bottleneck with many targets.
+Tracked as issues so they don't get lost:
+
+- **[#40](https://github.com/ckallum/calsuite/issues/40) — `/reconcile-targets` agentic skill.** On-demand LLM-mediated review of flagged divergences, upstream/cross-port decisions, PR opening. Second-layer on top of this mechanical sync.
+- **[#41](https://github.com/ckallum/calsuite/issues/41) — `--prune-stale` flag.** Opt-in cleanup of orphaned dirs/files left over from prior distribution models (old `.claude/scripts/`, old `~/Projects/.claude/*`, stale pre-protocol skill copies).
+- **[#42](https://github.com/ckallum/calsuite/issues/42) — `--reconcile <path>` interactive helper.** Single-file divergence resolver with three-way merge support.
+
+Not tracked as an issue (monitor and revisit if/when it matters):
+
+- **Hash manifest vs. `git show`** — the current design uses `git show <sha>:<path>` inside `$CALSUITE_DIR` to retrieve historical calsuite content. If performance becomes a bottleneck with many targets (e.g. 20+ repos × dozens of files per sync), consider pre-computing and shipping a hash manifest instead. No action until measured.

--- a/specs/personal-harness-refactor/design.md
+++ b/specs/personal-harness-refactor/design.md
@@ -27,13 +27,13 @@ flowchart LR
     subgraph SRC["calsuite/ (source of truth)"]
         direction TB
         S1["scripts/hooks/*.cjs<br/>scripts/lib/*.cjs"]
-        S2["hooks/hooks.json<br/>(template w/ $CALSUITE_DIR)"]
-        S3["skills/*<br/>agents/*<br/>review checklist, templates"]
+        S2["hooks/hooks.json<br/>(template, $CALSUITE_DIR resolved at install)"]
+        S3["skills/*/*.md<br/>agents/*.md<br/>(markdown with YAML frontmatter)"]
         S4["config/*.json<br/>config/lint-configs/*<br/>templates/specs/"]
     end
 
     subgraph PERSONAL["target/.claude/settings.local.json (gitignored)"]
-        P1["Hook wiring<br/>absolute paths via $CALSUITE_DIR"]
+        P1["Hook wiring<br/>literal absolute paths<br/>(e.g. /Users/me/Projects/calsuite/...)"]
     end
 
     subgraph SHARED["target/.claude/* (committed, team-visible)"]
@@ -60,9 +60,35 @@ flowchart LR
 | Skills and agents | `copyDirSync`/`copyFileSync` → unconditional overwrite on every `--sync` | Copied with `_origin: calsuite@<sha>` frontmatter, safe-overwrite protocol (see below) |
 | Parent-level symlinks | `syncParentAssets()` creates `~/Projects/.claude/skills/` and `agents/` — load-bearing for the (never-supported) parent-dir inheritance model | Removed. `syncParentAssets()` + `PARENT_CLAUDE_DIR` are deleted as dead code. |
 
+## Scope of the `_origin` protocol — what it applies to, what it doesn't
+
+The safe-overwrite protocol applies **only to markdown files under `skills/*` and `agents/*`** — i.e., files that can host YAML frontmatter. Everything else follows a different distribution path:
+
+| Asset class | Distribution | Why |
+|---|---|---|
+| `skills/<name>/SKILL.md` | `_origin` protocol | Already has YAML frontmatter; the natural place for a provenance field. |
+| `skills/<name>/*.md` (supporting files — `checklist.md`, `pr-template.md`, `greptile-triage.md`, etc.) | `_origin` protocol | Installer stamps a YAML frontmatter block at the top if one isn't already present. Markdown tolerates leading YAML blocks. |
+| `agents/*.md` | `_origin` protocol | Same as SKILL.md. |
+| `config/*.json`, `config/lint-configs/*.json`, `.eslintrc.json` | Copy-no-overwrite (S4) | JSON has no universal frontmatter convention. Schema validators would reject an unknown `_origin` field. Users override by editing their local copy (never touched again). |
+| `templates/specs/*.md` | Copy-no-overwrite (S4) | Templates are for downstream projects' spec authoring — once seeded, they're the project's. Calsuite should never push updates. |
+| Non-markdown files inside a skill dir (rare — a future `scripts/helper.py` or similar) | Fallback: sidecar `<filename>.origin` file next to it | Edge case. If it materializes, revisit before adding complexity. |
+
+Supporting markdown files that lack frontmatter today (e.g. `skills/review/checklist.md`, `skills/ship/pr-template.md`) get a YAML block added at the top on first install:
+
+```markdown
+---
+_origin: calsuite@a49a827
+---
+
+# Pre-Landing Review Checklist
+...
+```
+
+Markdown renderers ignore leading YAML blocks (most treat them as frontmatter, some render them as a code block at worst — cosmetic, not a break).
+
 ## The `_origin` safe-overwrite protocol
 
-Every calsuite-distributed skill / agent file carries a frontmatter marker stamped at install time:
+Every calsuite-distributed markdown file under `skills/` or `agents/` carries a frontmatter marker stamped at install time:
 
 ```yaml
 ---
@@ -93,6 +119,36 @@ On every `--sync`, the installer decides what to do with each dest file by runni
 
 **Frontmatter-only diffs** — comparing dest content against calsuite content must exclude the `_origin` line itself (since calsuite's source never has `_origin` but dest always does once stamped). Simplest implementation: strip any `_origin:` line from both sides before diffing.
 
+**Line-ending normalization** — content comparison runs on LF-normalized strings (`content.replace(/\r\n/g, '\n')` on both sides before diffing). Single-user calsuite in practice means this rarely matters, but without it a CRLF-editor touching a target would mark every file as divergent forever.
+
+## Escape hatches shipping with this refactor
+
+Row 6 of the safe-overwrite matrix (no `_origin` + content differs) creates a terminal skipped state. Without an exit, users would be stuck until the full interactive `--reconcile` helper lands (issue #42). Two minimal unblocker commands ship **in this PR**:
+
+- `node scripts/configure-claude.js --force-adopt <target>/<path>` — Overwrites the target file with calsuite's current content and stamps `_origin: calsuite@<current-sha>`. Destroys local edits. One-line confirmation prompt; `--yes` to skip.
+- `node scripts/configure-claude.js --claim <target>/<path>` — Reads the target file, stamps `_origin: <target-name>` (e.g. `verity`) in frontmatter, writes back. Marks the file as user-owned so sync never touches it again. Preserves local edits.
+
+These are ~20 lines apiece. The full three-way merge helper (issue #42) can come later; these two cover the urgent "I need to resolve this one file NOW" case.
+
+## Transition-day UX
+
+First `--sync` after this lands will flag every pre-protocol file across every target. To avoid a wall of noise with no actionable takeaway:
+
+- Per-file skip messages logged at info level.
+- **One-line summary at the end of `--sync`**: `N files skipped pending reconciliation across M targets. Run --reconcile <path>, --force-adopt <path>, or --claim <path> to resolve.`
+- CHANGELOG entry for the version that ships this must flag the migration explicitly (new "Breaking / migration" subsection with the expected log output and the resolution commands).
+
+## Automatic cleanup of prior-install stale symlinks
+
+On each `--sync`, after primary asset distribution, the installer inspects each target's `.claude/scripts/hooks/` and `.claude/scripts/lib/` directories:
+
+- If the directory exists AND every entry in it is a symbolic link pointing into `$CALSUITE_DIR` → safe to remove the whole directory.
+- If ANY entry is a real file or a symlink to elsewhere → leave the directory alone. User-added scripts are preserved.
+
+This is idempotent: first sync removes the stale calsuite-only dir; subsequent syncs see nothing to do. Avoids the situation where six months from now a collaborator clones a target and is confused by broken symlinks to `/Users/callumke/...`.
+
+This is the certain-safe subset of `--prune-stale` (issue #41); the broader cleanup stays opt-in under that flag.
+
 ## The gitignore layer
 
 The installer manages gitignore entries in every target repo (root + detected monorepo workspaces):
@@ -116,9 +172,9 @@ The installer resolves calsuite's location in this order:
 2. Default: `~/Projects/calsuite` (resolved via `os.homedir()`).
 3. Fallback: `path.resolve(__dirname, '..')` (the installer is always inside calsuite).
 
-The resolved value is written as a literal absolute path into target's `settings.local.json`. Users who keep calsuite elsewhere set `CALSUITE_DIR=/path/to/theirs` in their shell profile before running the installer.
+**The resolved value is written as a literal absolute path into `settings.local.json`** — e.g. `"node \"/Users/me/Projects/calsuite/scripts/hooks/guardian.cjs\""`, not `"node \"$CALSUITE_DIR/scripts/hooks/guardian.cjs\""`. Claude Code's hook runner doesn't shell-expand the command string, so embedded `$VAR` syntax wouldn't work at runtime. `$CALSUITE_DIR` is the *installer's* environment concern only.
 
-Each collaborator runs the installer themselves — there is no expectation that `settings.local.json` is portable across developers.
+Users who keep calsuite elsewhere set `CALSUITE_DIR=/path/to/theirs` in their shell profile and re-run the installer. Each collaborator runs the installer themselves — there is no expectation that `settings.local.json` is portable across developers.
 
 ## Key Decisions
 
@@ -136,7 +192,8 @@ Each collaborator runs the installer themselves — there is no expectation that
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Target has a pre-protocol file that's been edited locally; installer sees divergence and skips. User doesn't notice the log line and the file stays stale. | Medium | Medium — user keeps running old skill behavior | Log divergences prominently at the top of `--sync` output (not just per-file). Include a `--reconcile <path>` helper that interactively prompts to keep local, adopt calsuite's version, or three-way merge. |
+| Target has a pre-protocol file that's been edited locally; installer sees divergence and skips. User doesn't notice the log line and the file stays stale. | Medium | Medium — user keeps running old skill behavior | One-line summary at the end of `--sync` (count + resolution commands). `--force-adopt <path>` and `--claim <path>` escape hatches ship in this PR. Full interactive `--reconcile <path>` in issue #42. |
+| Auto-adding frontmatter to previously-unfrontmatter'd supporting markdown files (e.g. `checklist.md`) breaks a renderer that doesn't understand YAML blocks. | Low | Low — cosmetic | Most markdown renderers (GitHub, editors) handle leading YAML blocks correctly. If a specific surface breaks, move that file to sidecar `.origin` files instead. Not worth designing around upfront. |
 | `$CALSUITE_DIR` resolution depends on shell env; editor or CI run of Claude Code may not inherit it | Low | Low — hooks fail to fire | Default fallback (`~/Projects/calsuite`) covers the common case. Hook commands that fail gracefully (early-exit on missing file) keep the runtime robust. |
 | Content comparison excludes `_origin:` line — if the line is malformed (e.g. hand-edited to break YAML) the parse step could fail and the file gets skipped incorrectly | Low | Low | Tolerant parse: if frontmatter is invalid YAML, treat as "no `_origin`" and fall into the migration path. |
 | User adds a new skill directly in target's `.claude/skills/` without `_origin`; calsuite has a skill with the same name. First sync auto-migrates by filename match, clobbering the user's skill. | Low | High — silent data loss | Auto-stamp only when dest content is **byte-identical** to calsuite's current version. Different content → skip + flag. Filename collision alone does NOT trigger overwrite. |


### PR DESCRIPTION
## Summary

Rewrites how calsuite distributes hooks, skills, and agents into target repos. Addresses a verity-review-flagged critical issue (calsuite was writing 24 hardcoded `/Users/callumke/...` paths into committed `settings.json`, breaking every other collaborator's checkout) and the silent-data-loss footgun where every `--sync` unconditionally overwrote local skill/agent edits.

- **Hooks → `settings.local.json` (gitignored), never `settings.json`.** Hook commands contain literal resolved `$CALSUITE_DIR` paths (Claude Code's hook runner does not shell-expand). `settings.json` now only carries portable fields: `enabledPlugins` and `permissions`.
- **`_origin` safe-overwrite protocol for skills and agents.** Every distributed markdown file carries `_origin: calsuite@<sha>` frontmatter. Re-syncs cleanly update pristine files, skip user-edited files, and silently preserve user-claimed files. Pre-protocol targets auto-migrate file-by-file (byte-identical → stamp silently; diverged → skip + flag).
- **New CLI flags for divergence resolution:** `--force-adopt <path>` (take calsuite's version, with confirmation prompt / `--yes` to skip) and `--claim <path>` (stamp `_origin: <target-name>`, preserve local content forever).
- **Auto-cleanup of pre-refactor stale state:** `.claude/scripts/{hooks,lib}/` dirs that contained only calsuite-pointing symlinks are removed on first v2.6 sync. Non-symlinks in the same dirs are preserved.
- **Gitignore management:** installer adds `.claude/settings.local.json` to target root and every detected monorepo workspace.
- **Removed dead code:** `syncParentAssets()` and `PARENT_CLAUDE_DIR` (parent-dir inheritance is not a supported Claude Code feature per the [docs](https://code.claude.com/docs/en/skills)); `resolveHookPaths()` (the exact source of the hardcoded-path bug); `symlinkDirSync` / `symlinkOrSkip` (no longer reachable).
- **End-of-sync summary:** bulk-reports every skipped file plus the three resolution commands; one block, not one line per file buried in install output.
- **Spec + design doc** committed at `specs/personal-harness-refactor/design.md` — full architecture, decision rationale, migration matrix, risk table.
- **Docs:** CLAUDE.md gotchas rewritten (installer, runtime, divergence-resolution sections); README distribution-model section rebuilt with a mermaid diagram showing the actual three-tier flow; CHANGELOG has a "Breaking / migration notes" subsection with the expected first-sync output.

## How It Works

```mermaid
flowchart LR
    subgraph SRC["calsuite/ (source of truth)"]
        direction TB
        C1["scripts/hooks/*.cjs"]
        C2["hooks/hooks.json<br/>template"]
        C3["skills/*.md<br/>agents/*.md"]
    end

    subgraph TGT_LOCAL["target/.claude/settings.local.json<br/>(gitignored)"]
        L1["hook commands<br/>resolved \$CALSUITE_DIR paths"]
    end

    subgraph TGT_SHARED["target/.claude/ (committed)"]
        T1["skills/*/*.md<br/>agents/*.md<br/>(+ _origin frontmatter)"]
        T2["settings.json<br/>plugins + permissions only"]
    end

    subgraph RUNTIME["Claude Code hook runner"]
        R1["reads literal path<br/>no shell expansion"]
    end

    C1 -.->|invoked from calsuite| R1
    C2 -->|installer resolves \${CALSUITE_DIR}| L1
    C3 -->|"_origin safe-overwrite<br/>(skip local edits,<br/>auto-migrate pristine)"| T1
    L1 -->|at runtime| R1
```

The `_origin` decision matrix (per file, every `--sync`):

| dest state | action |
|---|---|
| missing | write + stamp `calsuite@<current>` |
| `_origin: calsuite@<sha>`, content == calsuite at `<sha>` | safe update + re-stamp |
| `_origin: calsuite@<sha>`, content != calsuite at `<sha>` | skip-diverged (user edited) |
| `_origin: <other>` | skip-claimed (user-owned, never touch) |
| no `_origin`, content byte-identical to calsuite current | migrate (stamp in place) |
| no `_origin`, content differs | skip-unknown (pre-protocol edit OR stale) |

## Important Files

| File | Change |
|------|--------|
| `scripts/lib/origin-protocol.cjs` | New — the whole protocol. `parseFrontmatter`, `readOrigin`, `stampOrigin` (function replacer), `normalizeForCompare` (LF + strip `_origin` + leading-newline tolerance), `contentAtSha` (via `git show`, distinguishes benign path-missing from infra errors), `currentCalsuiteSha` (throws, no sentinel), `decideFileAction` (the 6-row matrix). |
| `scripts/configure-claude.js` | Hooks routed to `settings.local.json`; legacy calsuite hooks stripped from `settings.json` on first sync; per-file `_origin` protocol for skills/agents; `--force-adopt` / `--claim` / `--yes` CLI flags; auto-cleanup of stale script dirs; gitignore management; end-of-sync divergence summary; `readJsonSync` throws on SyntaxError (not on ENOENT); top-level `try/catch` in `main()` prints clean errors. Simplifier-pass helpers (`makeInstallStats`, `summarizeInstallStats`, `WRITE_ACTIONS`, `BLOCKING_SKIP_ACTIONS`) factor out repeated plumbing. |
| `hooks/hooks.json` | `${CLAUDE_CONFIG_DIR}` → `${CALSUITE_DIR}` placeholder rename (18 occurrences). |
| `specs/personal-harness-refactor/design.md` | New — full design spec. Architecture, decisions table, risks table, migration semantics, out-of-scope tracking to [#40](https://github.com/ckallum/calsuite/issues/40), [#41](https://github.com/ckallum/calsuite/issues/41), [#42](https://github.com/ckallum/calsuite/issues/42). |
| `CLAUDE.md` | Version 2.5 → 2.6. Key file locations + gotchas rewritten (installer / runtime / divergence-resolution groups). Removed stale entries for deleted helpers. |
| `README.md` | Version bump. New Distribution model section with mermaid diagram + asset-flow table + resolution-command reference. |
| `CHANGELOG.md` | Full v2.6 entry: Breaking/migration notes with expected first-sync output; Added / Changed / Fixed / Removed subsections. |

## Test Results

| Suite | Result |
|-------|--------|
| Installer smoke test (11 scenarios) | ✅ All passing. Fresh install, file layout, no-hardcoded-paths in `settings.json`, absolute paths in `settings.local.json`, gitignore entry, `_origin` stamp format, idempotent re-sync, user-edit preservation, `--claim`, `--force-adopt --yes`, corrupt-JSON fail-loud. |
| `node --check` syntax | ✅ Clean. |
| Design-doc compliance review | ✅ Pass (1 finding addressed in `2a3a9af`). |
| Code review (3 rounds + final gate) | ✅ Pass (7 findings addressed in `3d4d686`, final gate `PASS`). |

Calsuite has no automated test runner; [#46](https://github.com/ckallum/calsuite/issues/46) tracks adding one.

## Pre-Landing Review

No outstanding issues. Three review rounds ran during development:

1. **Spec-compliance review** (caught 1 finding — guardian-rules / agent-rules being always-overwrite instead of copy-no-overwrite. Fixed in `2a3a9af`.)
2. **Code review** (caught 7 findings, 3 critical: `currentCalsuiteSha` returning `'unknown'`, bare-catch in `contentAtSha`, `installOnly` bypassing `_origin`. Plus 4 informational. All fixed in `3d4d686`.)
3. **Final pre-ship review** (PASS — no new findings beyond the prior rounds.)

## Doc Completeness

- [x] CHANGELOG.md updated with Breaking / Migration, Added, Changed, Fixed, Removed subsections
- [x] CLAUDE.md updated — key file locations, gotchas, structure all reflect the new model
- [x] README.md updated — new Distribution model section with mermaid diagram
- [x] Design spec at `specs/personal-harness-refactor/design.md` committed

## Out of scope / follow-ups

Issues opened during this work:

- [#40 `/reconcile-targets`](https://github.com/ckallum/calsuite/issues/40) — agentic LLM-mediated reconciliation across targets.
- [#41 `--prune-stale` flag](https://github.com/ckallum/calsuite/issues/41) — opt-in cleanup of pre-refactor orphaned state.
- [#42 `--reconcile <path>`](https://github.com/ckallum/calsuite/issues/42) — interactive three-way merge helper.
- [#44 Unit tests for `origin-protocol.cjs`](https://github.com/ckallum/calsuite/issues/44) — regression harness for the core protocol.
- [#45 Batch paths in `--force-adopt` / `--claim`](https://github.com/ckallum/calsuite/issues/45) — UX improvement for when many files diverge.
- [#46 Automated test harness for the installer](https://github.com/ckallum/calsuite/issues/46) — broader integration tests.


## Revision History

**Round 1** (2026-04-19):
- Accepted: 1 comment — `handleClaim` now validates path is under `.claude/skills` or `.claude/agents` and ends in `.md` (matches `handleForceAdopt`'s guard). Prevents silent corruption of non-markdown files if `--claim` is pointed at a JSON config.
- Pushed back: 0
- Questions answered: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New installer workflow for configuring target repositories
  * Divergence resolution commands: --force-adopt and --claim
  * Origin-based safe-overwrite and stamping for distributed skills/agents with reconciliation reporting

* **Improvements**
  * Machine-specific hook wiring moved to gitignored per-user config; hooks reference local install paths
  * Stronger JSON/error handling, clearer migration and end-of-sync summaries

* **Documentation**
  * Comprehensive docs updated for version 2.6 installation, distribution, and migration flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->