### PR TITLE
chore(harness): v2.8 — lint pack, plan/review/ship gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Local project config (installed by configure-claude.js)
 .claude/
 .worktrees/
+
+# calsuite (personal harness) — never commit
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 All notable changes to this repository.
 
-Current version: **2.7**
+Current version: **2.8**
+
+## [2.8] — 2026-04-20
+
+### Added
+
+- **Rust silent-failure lint pack** in `config/lint-configs/agent-rules.json` — 5 patterns (`let _ = .await`, `if let Ok(Some(...`, `.ok()` without `.or`, `debug_assert!`, `.contains("...not active")`) scoped to `**/*.rs`. Fires through the existing `lint-gate.cjs` hook — no runtime changes. Grouped under a `_pack` metadata key as forward-looking scaffolding for future per-language enable/disable; `lint-gate.cjs` currently treats them like any other rule.
+- **`/plan` — signal-gated state × event matrix.** Path signals (`session/`, `actor/`, `state_machine/`, `lifecycle/`, `fsm/`) + content signals (`enum *State|Lifecycle|Status`, `impl *Manager`) + explicit `--lifecycle` flag trigger matrix emission in INTERVIEW, BRAINSTORM, and REVIEW outputs. Skipped for CRUD/stateless work.
+- **`/review` — format-consistency agent (H).** Parallel agent that greps the full module around each changed file for mixed datetime writers, mixed `ORDER BY` directions, and snake/camel serialization drift. Rust-first; TS/JS/Python/Go/SQL patterns included.
+- **`/review` — spec-contract deviation agent (I).** Reads the active `.claude/specs/<slug>/design.md` + `tasks.md`, flags MISSING (spec promises / diff drops) and EXTRA (diff builds / spec silent) deviations.
+- **`/review` — versioned-struct checklist pass** (signal-gated on `const *_VERSION` / `version:` fields). Checks deserialize-path version check, degraded fallback, serialize/deserialize symmetry, and `.truncate(cap)` on capped arrays.
+- **`/ship` — Pre-PR Gates (Step 7.4):**
+  1. PR-size warning when `> 400` lines added — cites dominant files, does not block.
+  2. Test-presence gate — universal multi-language heuristic (Rust/TS/JS/Py/Go/Ruby test function counting) warning when `code_additions > 50 && new_tests == 0`. Optional strict mode via `.claude/ship-config.json` `criticalPaths` glob list; `strict: true` upgrades warning to block.
+  3. Spec-contract deviation — same detection as `/review` Agent I, with AskUserQuestion remediate-or-addendum flow. Option B mutates `design.md`/`tasks.md` with strikethrough + dated addendum.
+- **`/ship` — PR-claim-vs-diff grep (Step 8.5).** Extracts backticked symbol claims from the drafted PR body; flags any that `grep -F` can't find in the diff.
+
+### Why
+
+PR `ckallum/museli#173` needed 3 review rounds and ~29 findings before landing. The retrospective bucketed those findings into 6 root causes: silent failures (6 bugs), cross-file invariant drift (4), lifecycle/restart gaps (5), promised-but-not-persisted state (3), defensive-programming gaps (3), and missing tests (systemic). This release encodes deterministic catches for each: lint rules for silent failures, format-consistency agent for drift, state matrix for lifecycle, PR-claim grep for promised-state, versioned-struct pass for defensive gaps, test-presence gate for coverage. Signal-gated passes only fire when the codebase matches — zero overhead on unrelated work.
+
+### How to apply
+
+- Rust lint rules auto-fire on `git commit` in any repo with the shared config (target repos inherit via calsuite installer).
+- `/plan` matrix triggers on the signals automatically; use `/plan review <slug> --lifecycle` to force it.
+- `/review` runs H + I + versioned-struct whenever signals match; all conditional — no overhead otherwise.
+- `/ship` gates always run, but only surface findings when they fire. Add `.claude/ship-config.json` per-repo for strict test-presence on critical paths.
 
 ## [2.7] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Current version: **2.8**
 
 ### Added
 
-- **Rust silent-failure lint pack** in `config/lint-configs/agent-rules.json` — 5 patterns (`let _ = .await`, `if let Ok(Some(...`, `.ok()` without `.or`, `debug_assert!`, `.contains("...not active")`) scoped to `**/*.rs`. Fires through the existing `lint-gate.cjs` hook — no runtime changes. Grouped under a `_pack` metadata key as forward-looking scaffolding for future per-language enable/disable; `lint-gate.cjs` currently treats them like any other rule.
+- **Rust silent-failure lint pack** in `config/lint-configs/agent-rules.json` — 5 patterns (`let _ = .await`, `if let Ok(Some(...`, `.ok()` on a non-chained/non-`?` result, `debug_assert!`, `.contains("...not active")`) scoped to `**/*.rs` via the `files` glob. Fires through the existing `lint-gate.cjs` hook — no runtime changes. Adding a pack for another language is just more rule entries with a different `files` glob.
 - **`/plan` — signal-gated state × event matrix.** Path signals (`session/`, `actor/`, `state_machine/`, `lifecycle/`, `fsm/`) + content signals (`enum *State|Lifecycle|Status`, `impl *Manager`) + explicit `--lifecycle` flag trigger matrix emission in INTERVIEW, BRAINSTORM, and REVIEW outputs. Skipped for CRUD/stateless work.
 - **`/review` — format-consistency agent (H).** Parallel agent that greps the full module around each changed file for mixed datetime writers, mixed `ORDER BY` directions, and snake/camel serialization drift. Rust-first; TS/JS/Python/Go/SQL patterns included.
 - **`/review` — spec-contract deviation agent (I).** Reads the active `.claude/specs/<slug>/design.md` + `tasks.md`, flags MISSING (spec promises / diff drops) and EXTRA (diff builds / spec silent) deviations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.7** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.8** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.7**
+**Version: 2.8**
 
 ## Getting started
 

--- a/config/lint-configs/agent-rules.json
+++ b/config/lint-configs/agent-rules.json
@@ -1,8 +1,7 @@
 {
-  "_description": "Agent-directed structural lint rules. Checked by the lint-gate.cjs hook. These encode conventions that ESLint AST rules cannot express — file placement, import patterns, naming. Language packs are scoped via the `files` glob; add patterns for new languages without touching lint-gate.cjs.",
+  "_description": "Agent-directed structural lint rules. Checked by the lint-gate.cjs hook. These encode conventions that ESLint AST rules cannot express — file placement, import patterns, naming. Language scoping is handled by the `files` glob on each rule; add patterns for new languages without touching lint-gate.cjs.",
   "rules": [
     {
-      "_pack": "rust-silent-failures",
       "id": "rust-no-let-underscore-await",
       "pattern": "let\\s+_\\s*=.*\\.await",
       "files": "**/*.rs",
@@ -12,7 +11,6 @@
       "autofix": null
     },
     {
-      "_pack": "rust-silent-failures",
       "id": "rust-if-let-ok-some-swallow",
       "pattern": "if\\s+let\\s+Ok\\(Some\\(",
       "files": "**/*.rs",
@@ -22,17 +20,15 @@
       "autofix": null
     },
     {
-      "_pack": "rust-silent-failures",
       "id": "rust-ok-drops-err",
-      "pattern": "\\.ok\\(\\)(?!\\s*\\.or)",
+      "pattern": "\\.ok\\(\\)(?!\\s*(?:\\?|\\.(?:or|or_else|map|map_or|map_or_else|and_then|unwrap_or|unwrap_or_else|unwrap_or_default|ok_or|ok_or_else|filter|inspect|expect|is_some|is_none)\\b))",
       "files": "**/*.rs",
       "exclude": ["**/tests/**", "**/*_test.rs"],
       "severity": "warn",
-      "message": ".ok() drops the Err; log or propagate before discarding",
+      "message": ".ok() drops the Err silently; chain .map/.unwrap_or/? or match the Err first",
       "autofix": null
     },
     {
-      "_pack": "rust-silent-failures",
       "id": "rust-debug-assert-in-prod",
       "pattern": "debug_assert!\\(",
       "files": "**/*.rs",
@@ -42,7 +38,6 @@
       "autofix": null
     },
     {
-      "_pack": "rust-silent-failures",
       "id": "rust-string-match-err-message",
       "pattern": "\\.contains\\(\"[^\"]*not active\"\\)",
       "files": "**/*.rs",

--- a/config/lint-configs/agent-rules.json
+++ b/config/lint-configs/agent-rules.json
@@ -1,6 +1,56 @@
 {
-  "_description": "Agent-directed structural lint rules. Checked by lint-gate.js hook. These encode conventions that ESLint AST rules cannot express — file placement, import patterns, naming.",
+  "_description": "Agent-directed structural lint rules. Checked by the lint-gate.cjs hook. These encode conventions that ESLint AST rules cannot express — file placement, import patterns, naming. Language packs are scoped via the `files` glob; add patterns for new languages without touching lint-gate.cjs.",
   "rules": [
+    {
+      "_pack": "rust-silent-failures",
+      "id": "rust-no-let-underscore-await",
+      "pattern": "let\\s+_\\s*=.*\\.await",
+      "files": "**/*.rs",
+      "exclude": ["**/tests/**", "**/*_test.rs"],
+      "severity": "warn",
+      "message": "Discarding reply-channel result; match Err explicitly or propagate",
+      "autofix": null
+    },
+    {
+      "_pack": "rust-silent-failures",
+      "id": "rust-if-let-ok-some-swallow",
+      "pattern": "if\\s+let\\s+Ok\\(Some\\(",
+      "files": "**/*.rs",
+      "exclude": ["**/tests/**", "**/*_test.rs"],
+      "severity": "warn",
+      "message": "Swallows Err case silently; use match to handle Err explicitly",
+      "autofix": null
+    },
+    {
+      "_pack": "rust-silent-failures",
+      "id": "rust-ok-drops-err",
+      "pattern": "\\.ok\\(\\)(?!\\s*\\.or)",
+      "files": "**/*.rs",
+      "exclude": ["**/tests/**", "**/*_test.rs"],
+      "severity": "warn",
+      "message": ".ok() drops the Err; log or propagate before discarding",
+      "autofix": null
+    },
+    {
+      "_pack": "rust-silent-failures",
+      "id": "rust-debug-assert-in-prod",
+      "pattern": "debug_assert!\\(",
+      "files": "**/*.rs",
+      "exclude": ["**/tests/**", "**/*_test.rs"],
+      "severity": "warn",
+      "message": "debug_assert! is stripped in release builds — not valid for prod invariants. Use assert! or an explicit error return.",
+      "autofix": null
+    },
+    {
+      "_pack": "rust-silent-failures",
+      "id": "rust-string-match-err-message",
+      "pattern": "\\.contains\\(\"[^\"]*not active\"\\)",
+      "files": "**/*.rs",
+      "exclude": ["**/tests/**", "**/*_test.rs"],
+      "severity": "warn",
+      "message": "String-matching error messages is fragile; introduce a typed error variant",
+      "autofix": null
+    },
     {
       "id": "no-default-export",
       "pattern": "^export\\s+default\\b",

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -8,7 +8,7 @@ description: |
   Four modes: INTERVIEW (surface edge cases, write spec), BRAINSTORM (explore design),
   REVIEW (lock in architecture, data flow, edge cases, tests),
   VISUALIZE (diagram-based design validation, bug shakeout).
-argument-hint: [mode] [spec-path]
+argument-hint: "[mode] [spec-path] [--lifecycle]"
 allowed-tools:
   - Read
   - Write
@@ -24,6 +24,61 @@ allowed-tools:
 # Engineering Plan
 
 Consolidated planning skill. Start here before writing code.
+
+## Arguments
+
+- `/plan` — ask for mode via AskUserQuestion
+- `/plan [mode]` — where mode is `interview`, `brainstorm`, `review`, or `visualize`
+- `/plan [mode] [spec-path]` — e.g. `/plan review auth-flow`
+- `--lifecycle` — force state × event matrix emission even when auto-detection signals don't fire
+
+## Lifecycle Detection (shared — runs before mode dispatch)
+
+Detect whether the planned work touches a state machine. This determines whether plan outputs (INTERVIEW, BRAINSTORM, REVIEW) must include a **state × event matrix**. Signal detection is cheap — grep/glob only, no LLM calls.
+
+**Explicit override:** if `$ARGUMENTS` contains `--lifecycle`, treat as state-machine work unconditionally.
+
+**Path signals** (match any target or recently-changed file path):
+```
+**/session/**
+**/actor/**
+**/state_machine/**
+**/lifecycle/**
+**/fsm/**
+```
+
+**Content signals** (grep changed or referenced files):
+```
+enum\s+\w*(State|Lifecycle|Status)\b
+impl\s+\w*Manager\b
+```
+
+**Detection command:**
+```bash
+# Path signals — check both in-flight and spec-referenced files
+git diff origin/main --name-only 2>/dev/null | grep -E '(session|actor|state_machine|lifecycle|fsm)/' && LIFECYCLE=1
+# Content signals — check changed files
+git diff origin/main 2>/dev/null | grep -E '(enum\s+\w*(State|Lifecycle|Status)\b|impl\s+\w*Manager\b)' && LIFECYCLE=1
+# Explicit flag
+echo "$ARGUMENTS" | grep -q -- '--lifecycle' && LIFECYCLE=1
+```
+
+**When `LIFECYCLE=1`**, the plan's output MUST include a state × event matrix. When `LIFECYCLE=0` (typical CRUD/stateless work), skip the matrix — it's dead weight.
+
+### State × event matrix format
+
+Rows = events/commands the system accepts. Columns = current states. Cells = expected behavior (`OK`, `error`, `skip`, `stop-first`, `reject`, etc.). Example shape:
+
+```
+                 StateA    StateB    StateC    StateD
+event_1          OK        error     error     error
+event_2          skip      full      full      error
+event_3          clear     clear     reject    clear
+```
+
+Every cell is a review target — missing or fuzzy cells are the bugs. Derive states from the system's actual state enum (or the enum you are designing) and events from command entry points.
+
+---
 
 ## Mode Selection
 
@@ -74,6 +129,7 @@ Rewrite the spec file incorporating all decisions from the interview:
 - Add new sections for topics that emerged
 - Follow the spec format: `requirements.md`, `design.md`, `tasks.md`
 - Flag any remaining open questions
+- **If `LIFECYCLE=1`** (see Lifecycle Detection above): include a state × event matrix in `design.md` under a `## State Transitions` section. Every cell must be filled — fuzzy cells get called out as open questions.
 
 ---
 
@@ -104,7 +160,7 @@ After exploring options, synthesize into a concrete proposal:
 ### Step 4: Write the spec
 Create spec files in `.claude/specs/<feature-name>/`:
 - `requirements.md` — User stories, functional/non-functional requirements
-- `design.md` — Architecture, data model, API design, key decisions
+- `design.md` — Architecture, data model, API design, key decisions. **If `LIFECYCLE=1`** (see Lifecycle Detection): include a state × event matrix under `## State Transitions`.
 - `tasks.md` — Phased implementation tasks with checkboxes
 
 Update SPECLOG.md with the new spec entry.
@@ -244,6 +300,9 @@ Each potential TODO as its own AskUserQuestion. For each: What, Why, Pros, Cons,
 ### Diagrams
 ASCII diagrams for any non-trivial data flow, state machine, or pipeline.
 
+### State × event matrix (conditional)
+**If `LIFECYCLE=1`** (see Lifecycle Detection at top of file): emit a state × event matrix listing every event/command across every state. Every cell must specify expected behavior (OK, error, skip, reject, stop-first, etc.). Empty or fuzzy cells are flagged as CRITICAL gaps. If the spec's `design.md` already contains a matrix, validate it — every cell reachable, no stuck states. If missing, emit one and recommend adding to `design.md`. Skip this section entirely when `LIFECYCLE=0`.
+
 ### Failure modes
 For each new codepath: one realistic failure, whether a test covers it, whether error handling exists, whether the user would see a clear error or silent failure. Any failure with no test AND no error handling AND silent -> **critical gap**.
 
@@ -258,6 +317,7 @@ For each new codepath: one realistic failure, whether a test covers it, whether 
   What already exists:  written
   TODO.md updates:      ___ items proposed
   Failure modes:        ___ critical gaps
+  State × event matrix: ___ cells (or "skipped — not a state machine")
 ```
 
 ## VISUALIZE Mode

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -4,8 +4,9 @@ version: 1.0.0
 description: |
   review this, pre-landing review, check my code, review before merge, code review,
   look over my changes, audit this PR, review PR, review pull request.
-  Up to 7 parallel review agents: conventions, security checklist, git blame history,
-  previous PR comments, code comment compliance, silent failure hunting, type design.
+  Up to 9 parallel review agents: conventions, security checklist, git blame history,
+  previous PR comments, code comment compliance, silent failure hunting, type design,
+  cross-module format consistency, spec-contract deviation.
   Confidence scoring, Greptile triage, TODO cross-reference, flow diagrams.
   Adversarial converse mode: /review pr 123 --converse codex runs Claude's review then debates findings with another model CLI.
 argument-hint: "[pr <number>] [--converse cli[:model]]"
@@ -307,7 +308,7 @@ Read `.claude/skills/review/greptile-triage.md` and follow the fetch, filter, cl
 
 ## Step 3: Dispatch Parallel Review Agents
 
-Dispatch **up to 7 parallel agents** in a single message using the Agent tool. Agents F and G are conditional — only dispatch them if the diff contains relevant code.
+Dispatch **up to 9 parallel agents** in a single message using the Agent tool. Agents F, G, H, and I are conditional — only dispatch them if the diff contains relevant code or signals.
 
 **Agent A — Convention review (@code-reviewer):**
 ```text
@@ -336,6 +337,9 @@ Run `git diff origin/main` to get the full diff. Read the checklist at
 Pass 1 (CRITICAL): SQL & Data Safety, Race Conditions & Concurrency,
 LLM Output Trust Boundary, Auth & Security Boundaries.
 Pass 2 (INFORMATIONAL): All remaining categories.
+Signal-gated passes: read the 'Signal-Gated Passes' section of the checklist.
+Run the versioned-struct pass ONLY if the diff matches the signals listed there
+(const *_VERSION, struct field `version:`, or TS `version: number` on serialized types).
 
 Respect the Suppressions section — do NOT flag items listed there.
 Read the FULL diff before flagging anything.
@@ -472,13 +476,92 @@ improvement suggestions. Keep suggestions pragmatic — don't overcomplicate."
 description: "Type design review"
 ```
 
+**Agent H — Cross-module format consistency (conditional):**
+
+Dispatch this agent whenever the diff touches Rust, TypeScript/JavaScript, Python, Go, or SQL code. The agent greps the **whole module** around each changed file — not just the diff — for consistency contracts and flags any mismatches.
+
+```text
+prompt: "Hunt for cross-module format-consistency drift in the target diff.
+
+Use the same diff source selected in Step 1:
+- local mode: git diff origin/main
+- PR mode: the gh pr diff <number> output already fetched
+
+1. Run `git diff origin/main --name-only` to get the changed files.
+2. For each changed file, determine its module — the nearest enclosing directory
+   that groups related files (e.g. `src-tauri/src/db/` for Rust, `src/features/foo/`
+   for TS, `app/models/` for Ruby). Read every file in that module, not just the
+   changed ones.
+3. For each module, scan for these consistency contracts and flag mismatches:
+
+   **Datetime writers (Rust / TS / JS / Python / Go / SQL).**
+     - Rust: `datetime\\('now'\\)` vs `Utc::now\\(\\)` vs `chrono::Utc::now\\(\\)\\.to_rfc3339\\(\\)` vs `SystemTime::now\\(\\)`
+     - TS/JS: `new Date\\(\\)\\.toISOString\\(\\)` vs `Date\\.now\\(\\)` vs `dayjs\\(\\)\\.format\\(` vs raw `Date\\(\\)`
+     - Python: `datetime\\.utcnow\\(\\)` vs `datetime\\.now\\(tz=` vs `time\\.time\\(\\)`
+     - SQL: `datetime\\('now'\\)` vs `CURRENT_TIMESTAMP` vs `NOW\\(\\)`
+     If a single module writes timestamps using 2+ different functions, flag as CRITICAL — the serialized formats will diverge.
+
+   **SQL ORDER BY directions.** Grep for the same column appearing in `ORDER BY <col> ASC` and `ORDER BY <col> DESC` within one module — if two handlers sort the same column differently, results will be inconsistent.
+
+   **Serialization drift.** Grep for the same identifier written both snake_case and camelCase within one module (e.g. `created_at` and `createdAt` appearing on the same struct's serde attributes). Flag as CRITICAL — this causes silent deserialize failures.
+
+4. Return findings with file:line, the inconsistent values found, and which
+   module boundary they fall within. Only flag genuine mismatches — skip cases
+   where different formats are intentional (e.g. a TS/serde boundary where
+   snake↔camel is expected)."
+description: "Cross-module format consistency"
+```
+
+**Agent I — Spec-contract deviation (conditional):**
+
+Only dispatch if `.claude/specs/` exists and contains a spec matching the current branch. Detect the active spec:
+```bash
+SPEC_DIR=""
+# Try branch name → spec slug
+branch=$(git branch --show-current)
+slug=$(echo "$branch" | sed -E 's#^(feat|fix|chore|refactor|feature)/##')
+[ -d ".claude/specs/$slug" ] && SPEC_DIR=".claude/specs/$slug"
+# Fallback: most-recently-modified spec with both design.md and tasks.md
+[ -z "$SPEC_DIR" ] && SPEC_DIR=$(find .claude/specs -mindepth 1 -maxdepth 2 -name design.md -exec dirname {} \; 2>/dev/null | head -1)
+```
+If `$SPEC_DIR` is empty, skip this agent.
+
+```text
+prompt: "Check the diff for deviations from the spec contract.
+
+1. Read $SPEC_DIR/design.md and $SPEC_DIR/tasks.md — these are the contract.
+2. Run `git diff origin/main` (or the PR diff) to see what was built.
+3. For each top-level item in design.md (new components, APIs, data flows, event names,
+   field names) and each task in tasks.md:
+   - Is it delivered in the diff? If a design.md bullet names a specific symbol,
+     field, or event, grep the diff for it.
+   - Is there extra work in the diff not covered by any spec item?
+
+Flag two classes of deviation:
+  - MISSING: spec promises it, diff doesn't deliver it.
+  - EXTRA: diff builds it, spec doesn't describe it.
+
+For each deviation, return:
+  [file:line or spec-section] <deviation description>
+  Recommendation: either (A) remediate — bring the diff back to the spec, or
+                         (B) update spec — strikethrough the old bullet in
+                             design.md/tasks.md and add an addendum describing
+                             the current implementation path.
+  Include the one-sentence reasoning for which option fits better.
+
+Skip deviations that are obviously trivial (renaming a helper, moving a file).
+Focus on behavioral contract: commands the system accepts, events it emits,
+data shape it persists, failure modes it handles."
+description: "Spec-contract deviation"
+```
+
 Wait for all agents to return.
 
 ---
 
 ## Step 4: Merge, Score, and Filter Findings
 
-1. Collect findings from all agents (5-7 depending on which conditional agents ran).
+1. Collect findings from all agents (5-9 depending on which conditional agents ran).
 2. Deduplicate: if multiple agents flag the same file:line for the same issue, keep the one with most detail.
 3. **Confidence score each finding** on a 0-100 scale:
    - **0-25:** Likely false positive — doesn't stand up to scrutiny, or is a pre-existing issue.
@@ -502,7 +585,7 @@ Output all findings:
 ### CRITICAL (blocking) — confidence ≥ 80
 1. [file:line] Problem description (score: 85)
    Fix: suggested fix
-   Source: convention | checklist | blame | prev-PR | comments | silent-failure | type-design | greptile
+   Source: convention | checklist | blame | prev-PR | comments | silent-failure | type-design | format-consistency | spec-contract | greptile
 
 ### INFORMATIONAL (advisory) — confidence 60-79
 1. [file:line] Problem description (score: 65)

--- a/skills/review/checklist.md
+++ b/skills/review/checklist.md
@@ -109,6 +109,34 @@ Be terse. For each issue: one line describing the problem, one line with the fix
 
 ---
 
+## Signal-Gated Passes
+
+These passes only run when a cheap grep against the diff detects the corresponding signal. Skip silently if no signal fires.
+
+### Versioned-struct pass
+
+**Signal (run this pass only if the diff matches any of these):**
+- Rust: `const\s+\w*_VERSION\b`, or a struct field declared `\s+version\s*:\s*(u\d+|i\d+)\b`
+- TypeScript: `\bversion\s*:\s*number\b` on a type used in serialize/deserialize paths
+
+**When the signal fires, check every versioned struct in the diff for:**
+
+- **Version check on deserialize/hydrate:** does the deserialize path read `version` and branch? A missing check means a future-version payload silently loads with today's code.
+- **Degraded fallback for version mismatch:** on mismatch, does the code emit a degraded event, fall back to a safe default, or refuse to hydrate? Crashing is acceptable; silently ignoring is not.
+- **Serialize/deserialize symmetry:** every field on the struct must be populated in *both* directions. If a field is written but never read (or vice versa), flag it — this was the PR #173 `hydrated_from_storage` class of bug.
+- **Capped arrays truncated post-deserialize:** if the struct has a `Vec<T>` or `Array` with a declared cap (e.g. `const MAX_X: usize = 100`), the deserialize path must `.truncate(cap)` after reading — stored payloads from earlier versions may exceed the cap.
+
+**Output format:**
+```
+Versioned-Struct Pass: N issues
+- [file:line] <StructName>.version — <specific gap>
+  Fix: <concrete fix referencing the four checks>
+```
+
+If no issues, emit `Versioned-Struct Pass: clean`.
+
+---
+
 ## Gate Classification
 
 ```text

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -59,13 +59,17 @@ EOF
 
 Use `docs:` for documentation, `chore:` for config/skills, `style:` for formatting. If there are already commits on the branch and no uncommitted changes, skip this step.
 
-### Step 3: Push and create PR
+### Step 3: Push, run Pre-PR Gates, create PR
 
 ```bash
 git push -u origin $(git branch --show-current)
 ```
 
-Read the PR body template at `skills/ship/pr-template.md`. Create the PR following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits).
+Run the Pre-PR Gates from **Step 7.4** (PR-size, test-presence, spec-contract) before drafting the body. Even in pr-only mode, these gates surface useful warnings — the test-presence gate typically stays silent on docs/config changes because it only warns when `code_additions > 50`. Spec-contract still applies if the repo has active specs.
+
+Read the PR body template at `skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
+
+Run **Step 8.5** (PR-claim-vs-diff grep) against the drafted body before calling `gh pr create`.
 
 **Output the PR URL.**
 
@@ -249,6 +253,140 @@ git push -u origin $(git branch --show-current)
 
 ---
 
+## Step 7.4: Pre-PR Gates
+
+Before drafting the PR body, run three cheap grep/glob-based gates against the diff, then collect their output. These gates **warn but do not block** by default — surface context so the user can either proceed with intent or pause to address. Each gate runs independently; collect all outputs and show them together before Step 8.
+
+### Gate 1 — PR-size warning
+
+```bash
+added=$(git diff origin/main --shortstat | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
+if [ "${added:-0}" -gt 400 ]; then
+  # Identify the top files dominating the diff
+  git diff origin/main --numstat | awk '{print $1 + $2, $3}' | sort -rn | head -5
+fi
+```
+
+If `added > 400`, emit:
+```
+⚠ PR size: <N> lines added. Large PRs get surface-level reviews.
+  Top files:
+    <N1> lines  <path1>
+    <N2> lines  <path2>
+  Suggest: split on commit boundaries —
+    git log origin/main..HEAD --oneline
+  Each commit is already a logical split point. Consider shipping one per PR.
+```
+Do NOT block. The user decides.
+
+### Gate 2 — Test-presence gate
+
+**Universal heuristic (always runs):**
+```bash
+# Count new test functions across all languages in the diff
+diff=$(git diff origin/main)
+new_tests=$(echo "$diff" | grep -cE '^\+\s*(#\[(test|tokio::test|rstest)\]|\btest\(|\bit\(|def\s+test_|func\s+Test[A-Z]|it\s+[\x27"])' || true)
+
+# Count substantive code additions in non-test, non-docs, non-config files
+code_additions=$(git diff origin/main -- \
+  ':(exclude)**/*.test.*' \
+  ':(exclude)**/*.spec.*' \
+  ':(exclude)**/tests/**' \
+  ':(exclude)**/__tests__/**' \
+  ':(exclude)**/migrations/**' \
+  ':(exclude)docs/' \
+  ':(exclude).github/' \
+  ':(exclude)*.md' \
+  ':(exclude)*.json' \
+  | grep -cE '^\+[^+]' || true)
+```
+
+If `code_additions > 50` AND `new_tests == 0`, emit:
+```
+⚠ Test-presence: <N> lines of code added, zero new tests.
+  Code-only files (no tests alongside):
+    <list of non-test files with net-positive additions>
+  If this is intentional (refactor, config, docs), proceed. Otherwise consider
+  adding tests before shipping.
+```
+
+**Optional strict mode (per-repo):**
+```bash
+# Check for .claude/ship-config.json at the repo root
+if [ -f .claude/ship-config.json ]; then
+  critical_globs=$(node -e '
+    try {
+      const c = require(process.cwd() + "/.claude/ship-config.json");
+      if (Array.isArray(c.criticalPaths)) console.log(c.criticalPaths.join("\n"));
+    } catch {}
+  ')
+  strict=$(node -e '
+    try { console.log(!!require(process.cwd() + "/.claude/ship-config.json").strict); }
+    catch { console.log("false"); }
+  ')
+fi
+```
+
+For each critical glob, check whether any diff file matches it (use the same glob-matching logic as `lint-gate.cjs`). If a critical path is touched AND `new_tests == 0`, emit a strong warning that cites the matching glob:
+
+```
+⚠ Test-presence (STRICT): critical path touched without tests.
+  Matched glob: <glob pattern>
+  Files: <matching files from diff>
+  No new tests detected in this PR.
+```
+
+If `strict: true` in ship-config.json, this blocks. Otherwise surface and continue.
+
+### Gate 3 — Spec-contract deviation
+
+Detect the active spec the same way `/review` Agent I does:
+```bash
+branch=$(git branch --show-current)
+slug=$(echo "$branch" | sed -E 's#^(feat|fix|chore|refactor|feature)/##')
+SPEC_DIR=""
+[ -d ".claude/specs/$slug" ] && SPEC_DIR=".claude/specs/$slug"
+[ -z "$SPEC_DIR" ] && SPEC_DIR=$(find .claude/specs -mindepth 1 -maxdepth 2 -name design.md -exec dirname {} \; 2>/dev/null | head -1)
+```
+
+If `$SPEC_DIR` is non-empty:
+1. Read `$SPEC_DIR/design.md` and `$SPEC_DIR/tasks.md`.
+2. For each named symbol/field/event/task in these files, grep the diff.
+3. For each unchecked task in `tasks.md`, check whether the diff plausibly addresses it.
+
+Flag two classes:
+  - **MISSING:** spec promises a specific symbol/event/task, diff does not contain it.
+  - **EXTRA:** diff introduces behavior (new command handler, new event emitter, new persisted field) not described anywhere in `design.md`.
+
+For each deviation, use AskUserQuestion individually:
+```
+<Deviation description — what the spec says vs what the diff does>
+
+Recommendation: [A or B, lead with your pick and 1-sentence reason]
+
+A) Remediate: bring the diff back to the spec before shipping.
+B) Update spec: mark the outdated bullet in design.md/tasks.md with strikethrough
+   (~~old text~~) and append an **Addendum** under the same section describing
+   the current implementation path. Then ship.
+C) Dismiss: not a real deviation.
+```
+
+If the user picks B, apply the edit to `design.md` and/or `tasks.md` using the following pattern — preserve the original bullet (struck through) and add a dated addendum directly beneath it:
+
+```markdown
+- ~~Original task/bullet text~~
+  - **Addendum (YYYY-MM-DD):** <current implementation path — what was built
+    instead, and why (1-2 sentences)>.
+```
+
+Stage the spec edit alongside the PR commits. Skip this gate silently if `$SPEC_DIR` is empty.
+
+### Output collection
+
+Collect the output of Gates 1-3 as `PRE_PR_GATE_FINDINGS`. These will be surfaced in the PR body (below the Summary section, above How It Works) and in the user-facing console output before Step 8. If every gate passes cleanly, `PRE_PR_GATE_FINDINGS` is empty and nothing is added to the PR body.
+
+---
+
 ## Step 7.5: Generate Development Flow diagram
 
 Before creating the PR, check if a flow trace file exists for this session and is non-empty. Use the `:-unknown` fallback so the path still resolves when `CLAUDE_SESSION_ID` is unset (matching the convention used by calsuite's other session-scoped trackers, e.g. `skill-usage-tracker.cjs`):
@@ -270,12 +408,13 @@ If the trace file is missing or empty, skip the `## Development Flow` section en
 
 ---
 
-## Step 8: Create PR
+## Step 8: Draft PR body
 
 Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
 
 Populate each section:
 - **Summary** — bullet points from CHANGELOG entries (what shipped)
+- **Pre-PR Gates** — findings from Step 7.4 (omit section entirely if no findings)
 - **How It Works** — Mermaid diagram for non-trivial PRs (skip for < 50 lines, config-only, docs-only)
 - **Development Flow** — Mermaid diagram from flow trace (insert after How It Works, before Important Files). Only include if trace data exists.
 - **Important Files** — table of key files with one-line descriptions
@@ -283,7 +422,49 @@ Populate each section:
 - **Pre-Landing Review** — findings from Step 4.5, or "No issues found."
 - **Doc Completeness** — checklist
 
-Create the PR using `gh pr create` with a HEREDOC body. **Output the PR URL.**
+Hold the drafted body as `PR_BODY_DRAFT` — do NOT call `gh pr create` yet. Step 8.5 verifies the body against the diff.
+
+---
+
+## Step 8.5: PR-claim-vs-diff grep
+
+Before creating the PR, cross-check the drafted body against the actual diff. The goal is to catch "promised-but-not-delivered" claims — PR bodies that mention symbols, fields, or events that never appear in the changes.
+
+1. Extract claims from `PR_BODY_DRAFT`. A claim is any identifier wrapped in backticks that names code:
+   - Type/struct names (e.g. `` `SessionDetail` ``)
+   - Field/key names (e.g. `` `hydrated_from_storage` ``)
+   - Event names (e.g. `` `session-hydrate-degraded` ``)
+   - Function/method names (e.g. `` `open_session()` ``)
+   - Constants (e.g. `` `MAX_RETRY_COUNT` ``)
+
+   Skip claims that are obviously not symbols: English prose in backticks, file paths, shell commands, or package names.
+
+2. For each extracted claim, grep the diff:
+   ```bash
+   git diff origin/main | grep -F "<claim>" >/dev/null || echo "MISSING: <claim>"
+   ```
+
+3. If any claims are missing from the diff, surface them above the PR body draft:
+   ```
+   ⚠ PR body claims not found in diff:
+     - `hydrated_from_storage`  — mentioned in Summary, not in any changed file
+     - `session-hydrate-degraded` — mentioned in How It Works, not emitted anywhere
+
+   Options:
+     A) Edit PR body to remove the claim(s)
+     B) Edit the code to actually deliver the claim(s)
+     C) Dismiss — the claim is correct, grep missed it (explain why)
+   ```
+
+   Use AskUserQuestion for each missing claim individually.
+
+4. If no claims are missing, proceed silently.
+
+---
+
+## Step 8.6: Create PR
+
+Create the PR using `gh pr create` with `PR_BODY_DRAFT` passed via HEREDOC. **Output the PR URL.**
 
 ---
 
@@ -311,6 +492,10 @@ This scans the conversation for deferred items, fast-follows, enhancements, mino
 - **`git push` may fail if the branch was force-pushed elsewhere.** Never force push to recover — ask the user.
 - **CHANGELOG auto-generation reads all commits on the branch** — if prior commits have bad messages, the CHANGELOG entries will be vague.
 - **`/ship pr` skips ALL safety checks** (tests, review, simplification). Only use for genuinely low-risk changes. If in doubt, use `/ship`.
+- **Pre-PR Gates (Step 7.4) warn but do not block** unless `.claude/ship-config.json` sets `strict: true`. They surface context about the diff shape — large PRs, no-test diffs, spec deviations — but the user always has the final word.
+- **`.claude/ship-config.json` is optional and per-repo.** Keys: `criticalPaths: [glob, ...]` for strict test-presence on sensitive files, `strict: true` to promote the strict warning into a block. Only the test-presence gate reads this file — size, spec-contract, and claim-grep gates run unconditionally.
+- **PR-claim-vs-diff grep (Step 8.5) uses literal string search.** A claim is missing if `grep -F` doesn't find it in the full diff. If the code renamed a symbol that the PR body still references, the grep correctly flags it.
+- **Spec-contract deviation (Gate 3) mutates `design.md`/`tasks.md`** when the user picks option B (strikethrough + addendum). Those edits get staged with the shipping commits — review them before pushing.
 
 ## Important Rules
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -253,6 +253,52 @@ git push -u origin $(git branch --show-current)
 
 ---
 
+## Step 7.2: Sweep and Fix Inline
+
+**Before** running Pre-PR Gates, scan the conversation for deferred items, fast-follows, minor bugs, enhancements, and tech debt — the same categories `/sweep-issues` looks for. Fix anything coherent with the current PR; defer the rest to Step 9.
+
+### 7.2a: Gather candidates
+
+Review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description and its source (conversation turn, review finding, etc.).
+
+### 7.2b: Triage — fix now vs. create issue
+
+Classify each candidate:
+
+| Fix now (inline) | Create issue (later) |
+|---|---|
+| Minor bug in code touched by this PR | Feature request unrelated to this PR |
+| Missing edge case in a function this PR added/modified | Large refactor spanning multiple files not in this diff |
+| TODO/FIXME left in files changed by this PR | Work that requires design discussion |
+| Small enhancement coherent with the PR's purpose | Performance optimization with unclear scope |
+| Cleanup in files already being modified | Anything that would change the PR's scope significantly |
+
+**The test:** "Would a reviewer expect this to be part of this PR?" If yes → fix now. If no → create issue.
+
+### 7.2c: Apply inline fixes
+
+For each "fix now" item:
+1. Make the fix
+2. Stage it: `git add <files>`
+3. Commit: `git commit -m "fix: <what was fixed>"`
+
+### 7.2d: Re-run tests if fixes were applied
+
+If any inline fixes were made, re-run the test suites from Step 3 to verify no regressions. If tests fail, fix the failure before proceeding.
+
+### 7.2e: Push inline fixes
+
+If new commits were created:
+```bash
+git push
+```
+
+### 7.2f: Hand off deferred items
+
+Record the "create issue" candidates from 7.2b as `DEFERRED_ITEMS` — Step 9 will turn them into GitHub issues. Do not create the issues now (the PR should be open first, so issues can cross-link it).
+
+---
+
 ## Step 7.4: Pre-PR Gates
 
 Before drafting the PR body, run three cheap grep/glob-based gates against the diff, then collect their output. These gates **warn but do not block** by default — surface context so the user can either proceed with intent or pause to address. Each gate runs independently; collect all outputs and show them together before Step 8.
@@ -468,18 +514,18 @@ Create the PR using `gh pr create` with `PR_BODY_DRAFT` passed via HEREDOC. **Ou
 
 ---
 
-## Step 9: Sweep for Deferred Issues
+## Step 9: Create Issues for Deferred Items
 
-After the PR is created, invoke `/sweep-issues` using the Skill tool:
+After the PR is created, turn the `DEFERRED_ITEMS` list from Step 7.2b into GitHub issues. The triage already happened — `/sweep-issues` only needs to create the issues.
 
 ```text
 skill: "sweep-issues"
 args: ""
 ```
 
-This scans the conversation for deferred items, fast-follows, enhancements, minor bugs, and technical debt identified during development — and auto-creates GitHub issues for each.
+`/sweep-issues` re-scans the conversation as a safety net in case new items emerged after Step 7.2 (e.g. from Step 4.5 review or the claim-grep in 8.5). It deduplicates against the `DEFERRED_ITEMS` list and against existing GitHub issues.
 
-**If nothing found:** Continue silently — the PR URL is the final output.
+**If nothing remains to defer:** Continue silently — the PR URL is the final output.
 **If items found:** Create the issues and output the sweep summary. The PR URL remains the last line of output.
 
 ---

--- a/skills/ship/pr-template.md
+++ b/skills/ship/pr-template.md
@@ -4,7 +4,7 @@ Shared template for PR creation across skills (`/ship`, `/execute`, `/receiving-
 
 ## Usage
 
-This is the canonical PR body structure. Both `/ship` (Step 8) and `/receiving-pr-feedback` (Step 4.5) follow this format.
+This is the canonical PR body structure. Both `/ship` (Steps 8 draft + 8.6 create) and `/receiving-pr-feedback` (Step 4.5) follow this format.
 
 - **On initial PR creation** (`/ship`): all sections are generated fresh from the current branch state.
 - **After feedback rounds** (`/receiving-pr-feedback`): dynamic sections (Summary, Important Files, Test Results, Development Flow) are regenerated to reflect fixes. Static sections (How It Works, Pre-Landing Review, Doc Completeness) are preserved as-is. A Revision History section is appended with per-round summaries.
@@ -26,6 +26,11 @@ Parser utility: `.claude/scripts/lib/pr-body-parser.cjs` provides `parsePrBody` 
 ```markdown
 ## Summary
 <1-5 bullet points describing what shipped — derived from CHANGELOG or commit history>
+
+## Pre-PR Gates
+<Findings from Step 7.4 pre-PR gates: size warning, test-presence, spec-contract.
+Omit this section entirely when all gates pass cleanly. Only include when there
+is at least one non-silent finding.>
 
 ## How It Works
 <Mermaid diagram showing the key flow introduced or changed>


### PR DESCRIPTION
## Summary
- **Rust silent-failure lint pack** (5 patterns) scoped to `**/*.rs` via the existing `lint-gate.cjs` hook
- **`/plan` — signal-gated state × event matrix** when paths match `session|actor|state_machine|lifecycle|fsm` or enum signals fire; `--lifecycle` flag overrides
- **`/review` — 2 new agents + 1 signal-gated pass**: Agent H (cross-module format consistency), Agent I (spec-contract deviation), and versioned-struct pass gated on `const *_VERSION` / `version:` fields
- **`/ship` — 4 new pre-PR gates**: PR-size warning (>400 lines), test-presence heuristic, spec-contract deviation with remediate-or-addendum flow, and PR-claim-vs-diff grep that catches "promised but not delivered" symbols in the PR body
- Version bumped to 2.8 across CLAUDE.md / README.md / CHANGELOG.md

## Pre-PR Gates
> ⚠ **PR size: 456 lines added.** Large PRs get surface-level reviews.
> Top files dominating the diff:
>
> | Lines | File |
> |---|---|
> | 193 | `skills/ship/SKILL.md` |
> | 93  | `skills/review/SKILL.md` |
> | 64  | `skills/plan/SKILL.md` |
> | 52  | `config/lint-configs/agent-rules.json` |
> | 28  | `skills/review/checklist.md` |
>
> Split on commit boundaries: this PR is already structured as 5 bisectable commits. Each commit represents one logical improvement and can be reverted independently.

Test-presence gate: silent (2 non-markdown/json code additions, below threshold).
Spec-contract gate: skipped (no spec matches this branch).

## How It Works

```mermaid
flowchart TD
    Diff[git diff origin/main] --> Size{added > 400?}
    Size -->|yes| SizeWarn[⚠ Surface top files]
    Size -->|no| TestGate
    SizeWarn --> TestGate{code > 50<br/>AND tests == 0?}
    TestGate -->|yes| TestWarn[⚠ Name code-only files]
    TestGate -->|no| SpecGate
    TestWarn --> SpecGate{.claude/specs/slug<br/>exists?}
    SpecGate -->|yes| SpecCheck[MISSING / EXTRA<br/>deviations]
    SpecCheck --> Remediate{user choice}
    Remediate -->|A| RevertDiff[revert to spec]
    Remediate -->|B| SpecAddendum[strikethrough + addendum]
    SpecGate -->|no| PRDraft
    Remediate --> PRDraft[Draft PR body]
    PRDraft --> ClaimGrep[grep -F each backticked<br/>claim against diff]
    ClaimGrep -->|all found| Create[gh pr create]
    ClaimGrep -->|missing| UserFix[Edit body or code]
    UserFix --> ClaimGrep
```

## Development Flow

```mermaid
flowchart TD
    S1(execute) --> A1{{code-simplifier: Simplify changed code}}
    A1 --> S2(review)
    S2 --> A2{{code-reviewer: Convention review}}
    S2 --> A3{{general-purpose: Checklist review}}
    S2 --> A4{{general-purpose: Git blame review}}
    S2 --> A5{{general-purpose: Previous PR comments}}
    S2 --> A6{{general-purpose: Comment compliance}}
```

## Important Files

| File | Change |
|------|--------|
| `config/lint-configs/agent-rules.json` | +5 Rust lint patterns with `_pack: rust-silent-failures` grouping |
| `skills/plan/SKILL.md` | `## Arguments` section + `## Lifecycle Detection` block + matrix emission wired into INTERVIEW/BRAINSTORM/REVIEW modes |
| `skills/review/SKILL.md` | Agent H (format-consistency), Agent I (spec-contract), signal-gated versioned-struct pass hook |
| `skills/review/checklist.md` | `## Signal-Gated Passes` section with versioned-struct checklist |
| `skills/ship/SKILL.md` | Step 7.4 (Pre-PR Gates with 3 gates) + Step 8.5 (PR-claim-vs-diff grep) |
| `skills/ship/pr-template.md` | Optional `## Pre-PR Gates` section in template |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md` | v2.8 |

## Test Results

| Suite | Result |
|-------|--------|
| Lint-pattern smoke test | ✅ All 5 Rust patterns fire on synthetic `.rs` input |
| Shell snippet sanity | ✅ Gate 1 (PR size), Gate 2 (test count) validated against real diffs |
| Installer integration | ✅ `node scripts/configure-claude.js .` runs cleanly |
| JSON validity | ✅ `agent-rules.json` parses with 11 rules |

## Pre-Landing Review

5 parallel review agents ran (convention, checklist, git blame, previous PR comments, comment compliance). 8 findings surfaced; 6 fixes applied inline before commit:

| Finding | Action |
|---|---|
| `rust-string-match-err-message` pattern `[^"]+` missed the bare `.contains("not active")` form | **Fixed** — `[^"]+` → `[^"]*` |
| `agent-rules.json` `_description` referenced `lint-gate.js` (actual: `.cjs`) | **Fixed** |
| `skills/plan/SKILL.md` missing `## Arguments` section for `--lifecycle` | **Fixed** |
| Agent I spec-detection missing `SPEC_DIR=""` init (Gate 3 has it) | **Fixed** |
| `pr-template.md` Usage header referenced stale Step 8 | **Fixed** — now `Steps 8 draft + 8.6 create` |
| CHANGELOG `_pack` claim overstated implementation — softened to "forward-looking scaffolding" | **Fixed** |
| `.claude/skills/ship/SKILL.md` sync would have erased project-local `sweep-and-fix-inline` feature (commit `4454110`) | **Reverted** — project-local file left untouched; feature preserved |
| `rust-ok-drops-err` pattern fires on idiomatic `.ok()?` and `.ok().unwrap_or(...)` | **Acknowledged** — tuning fast-follow; user dictated this exact pattern |

## Doc Completeness

- [x] `CHANGELOG.md` updated with v2.8 entry including Why + How-to-apply
- [x] `CLAUDE.md` version bumped (2.7 → 2.8)
- [x] `README.md` version bumped (2.7 → 2.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-ups (added to this PR)

- **#52** — Tune `rust-ok-drops-err` to skip `.ok()?`, `.ok().map/.unwrap_or/.and_then/.or/.ok_or/.filter/.is_some/.inspect/.expect`. Validated: 3 real drops fire, 13 idiomatic patterns correctly skipped.
- **#54** — Port the `sweep-and-fix-inline` flow (commit `4454110`) from the `.claude/` divergence into canonical `skills/ship/SKILL.md` as new Step 7.2. Step 9 consumes the `DEFERRED_ITEMS` handoff.
- **#55** — Drop the `_pack` metadata key. Language scoping is already handled by the `files` glob on each rule.

Closes #52
Closes #54
Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust-specific linting rules for enhanced code analysis
  * Enhanced `/plan` with optional lifecycle detection and state×event matrix generation
  * Expanded `/review` with additional validation agents for format consistency and spec-contract checks
  * Introduced pre-PR gates and verification workflow in `/ship`

* **Chores**
  * Version bumped to 2.10
  * Updated configuration and documentation files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->