### PR TITLE
fix(installer): use lastIndexOf for nested .claude/ path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.8**
+Current version: **2.9**
+
+## [2.9] — 2026-04-20
+
+### Fixed
+
+- `configure-claude.js --force-adopt` and `--claim` no longer reject paths inside nested `.claude/` directories (e.g. calsuite's own git worktrees at `calsuite/.claude/worktrees/<id>/.claude/skills/…`). `destToCalsuiteRel()` and `deriveTargetName()` now anchor on the innermost `.claude/` via `lastIndexOf` instead of the outermost via `indexOf`. Both helpers moved to a new `scripts/lib/path-helpers.cjs` with inline unit tests covering the flat and nested-worktree cases.
+
+### Why
+
+Running `/customise` or `--force-adopt <path>` from inside a calsuite worktree resolved the `.claude/` boundary against the outer `calsuite/.claude/`, so the first path segment became `worktrees` instead of `skills` or `agents` — the installer rejected every path as "not under a target's .claude/skills or .claude/agents". With the innermost-boundary fix, worktree-authored edits can be adopted/claimed through the normal divergence-resolution flow.
 
 ## [2.8] — 2026-04-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.8** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.9** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.8**
+**Version: 2.9**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -33,6 +33,7 @@
 const fs = require('fs');
 const path = require('path');
 const originProtocol = require('./lib/origin-protocol.cjs');
+const { destToCalsuiteRel, deriveTargetName } = require('./lib/path-helpers.cjs');
 
 const CONFIG_REPO = path.resolve(__dirname, '..');
 const HOOKS_JSON = path.join(CONFIG_REPO, 'hooks', 'hooks.json');
@@ -845,33 +846,6 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
   const resolved = resolveProfile(detectedProfiles, profilesConfig);
   installForProfile(targetDir, resolved, detectedProfiles.join(', '), opts);
   return { detectedProfiles, isMonorepo };
-}
-
-/**
- * Given a destination file inside a target's .claude/skills or .claude/agents,
- * return the calsuite-relative path to the same file (skills/<name>/...
- * or agents/<name>.md). Returns null if the path isn't under a recognized
- * managed dir.
- */
-function destToCalsuiteRel(destPath) {
-  const marker = path.sep + '.claude' + path.sep;
-  const idx = destPath.indexOf(marker);
-  if (idx === -1) return null;
-  const afterClaude = destPath.slice(idx + marker.length);
-  const first = afterClaude.split(path.sep)[0];
-  if (first === 'skills' || first === 'agents') {
-    // Normalize to forward-slashes so the path matches calsuite's git-tracked layout on Windows too.
-    return afterClaude.split(path.sep).join('/');
-  }
-  return null;
-}
-
-function deriveTargetName(destPath) {
-  const marker = path.sep + '.claude' + path.sep;
-  const idx = destPath.indexOf(marker);
-  if (idx === -1) return 'local';
-  const targetDir = destPath.slice(0, idx);
-  return path.basename(targetDir);
 }
 
 function promptYesNo(question) {

--- a/scripts/lib/path-helpers.cjs
+++ b/scripts/lib/path-helpers.cjs
@@ -1,0 +1,102 @@
+'use strict';
+
+const path = require('path');
+
+const CLAUDE_MARKER = path.sep + '.claude' + path.sep;
+
+/**
+ * Given a destination file inside a target's .claude/skills or .claude/agents,
+ * return the calsuite-relative path to the same file (skills/<name>/...
+ * or agents/<name>.md). Returns null if the path isn't under a recognized
+ * managed dir.
+ *
+ * Uses lastIndexOf so nested `.claude/` directories (e.g. calsuite's own
+ * worktrees at `calsuite/.claude/worktrees/<id>/.claude/skills/...`) resolve
+ * against the innermost `.claude/` rather than the outer one.
+ */
+function destToCalsuiteRel(destPath) {
+  const idx = destPath.lastIndexOf(CLAUDE_MARKER);
+  if (idx === -1) return null;
+  const afterClaude = destPath.slice(idx + CLAUDE_MARKER.length);
+  const first = afterClaude.split(path.sep)[0];
+  if (first === 'skills' || first === 'agents') {
+    return afterClaude.split(path.sep).join('/');
+  }
+  return null;
+}
+
+function deriveTargetName(destPath) {
+  const idx = destPath.lastIndexOf(CLAUDE_MARKER);
+  if (idx === -1) return 'local';
+  const targetDir = destPath.slice(0, idx);
+  return path.basename(targetDir);
+}
+
+module.exports = { destToCalsuiteRel, deriveTargetName };
+
+if (require.main === module) {
+  const assert = require('assert');
+  const sep = path.sep;
+  const j = (...parts) => parts.join(sep);
+
+  // destToCalsuiteRel: flat target path
+  assert.strictEqual(
+    destToCalsuiteRel(j('', 'Users', 'x', 'proj', '.claude', 'skills', 'plan', 'SKILL.md')),
+    'skills/plan/SKILL.md',
+    'flat skills path'
+  );
+  assert.strictEqual(
+    destToCalsuiteRel(j('', 'Users', 'x', 'proj', '.claude', 'agents', 'reviewer.md')),
+    'agents/reviewer.md',
+    'flat agents path'
+  );
+
+  // destToCalsuiteRel: nested .claude (calsuite worktree scenario)
+  const nested = j('', 'Users', 'x', 'Projects', 'calsuite', '.claude', 'worktrees', 'charming-buck-afc54a', '.claude', 'skills', 'plan', 'SKILL.md');
+  assert.strictEqual(
+    destToCalsuiteRel(nested),
+    'skills/plan/SKILL.md',
+    'nested .claude resolves against innermost'
+  );
+  const nestedAgent = j('', 'Users', 'x', 'Projects', 'calsuite', '.claude', 'worktrees', 'foo', '.claude', 'agents', 'r.md');
+  assert.strictEqual(
+    destToCalsuiteRel(nestedAgent),
+    'agents/r.md',
+    'nested .claude agents path'
+  );
+
+  // destToCalsuiteRel: rejects unknown first segment
+  assert.strictEqual(
+    destToCalsuiteRel(j('', 'x', '.claude', 'settings.json')),
+    null,
+    'non-managed dir returns null'
+  );
+  assert.strictEqual(
+    destToCalsuiteRel(j('', 'x', 'no-claude-here', 'skills', 'plan.md')),
+    null,
+    'missing .claude returns null'
+  );
+
+  // deriveTargetName: flat
+  assert.strictEqual(
+    deriveTargetName(j('', 'Users', 'x', 'my-repo', '.claude', 'skills', 'plan', 'SKILL.md')),
+    'my-repo',
+    'flat target name'
+  );
+
+  // deriveTargetName: nested — innermost .claude wins, so target is the worktree dir
+  assert.strictEqual(
+    deriveTargetName(nested),
+    'charming-buck-afc54a',
+    'nested target name is innermost parent'
+  );
+
+  // deriveTargetName: no .claude
+  assert.strictEqual(
+    deriveTargetName(j('', 'x', 'y', 'z.md')),
+    'local',
+    'no .claude returns local'
+  );
+
+  console.log('path-helpers.cjs: all tests passed');
+}


### PR DESCRIPTION
## Summary
- Fixed `destToCalsuiteRel()` and `deriveTargetName()` resolving the `.claude/` boundary against the outermost marker, so paths inside calsuite's own worktrees (`calsuite/.claude/worktrees/<id>/.claude/skills/…`) were rejected by `--force-adopt` and `--claim`.
- Switched both helpers to `lastIndexOf` so the innermost `.claude/` wins, matching the actual target boundary.
- Extracted the helpers to `scripts/lib/path-helpers.cjs` with inline unit tests (`node scripts/lib/path-helpers.cjs`) covering the flat case, the nested-worktree case, and the rejection branches.
- Bumped to v2.9 with a CHANGELOG entry.

## How It Works

```mermaid
flowchart TD
    A["destPath: calsuite/.claude/worktrees/id/.claude/skills/plan/SKILL.md"] --> B{Find /.claude/ marker}
    B -->|Before: indexOf| C["idx → outer .claude/"]
    B -->|After: lastIndexOf| D["idx → inner .claude/"]
    C --> E["first segment: 'worktrees'"]
    D --> F["first segment: 'skills'"]
    E --> G["❌ rejected: not under skills/agents"]
    F --> H["✓ returns 'skills/plan/SKILL.md'"]
```

## Important Files
| File | Change |
|------|--------|
| `scripts/lib/path-helpers.cjs` | New module housing `destToCalsuiteRel` + `deriveTargetName` with `lastIndexOf` fix and inline `require.main === module` unit tests |
| `scripts/configure-claude.js` | Removed inline copies of both helpers; imports them from the new lib module |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md` | Version bump 2.8 → 2.9 with the `### Fixed` entry |

## Test Results
| Suite | Result |
|-------|--------|
| `node scripts/lib/path-helpers.cjs` | ✅ all assertions pass |
| `node --check scripts/configure-claude.js` | ✅ syntax OK |
| Integration: `node scripts/configure-claude.js /tmp/test` | ✅ installer completes (27 skills / 1 agent / 19 hooks) |

## Pre-Landing Review
No critical issues. Two informational notes from the convention agent:
- `scripts/configure-claude.js:228` has stale `(issue #42) three-way merge` help text — pre-existing on `origin/main` now that `--reconcile` shipped, not introduced by this diff.
- `'use strict';` at the top of the new `path-helpers.cjs` is one of the only `.cjs` files in `scripts/lib/` that uses it. Stylistic only; left alone.

During review, `origin/main` advanced with PR #50 (the `--reconcile` ship). Pulled those commits in via fast-forward merge before finalizing — the new `handleReconcile` function already consumes `destToCalsuiteRel` / `deriveTargetName`, so it transparently picks up the `lastIndexOf` fix.

## Doc Completeness
- [x] CHANGELOG.md updated (v2.9 entry)
- [x] CLAUDE.md updated (version bump)
- [ ] tasks.md — N/A, not spec work

🤖 Generated with [Claude Code](https://claude.com/claude-code)