### PR TITLE
feat(installer): add --prune-stale for opt-in orphan cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.11**
+Current version: **2.12**
+
+## [2.12] — 2026-04-21
+
+### Added
+
+- `configure-claude.js --prune-stale [path]` — opt-in cleanup of orphaned calsuite state from prior distribution models. Three categories: **[A]** parent-level symlinks under `~/Projects/.claude/{skills,agents}` that point into calsuite (no longer discovered by Claude Code post-refactor); **[B]** mixed `<target>/.claude/scripts/{hooks,lib}` dirs where calsuite symlinks coexist with user files (the existing `--sync` pure-symlink-dir auto-cleanup skips mixed dirs); **[C]** skill/agent markdown files with no `_origin` that diverge from calsuite's current (row 6 of the safe-overwrite matrix — `decideFileAction → skip-unknown`). Without a path, iterates every target in `config/targets.json`; with a path, scopes to that single target and skips the global category A sweep. Dry-run by default — pass `--yes` to apply. Categories A & B remove automatically under `--yes`; category C always prompts per-file because deleting a potentially-edited file is irreversible. Non-TTY + `--yes` + category C candidates errors out rather than silently skipping or deleting. Respects user-added files by only considering category C candidates whose basename matches a calsuite source (cleaner signal than parsing `.gitignore`). Closes [#41](https://github.com/ckallum/calsuite/issues/41).
+
+### Why
+
+The v2.6 personal-harness-refactor intentionally left orphaned state on disk — deleting across five target repos is a footgun that belongs to the user, not the installer. `--prune-stale` is the clean way to reconcile that orphan state when the user is ready. Complements the certain-safe pure-symlink-dir cleanup that `--sync` already performs automatically.
 
 ## [2.11] — 2026-04-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.11** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.12** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.11**
+**Version: 2.12**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -27,6 +27,16 @@
  *                                at install sha, and target-current side-by-side, then
  *                                offers keep / adopt / merge-in-$EDITOR / skip. Requires
  *                                a TTY.
+ *   --prune-stale [path]         Clean orphaned calsuite state from prior distribution
+ *                                models: (A) parent-level orphan symlinks under
+ *                                ~/Projects/.claude/{skills,agents}, (B) mixed
+ *                                .claude/scripts/{hooks,lib} dirs containing calsuite
+ *                                symlinks alongside user files, and (C) stale
+ *                                skill/agent .md files without `_origin` that diverge
+ *                                from calsuite's current. Without `<path>`, iterates
+ *                                every target in config/targets.json. Dry-run by
+ *                                default; pass --yes to apply. Category C always
+ *                                prompts per-file (no bulk delete).
  *   --yes, -y                    Skip confirmation prompts for destructive operations.
  */
 
@@ -1104,6 +1114,368 @@ function handleReconcile(targetPath) {
   console.log(`  ✓ Merged. ${destPath} ← calsuite@${currentSha} (user-resolved)`);
 }
 
+/**
+ * True if `entryPath` is a symlink whose resolved target lives inside
+ * `calsuiteDir` (or equals it). Used to distinguish calsuite-placed
+ * symlinks — safe to remove — from user-placed files/symlinks.
+ */
+function isCalsuiteSymlink(entryPath, calsuiteDir) {
+  let stat;
+  try {
+    stat = fs.lstatSync(entryPath);
+  } catch {
+    return false;
+  }
+  if (!stat.isSymbolicLink()) return false;
+  const linkTarget = fs.readlinkSync(entryPath);
+  const resolved = path.resolve(path.dirname(entryPath), linkTarget);
+  return resolved === calsuiteDir || resolved.startsWith(calsuiteDir + path.sep);
+}
+
+/**
+ * Walk a directory recursively and yield every file path. Symlinks are
+ * reported as files (no follow). Missing dirs yield nothing.
+ */
+function walkFilesRecursive(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  const stack = [dir];
+  while (stack.length) {
+    const cur = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(cur, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const full = path.join(cur, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+      } else {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Opt-in cleanup of orphaned calsuite state left behind by prior
+ * distribution models. Three categories:
+ *   [A] Parent-level symlinks under ~/Projects/.claude/{skills,agents}
+ *       pointing into calsuite. Nothing reads these since the refactor
+ *       (Claude Code doesn't discover parent .claude/ skill dirs).
+ *   [B] Mixed `<target>/.claude/scripts/{hooks,lib}` dirs — calsuite
+ *       symlinks alongside user files. The `--sync` pure-symlink-dir
+ *       auto-cleanup can't handle the mixed case; this prompts per-file.
+ *   [C] Skill/agent .md files without `_origin` that diverge from calsuite
+ *       current (decideFileAction → 'skip-unknown'). Only those whose
+ *       filename matches a calsuite source — foreign files are treated
+ *       as user-added and left alone (stand-in for honoring .gitignore).
+ *
+ * Dry-run by default. `--yes` applies A & B automatically; C always
+ * prompts per-file, since deleting a potentially-edited file is
+ * irreversible. Non-TTY + apply mode + category C candidates errors out.
+ *
+ * Without `<path>`, iterates every target in config/targets.json and
+ * treats category A as a global one-shot before the per-target loop.
+ */
+function handlePruneStale(targetPath, { assumeYes = false } = {}) {
+  const calsuiteDir = resolveCalsuiteDir();
+
+  // Resolve which targets to walk.
+  let targets;
+  if (targetPath) {
+    const resolved = path.resolve(targetPath);
+    if (!fs.existsSync(resolved)) {
+      console.error(`  ✗ ${resolved} does not exist`);
+      process.exit(1);
+    }
+    targets = [{ path: resolved, label: path.basename(resolved) }];
+  } else {
+    const targetsJson = readJsonSync(TARGETS_JSON);
+    if (!targetsJson?.targets?.length) {
+      console.error('  ✗ No targets found in config/targets.json');
+      process.exit(1);
+    }
+    targets = [];
+    for (const t of targetsJson.targets) {
+      const resolved = path.resolve(t.path.replace(/^~/, HOME_DIR));
+      if (!fs.existsSync(resolved)) {
+        console.log(`  ⚠ Skipping ${t.path} (not found)`);
+        continue;
+      }
+      targets.push({ path: resolved, label: path.basename(resolved) });
+    }
+    if (!targets.length) {
+      console.error('  ✗ No reachable targets to prune.');
+      process.exit(1);
+    }
+  }
+
+  const mode = assumeYes ? 'apply' : 'dry-run';
+  console.log(`\n--- prune-stale (${mode}) ---`);
+  if (!assumeYes) {
+    console.log('  Dry-run only. Re-run with --yes to actually remove items.');
+  }
+
+  let totalRemoved = 0;
+  let totalKeptByUser = 0;
+
+  // --- Category A (global; run once when no per-target path was given) ---
+  if (!targetPath) {
+    console.log('\n  [A] Parent-level orphan symlinks');
+    const parentClaude = path.join(HOME_DIR, 'Projects', '.claude');
+    const parentDirs = [
+      path.join(parentClaude, 'skills'),
+      path.join(parentClaude, 'agents'),
+    ];
+
+    let anyA = false;
+    for (const dir of parentDirs) {
+      if (!fs.existsSync(dir)) continue;
+      let entries;
+      try {
+        entries = fs.readdirSync(dir);
+      } catch {
+        continue;
+      }
+      for (const name of entries) {
+        const full = path.join(dir, name);
+        if (!isCalsuiteSymlink(full, calsuiteDir)) continue;
+        anyA = true;
+        const linkTarget = path.resolve(dir, fs.readlinkSync(full));
+        if (assumeYes) {
+          try {
+            fs.unlinkSync(full);
+            console.log(`  ✓ Removed ${full} (→ ${linkTarget})`);
+            totalRemoved++;
+          } catch (err) {
+            console.log(`  ✗ Failed to remove ${full}: ${err.message}`);
+          }
+        } else {
+          console.log(`  · would remove: ${full}  (→ ${linkTarget})`);
+        }
+      }
+      // In apply mode, if the dir is now empty, remove it too.
+      if (assumeYes && fs.existsSync(dir)) {
+        let remaining;
+        try {
+          remaining = fs.readdirSync(dir);
+        } catch {
+          remaining = ['?'];
+        }
+        if (remaining.length === 0) {
+          try {
+            fs.rmdirSync(dir);
+            console.log(`  ✓ Removed empty dir ${dir}`);
+          } catch (err) {
+            console.log(`  ✗ Failed to remove dir ${dir}: ${err.message}`);
+          }
+        }
+      }
+    }
+    // Also remove the parent ~/Projects/.claude/ dir if both children are gone
+    // and it has no other content.
+    if (assumeYes && fs.existsSync(parentClaude)) {
+      let parentEntries;
+      try {
+        parentEntries = fs.readdirSync(parentClaude);
+      } catch {
+        parentEntries = ['?'];
+      }
+      if (parentEntries.length === 0) {
+        try {
+          fs.rmdirSync(parentClaude);
+          console.log(`  ✓ Removed empty dir ${parentClaude}`);
+        } catch {
+          /* non-fatal */
+        }
+      }
+    }
+    if (!anyA) console.log('  (none)');
+  }
+
+  // --- Per-target categories B and C ---
+  for (const target of targets) {
+    console.log(`\n--- Pruning: ${target.label} (${target.path}) ---`);
+
+    // Category B: mixed scripts/hooks, scripts/lib dirs.
+    console.log('\n  [B] Stale scripts/hooks, scripts/lib dirs');
+    const scriptsDirs = [
+      path.join(target.path, '.claude', 'scripts', 'hooks'),
+      path.join(target.path, '.claude', 'scripts', 'lib'),
+    ];
+    let anyB = false;
+    for (const dir of scriptsDirs) {
+      if (!fs.existsSync(dir)) continue;
+      let stat;
+      try {
+        stat = fs.lstatSync(dir);
+      } catch {
+        continue;
+      }
+      if (!stat.isDirectory()) continue;
+
+      let entries;
+      try {
+        entries = fs.readdirSync(dir);
+      } catch {
+        continue;
+      }
+
+      const calsuiteLinks = [];
+      const preserved = [];
+      for (const name of entries) {
+        const full = path.join(dir, name);
+        if (isCalsuiteSymlink(full, calsuiteDir)) {
+          calsuiteLinks.push(full);
+        } else {
+          preserved.push(full);
+        }
+      }
+
+      if (calsuiteLinks.length === 0 && preserved.length === 0) {
+        // Empty dir — remove it in apply mode.
+        if (assumeYes) {
+          try {
+            fs.rmdirSync(dir);
+            console.log(`  ✓ Removed empty dir ${dir}`);
+            totalRemoved++;
+            anyB = true;
+          } catch {
+            /* non-fatal */
+          }
+        } else {
+          console.log(`  · would remove empty dir: ${dir}`);
+          anyB = true;
+        }
+        continue;
+      }
+
+      if (calsuiteLinks.length === 0) {
+        // Purely user content — leave alone.
+        continue;
+      }
+
+      anyB = true;
+      if (preserved.length === 0) {
+        // All calsuite symlinks — noted that --sync auto-cleanup handles
+        // this case too, but we can act directly here.
+        for (const link of calsuiteLinks) {
+          const linkTarget = path.resolve(dir, fs.readlinkSync(link));
+          if (assumeYes) {
+            try {
+              fs.unlinkSync(link);
+              console.log(`  ✓ Removed ${link} (→ ${linkTarget})`);
+              totalRemoved++;
+            } catch (err) {
+              console.log(`  ✗ Failed to remove ${link}: ${err.message}`);
+            }
+          } else {
+            console.log(`  · would remove: ${link}  (→ ${linkTarget})`);
+          }
+        }
+        if (assumeYes) {
+          try {
+            fs.rmdirSync(dir);
+            console.log(`  ✓ Removed empty dir ${dir}`);
+          } catch {
+            /* non-fatal */
+          }
+        } else {
+          console.log(`  · would remove empty dir: ${dir} (after symlinks)`);
+        }
+      } else {
+        // Mixed dir: prune calsuite symlinks only, leave user files.
+        for (const link of calsuiteLinks) {
+          const linkTarget = path.resolve(dir, fs.readlinkSync(link));
+          if (assumeYes) {
+            try {
+              fs.unlinkSync(link);
+              console.log(`  ✓ Removed ${link} (→ ${linkTarget})`);
+              totalRemoved++;
+            } catch (err) {
+              console.log(`  ✗ Failed to remove ${link}: ${err.message}`);
+            }
+          } else {
+            console.log(`  · would remove: ${link}  (→ ${linkTarget})  (mixed dir: ${preserved.length} user file(s) preserved)`);
+          }
+        }
+      }
+    }
+    if (!anyB) console.log('  (none)');
+
+    // Category C: stale skill/agent files without _origin that diverge.
+    console.log('\n  [C] Stale skill/agent files without _origin');
+    const skillDir = path.join(target.path, '.claude', 'skills');
+    const agentDir = path.join(target.path, '.claude', 'agents');
+    const candidates = [
+      ...walkFilesRecursive(skillDir),
+      ...walkFilesRecursive(agentDir),
+    ].filter(p => p.endsWith('.md'));
+
+    const stale = [];
+    for (const destFile of candidates) {
+      const calsuiteRel = destToCalsuiteRel(destFile);
+      if (!calsuiteRel) continue;
+      const srcFile = path.join(calsuiteDir, calsuiteRel);
+      // User-added file with no calsuite counterpart → not ours to prune.
+      if (!fs.existsSync(srcFile)) continue;
+
+      let decision;
+      try {
+        decision = originProtocol.decideFileAction(destFile, calsuiteRel, calsuiteDir);
+      } catch (err) {
+        console.log(`  ⚠ Unable to inspect ${destFile}: ${err.message}`);
+        continue;
+      }
+      if (decision.action === 'skip-unknown') {
+        stale.push({ destFile, reason: decision.reason });
+      }
+    }
+
+    if (stale.length === 0) {
+      console.log('  (none)');
+    } else if (!assumeYes) {
+      for (const { destFile, reason } of stale) {
+        console.log(`  · would remove: ${destFile}  (${reason})`);
+      }
+    } else {
+      // Apply mode requires a TTY for the per-file prompts.
+      if (!process.stdin.isTTY) {
+        console.error(`  ✗ --prune-stale --yes found category C candidate(s) but stdin is not a TTY.`);
+        console.error(`    Category C deletions require per-file confirmation — re-run interactively.`);
+        process.exit(1);
+      }
+      for (const { destFile, reason } of stale) {
+        const confirmed = promptYesNo(`Remove ${destFile}? (${reason})`);
+        if (confirmed) {
+          try {
+            fs.unlinkSync(destFile);
+            console.log(`  ✓ Removed ${destFile}`);
+            totalRemoved++;
+          } catch (err) {
+            console.log(`  ✗ Failed to remove ${destFile}: ${err.message}`);
+          }
+        } else {
+          console.log(`  ⊘ Kept ${destFile}`);
+          totalKeptByUser++;
+        }
+      }
+    }
+  }
+
+  console.log('');
+  if (assumeYes) {
+    const keptSuffix = totalKeptByUser > 0 ? ` ${totalKeptByUser} candidate(s) skipped.` : '';
+    console.log(`Pruned ${totalRemoved} item(s) across ${targets.length} target(s).${keptSuffix}`);
+  } else {
+    console.log(`Dry-run complete across ${targets.length} target(s). Re-run with --yes to apply.`);
+  }
+}
+
 function parseArgv() {
   const args = process.argv.slice(2);
   const flags = {};
@@ -1154,6 +1526,12 @@ function parseArgv() {
       }
       flags.reconcile = next;
       i++;
+    } else if (args[i] === '--prune-stale') {
+      flags.pruneStale = true;
+      // Optional path: only consume next arg if it's not another flag.
+      if (args[i + 1] && !args[i + 1].startsWith('--')) {
+        flags.pruneStalePath = args[++i];
+      }
     } else if (args[i].startsWith('--')) {
       console.error(`  ✗ Unknown flag: ${args[i]}`);
       process.exit(1);
@@ -1185,6 +1563,10 @@ function main() {
   }
   if (flags.reconcile) {
     handleReconcile(flags.reconcile);
+    return;
+  }
+  if (flags.pruneStale) {
+    handlePruneStale(flags.pruneStalePath || null, { assumeYes: flags.yes });
     return;
   }
 


### PR DESCRIPTION
## Summary
- Add `node scripts/configure-claude.js --prune-stale [path]` — opt-in cleanup of three orphan categories left by pre-refactor distribution models. Dry-run by default; `--yes` to apply.
- **[A]** Parent-level symlinks under `~/Projects/.claude/{skills,agents}` pointing into calsuite (leftover from the deleted `syncParentAssets()`).
- **[B]** Mixed `<target>/.claude/scripts/{hooks,lib}` dirs — calsuite symlinks alongside user files. The existing `--sync` pure-symlink-dir auto-cleanup handles the all-symlinks case; this fills the mixed-dir gap by pruning calsuite symlinks per-file while preserving user content.
- **[C]** Skill/agent `.md` files without `_origin` that diverge from calsuite current (`decideFileAction → skip-unknown`). Always prompts per-file, even under `--yes` — deleting potentially-edited files is irreversible, so bulk delete is off the table. Files without a matching calsuite source are left alone (user-added).
- Without a `<path>`, iterates every target in `config/targets.json`. Category A runs once globally before the per-target loop.
- Version bump 2.8 → 2.9; CHANGELOG entry closes [#41](https://github.com/ckallum/calsuite/issues/41).

## How It Works
```mermaid
flowchart TD
    A["--prune-stale [path]"] --> B{path given?}
    B -- yes --> C[Single target]
    B -- no --> D[Every target in config/targets.json]
    C --> E[Category A: global check, once]
    D --> E
    E --> F[Category B: per-target mixed scripts dirs]
    F --> G[Category C: per-target stale _origin-less .md files]
    G --> H{--yes?}
    H -- no --> I[Dry-run: list candidates, no removals]
    H -- yes --> J{Category C candidates + non-TTY?}
    J -- yes --> K[Error: requires interactive confirmation]
    J -- no --> L[Apply: A+B auto-remove, C prompts per file]
```

## Important Files
| File | Change |
|------|--------|
| `scripts/configure-claude.js` | Add `handlePruneStale`, `isCalsuiteSymlink`, `walkFilesRecursive`; `--prune-stale` argparse branch (optional positional path); `main()` dispatch; top-of-file `Flags:` docstring. No edits to any other handler. |
| `CHANGELOG.md` | New `[2.9] — 2026-04-20` block; bumped `Current version`. |
| `CLAUDE.md`, `README.md` | Version header bumped 2.8 → 2.9. |

No changes to `scripts/lib/origin-protocol.cjs` — reuses `decideFileAction`, `readOrigin`. Reuses in-file helpers `destToCalsuiteRel`, `resolveCalsuiteDir`, `readJsonSync`, `promptYesNo`.

## Test Results
| Scenario | Result |
|----------|--------|
| Dry-run on clean fresh install | ✅ All categories `(none)` |
| Error path (`--prune-stale /tmp/nonexistent/`) | ✅ Clean error, exit 1 |
| Synthetic mixed scripts dir + synthetic row-6 skill | ✅ Both listed under the correct category |
| Apply mode (`--yes`) with non-TTY + category C candidates | ✅ Errors out rather than silently delete |
| Apply mode against a live machine state | ✅ Removed orphan calsuite symlinks under `~/Projects/.claude/{skills,agents}`, preserved all real content (`CLAUDE.md`, `docs/`, `.git/`, `settings.local.json`). Idempotent — follow-up dry-run reported `(none)`. |

## Pre-Landing Review
No issues found. Scope strictly limited to new handler + argparse + dispatch + docstring.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md + README.md
- [x] `Flags:` docstring at top of `scripts/configure-claude.js` updated