### PR TITLE
chore(config): gitignore targets.json, add targets.example.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 # calsuite (personal harness) — never commit
 .claude/settings.local.json
+
+# Local target repo list — each user maintains their own.
+# Copy config/targets.example.json to config/targets.json to populate.
+/config/targets.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this repository.
 
-Current version: **2.12**
+Current version: **2.13**
+
+## [2.13] — 2026-04-21
+
+### Changed
+
+- `config/targets.json` is now **gitignored and untracked**. Each user maintains their own local target list. A committed `config/targets.example.json` ships as the template — copy it to `config/targets.json` to populate. Removes the personal-info leak where target repo names (previously checked in) were visible in the public repo. Existing forks keep their in-history copies; to scrub history, rewrite with `git filter-repo` separately.
+- Installer error messages for `--sync` and `--prune-stale` now distinguish "file missing" from "file empty" and point users to the example file.
+
+### Why
+
+`targets.json` was the only personally-identifying thing in the tracked tree — a list of the user's side projects. Nothing secret, but nothing anyone else needs either. Moving to an example-plus-local split mirrors how every other user-specific file in the repo works (`~/.mcp.json`, `settings.local.json`, etc.) and removes a small ongoing leak with each new entry.
 
 ## [2.12] — 2026-04-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.12** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.13** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.12**
+**Version: 2.13**
 
 ## Getting started
 
@@ -18,7 +18,7 @@ Repo layout:
 hooks/       # Shell commands triggered by Claude Code events
 commands/    # Custom slash commands
 scripts/     # configure-claude installer, scripts/hooks/*.cjs, scripts/lib/*.cjs
-config/      # global-settings.json (manifest), profiles.json, targets.json
+config/      # global-settings.json (manifest), profiles.json, targets.example.json (copy to targets.json; gitignored)
 plugins/     # Claude Code plugins
 skills/      # Markdown skills (invoked as /skill-name)
 agents/      # Agent definitions (invoked as @agent-name)

--- a/config/targets.example.json
+++ b/config/targets.example.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Copy this file to config/targets.json and replace the paths with your own target repos. targets.json is gitignored — it stays local and is never committed. Paths may use '~' for your home directory; the installer expands it.",
+  "targets": [
+    { "path": "~/Projects/my-first-repo" },
+    { "path": "~/Projects/my-second-repo" }
+  ]
+}

--- a/config/targets.json
+++ b/config/targets.json
@@ -1,9 +1,0 @@
-{
-  "targets": [
-    { "path": "~/Projects/verity" },
-    { "path": "~/Projects/timeline" },
-    { "path": "~/Projects/museli" },
-    { "path": "~/Projects/cake" },
-    { "path": "~/Projects/elliente" }
-  ]
-}

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -1195,8 +1195,14 @@ function handlePruneStale(targetPath, { assumeYes = false } = {}) {
     targets = [{ path: resolved, label: path.basename(resolved) }];
   } else {
     const targetsJson = readJsonSync(TARGETS_JSON);
+    if (!targetsJson) {
+      console.error('  ✗ config/targets.json not found.');
+      console.error('    Copy config/targets.example.json to config/targets.json and add your target repo paths.');
+      console.error('    (targets.json is gitignored so each user maintains their own list.)');
+      process.exit(1);
+    }
     if (!targetsJson?.targets?.length) {
-      console.error('  ✗ No targets found in config/targets.json');
+      console.error('  ✗ config/targets.json has no targets. Add at least one entry under "targets".');
       process.exit(1);
     }
     targets = [];
@@ -1584,8 +1590,14 @@ function main() {
   // Handle --sync mode: re-run install against all targets in config/targets.json
   if (flags.sync) {
     const targets = readJsonSync(TARGETS_JSON);
+    if (!targets) {
+      console.error('  ✗ config/targets.json not found.');
+      console.error('    Copy config/targets.example.json to config/targets.json and add your target repo paths.');
+      console.error('    (targets.json is gitignored so each user maintains their own list.)');
+      process.exit(1);
+    }
     if (!targets?.targets?.length) {
-      console.error('  ✗ No targets found in config/targets.json');
+      console.error('  ✗ config/targets.json has no targets. Add at least one entry under "targets".');
       process.exit(1);
     }
 


### PR DESCRIPTION
## Summary
- Untrack `config/targets.json` and gitignore it (`/config/targets.json` rule). Each user maintains their own local target list.
- Add `config/targets.example.json` as the committed template with generic placeholder paths and an inline `_comment` explaining the copy-to-targets.json flow.
- Installer error messages for `--sync` and `--prune-stale` now distinguish "file missing" (points to the example) from "file empty" (asks for at least one entry).
- Closes the personal-info leak where side-project names were visible in the public repo. Existing history is not scrubbed — a separate `git filter-repo` pass is required if old commits need cleaning too.
- Version bump 2.12 → 2.13.

## How It Works
```mermaid
flowchart TD
    A[Fresh clone] --> B{config/targets.json exists?}
    B -- no --> C[Installer --sync: ✗ points to targets.example.json]
    B -- yes --> D{targets array non-empty?}
    D -- no --> E[Installer --sync: ✗ add at least one entry]
    D -- yes --> F[Proceed with sync]
    G[User action on fresh clone] --> H[cp config/targets.example.json config/targets.json]
    H --> I[Edit paths → run --sync]
```

## Important Files
| File | Change |
|------|--------|
| `.gitignore` | Add `/config/targets.json` (rooted so a nested target's copy is not affected). |
| `config/targets.example.json` | New committed template. `_comment` field + two placeholder paths. |
| `config/targets.json` | Removed from tracking via `git rm --cached`. Local file preserved on disk. |
| `scripts/configure-claude.js` | Split "not found" vs "empty" errors in two call sites (`--sync` main dispatch, `handlePruneStale` multi-target path). Both now point to the example file. |
| `CHANGELOG.md` | New `[2.13]` entry. |
| `CLAUDE.md`, `README.md` | Version bump + README layout line updated to mention `targets.example.json`. |

## Test Results
| Scenario | Result |
|----------|--------|
| `--sync` with `config/targets.json` missing | ✅ New three-line error pointing to example file, exit 1 |
| `node configure-claude.js /tmp/test-project` (normal install) | ✅ Full install succeeds, no regression |
| `git check-ignore -v config/targets.json` | ✅ Matched by `.gitignore:10:/config/targets.json` |

## Pre-Landing Review
No issues found. Scope limited to config layout + error message copy + version bump.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md + README.md
- [x] README repo-layout line updated to reference `targets.example.json`