### PR TITLE
feat(skills): add /sync and /sync-preview calsuite-internal skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 All notable changes to this repository.
 
-Current version: **2.13**
+Current version: **2.14**
+
+## [2.14] — 2026-04-21
+
+### Added
+
+- `scripts/sync-preview.cjs` — read-only preview of what `configure-claude.js --sync` would do across every target in `config/targets.json`. Walks each target's installed `.claude/skills` + `.claude/agents` markdown, calls `decideFileAction` per file, aggregates into `write-new` / `write-update` / `migrate` / `skip-diverged` / `skip-unknown` / `skip-claimed` buckets with per-target and grand-total counts. Supports `--target <name>` to scope and `--json` for machine-readable output. Writes nothing — safe any time.
+- `/sync-preview` calsuite-internal skill — wraps the script, interprets the output (e.g. 28 skip-unknowns → suggest `/reconcile-targets`; 3 skip-diverged on one target → suggest per-file `--reconcile` commands). Never distributed to targets.
+- `/sync` calsuite-internal skill — wraps `configure-claude.js --sync` with pre-flight, interpretation of the divergence summary, and proactive suggestions (picks the smallest-viable follow-up: direct commands for 1–3 files, `/reconcile-targets` for 4+). Supports `/sync preview` which delegates to `/sync-preview` for dry-run.
+- `sync` and `sync-preview` added to `INTERNAL_SKILLS` in `configure-claude.js` so they're listed in the `base`/`monorepo-root` profiles for completeness but filtered out at install time — the skills only make sense inside the calsuite repo itself.
+
+### Why
+
+Previously, the manual-sync workflow required remembering to type `node scripts/configure-claude.js --sync` and interpreting raw output. The two new skills collapse that into a command-palette interaction plus inline interpretation of what's next. `/sync-preview` in particular turns the "what's the current divergence state" question into a one-line command that produces a readable report — useful before kicking off the heavier `/reconcile-targets` agentic pass.
 
 ## [2.13] — 2026-04-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.13** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.14** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.13**
+**Version: 2.14**
 
 ## Getting started
 

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets"],
+      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets", "sync", "sync-preview"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets"],
+      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets", "sync", "sync-preview"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -60,7 +60,7 @@ const HOME_SETTINGS_LOCAL = path.join(HOME_DIR, '.claude', 'settings.local.json'
 const HOME_MCP_JSON = path.join(HOME_DIR, '.mcp.json');
 const KNOWN_MARKETPLACES = path.join(HOME_DIR, '.claude', 'plugins', 'known_marketplaces.json');
 // Skills that only make sense in the config repo itself — never export to target repos
-const INTERNAL_SKILLS = new Set(['configure-claude', 'skill-builder']);
+const INTERNAL_SKILLS = new Set(['configure-claude', 'skill-builder', 'sync', 'sync-preview']);
 
 /**
  * Resolve the absolute path to the calsuite checkout on this machine.

--- a/scripts/sync-preview.cjs
+++ b/scripts/sync-preview.cjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+
+/**
+ * sync-preview.cjs
+ *
+ * Read-only preview of what `configure-claude.js --sync` would do across
+ * every target in config/targets.json. Walks each target's installed
+ * .claude/skills + .claude/agents markdown and calls decideFileAction on
+ * each; aggregates the results into per-target and grand-total buckets.
+ *
+ * Writes NOTHING. Safe to run any time. Intended companion to /sync-preview
+ * skill and to /reconcile-targets when you want a quick divergence snapshot
+ * before committing to an agentic pass.
+ *
+ * Usage:
+ *   node scripts/sync-preview.cjs          # all targets in config/targets.json
+ *   node scripts/sync-preview.cjs --target <name>   # filter to one target by basename
+ *   node scripts/sync-preview.cjs --json   # machine-readable output
+ *
+ * Exit codes:
+ *   0 — ran to completion (regardless of divergence count)
+ *   1 — fatal error (missing targets.json, missing calsuite, etc.)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const CALSUITE_DIR = path.resolve(__dirname, '..');
+const originProtocol = require(path.join(CALSUITE_DIR, 'scripts/lib/origin-protocol.cjs'));
+
+const HOME = os.homedir();
+const TARGETS_JSON = path.join(CALSUITE_DIR, 'config/targets.json');
+const EXAMPLE_JSON = path.join(CALSUITE_DIR, 'config/targets.example.json');
+const SKILLS_DIR = path.join(CALSUITE_DIR, 'skills');
+const AGENTS_DIR = path.join(CALSUITE_DIR, 'agents');
+
+function parseArgv() {
+  const args = process.argv.slice(2);
+  const flags = { json: false, target: null };
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--json') flags.json = true;
+    else if (args[i] === '--target') flags.target = args[++i];
+    else if (args[i].startsWith('--')) {
+      console.error(`✗ Unknown flag: ${args[i]}`);
+      process.exit(1);
+    }
+  }
+  return flags;
+}
+
+function expandHome(p) {
+  return p.startsWith('~') ? path.join(HOME, p.slice(1)) : p;
+}
+
+function walkMd(dir) {
+  const out = [];
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkMd(full));
+    else if (entry.isFile() && entry.name.endsWith('.md')) out.push(full);
+  }
+  return out;
+}
+
+function destToCalsuiteRel(destPath) {
+  const marker = path.sep + '.claude' + path.sep;
+  const idx = destPath.indexOf(marker);
+  if (idx === -1) return null;
+  const after = destPath.slice(idx + marker.length);
+  const first = after.split(path.sep)[0];
+  if (first !== 'skills' && first !== 'agents') return null;
+  return after.split(path.sep).join('/');
+}
+
+function previewTarget(targetPath) {
+  const rel = p => path.relative(targetPath, p);
+  const buckets = {
+    'write-new': [],
+    'write-update': [],
+    'migrate': [],
+    'skip-diverged': [],
+    'skip-unknown': [],
+    'skip-claimed': [],
+  };
+
+  const installed = [
+    ...walkMd(path.join(targetPath, '.claude/skills')),
+    ...walkMd(path.join(targetPath, '.claude/agents')),
+  ];
+
+  for (const destPath of installed) {
+    const calsuiteRel = destToCalsuiteRel(destPath);
+    if (!calsuiteRel) continue;
+    const srcFile = path.join(CALSUITE_DIR, calsuiteRel);
+    if (!fs.existsSync(srcFile)) continue; // target-side-only file
+    const decision = originProtocol.decideFileAction(destPath, calsuiteRel, CALSUITE_DIR);
+    buckets[decision.action].push({ path: rel(destPath), reason: decision.reason });
+  }
+
+  // Enumerate calsuite sources missing from the target — those are write-new
+  // candidates. Profile filtering happens at real sync time; this overcounts
+  // slightly for targets on narrow profiles, but the preview's job is to
+  // reveal max divergence, not reproduce the installer's profile resolver.
+  const srcMd = [...walkMd(SKILLS_DIR), ...walkMd(AGENTS_DIR)];
+  const installedRel = new Set(installed.map(destToCalsuiteRel).filter(Boolean));
+  for (const srcFile of srcMd) {
+    const calsuiteRel = path.relative(CALSUITE_DIR, srcFile).split(path.sep).join('/');
+    if (installedRel.has(calsuiteRel)) continue;
+    const wouldLand = path.join(targetPath, '.claude', calsuiteRel);
+    buckets['write-new'].push({ path: rel(wouldLand), reason: 'not present at target' });
+  }
+
+  return { label: path.basename(targetPath), targetPath, buckets };
+}
+
+function summariseBuckets(buckets) {
+  return Object.fromEntries(
+    Object.entries(buckets).map(([k, v]) => [k, v.length])
+  );
+}
+
+function printHumanTarget(report) {
+  const { label, targetPath, buckets } = report;
+  const totals = summariseBuckets(buckets);
+  console.log('');
+  console.log(`=== ${label} (${targetPath}) ===`);
+  console.log(`  write-new:     ${totals['write-new']}`);
+  console.log(`  write-update:  ${totals['write-update']}`);
+  console.log(`  migrate:       ${totals['migrate']}`);
+  console.log(`  skip-diverged: ${totals['skip-diverged']}   ← would stay stuck without --reconcile/--force-adopt/--claim`);
+  console.log(`  skip-unknown:  ${totals['skip-unknown']}    ← pre-protocol or stale; same resolution`);
+  console.log(`  skip-claimed:  ${totals['skip-claimed']}    ← user-owned, working as designed`);
+
+  for (const action of ['skip-diverged', 'skip-unknown', 'skip-claimed']) {
+    if (!buckets[action].length) continue;
+    console.log(`\n  [${action}]`);
+    for (const { path: p, reason } of buckets[action]) {
+      console.log(`    • ${p}${reason ? ` — ${reason}` : ''}`);
+    }
+  }
+
+  // Only show write-new detail when small enough to be readable.
+  if (buckets['write-new'].length) {
+    const cap = 8;
+    const header = buckets['write-new'].length > cap
+      ? `[write-new — first ${cap} of ${buckets['write-new'].length}]`
+      : `[write-new]`;
+    console.log(`\n  ${header}`);
+    for (const { path: p } of buckets['write-new'].slice(0, cap)) {
+      console.log(`    • ${p}`);
+    }
+  }
+  return totals;
+}
+
+function main() {
+  const flags = parseArgv();
+
+  let targets;
+  try {
+    targets = JSON.parse(fs.readFileSync(TARGETS_JSON, 'utf8')).targets;
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      console.error(`✗ config/targets.json not found.`);
+      console.error(`  Copy ${path.relative(CALSUITE_DIR, EXAMPLE_JSON)} to config/targets.json and add your target repo paths.`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  if (flags.target) {
+    targets = targets.filter(t => path.basename(expandHome(t.path)) === flags.target);
+    if (!targets.length) {
+      console.error(`✗ No target named "${flags.target}" in config/targets.json`);
+      process.exit(1);
+    }
+  }
+
+  const currentSha = originProtocol.currentCalsuiteSha(CALSUITE_DIR);
+  const reports = [];
+  for (const t of targets) {
+    const tp = path.resolve(expandHome(t.path));
+    if (!fs.existsSync(tp)) {
+      reports.push({ label: path.basename(tp), targetPath: tp, missing: true });
+      continue;
+    }
+    reports.push(previewTarget(tp));
+  }
+
+  if (flags.json) {
+    const out = {
+      calsuiteSha: currentSha,
+      targetCount: targets.length,
+      targets: reports.map(r => r.missing
+        ? { label: r.label, targetPath: r.targetPath, missing: true }
+        : {
+            label: r.label,
+            targetPath: r.targetPath,
+            totals: summariseBuckets(r.buckets),
+            files: r.buckets,
+          }),
+    };
+    process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+    return;
+  }
+
+  console.log(`Calsuite HEAD: ${currentSha}`);
+  console.log(`Targets: ${targets.length}`);
+
+  const grand = {
+    'write-new': 0, 'write-update': 0, 'migrate': 0,
+    'skip-diverged': 0, 'skip-unknown': 0, 'skip-claimed': 0,
+  };
+  for (const report of reports) {
+    if (report.missing) {
+      console.log(`\n=== ${report.label} (${report.targetPath}) ===\n  ⚠ not found — skipping`);
+      continue;
+    }
+    const totals = printHumanTarget(report);
+    for (const k of Object.keys(grand)) grand[k] += totals[k];
+  }
+
+  console.log('\n────────────────────────────────────────');
+  console.log('Totals across all targets:');
+  for (const [k, v] of Object.entries(grand)) {
+    console.log(`  ${k.padEnd(14)} ${v}`);
+  }
+  console.log('────────────────────────────────────────');
+
+  const blocking = grand['skip-diverged'] + grand['skip-unknown'];
+  if (blocking > 0) {
+    console.log(`\n${blocking} file(s) would be skipped pending reconciliation.`);
+    console.log('Resolve per-file with: --reconcile <path> / --force-adopt <path> / --claim <path>');
+    console.log('Or invoke /reconcile-targets for agentic cross-target handling.');
+  } else {
+    console.log('\nNo reconciliation needed — all installed files are clean.');
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`✗ ${err.message}`);
+  process.exit(1);
+}

--- a/skills/sync-preview/SKILL.md
+++ b/skills/sync-preview/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sync-preview
+description: |
+  Read-only preview of calsuite --sync across every target in config/targets.json.
+  Aliases: sync-preview, sync --preview, what would sync do, preview sync, dry-run sync,
+  show divergence, divergence report, which skills have diverged, what will --sync change,
+  check target drift, target drift report.
+  Reports per-target counts of files that would be written/updated/migrated/skipped,
+  plus a full list of diverged files with reasons. Writes nothing — safe any time.
+  Run BEFORE /reconcile-targets to understand scope. Calsuite-internal: lives in
+  this repo, not distributed to targets.
+argument-hint: "[--target <name>] [--json]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Preview what calsuite --sync would do
+
+Read-only snapshot of every target's divergence state against calsuite's current HEAD. Tells you:
+
+- How many files are pristine (would safely update)
+- How many are pre-protocol but byte-identical to current calsuite (auto-migrate silently)
+- How many **need reconciliation** (diverged or pre-protocol with local edits) — the ones stuck on every `--sync` until resolved
+
+This skill never writes. Its only job is to produce a readable report.
+
+## When to invoke
+
+- **Before `/reconcile-targets`** — scope check. If `skip-unknown` + `skip-diverged` sum to 3, you can handle it manually; if they sum to 30, you want the agentic pass.
+- **After a long absence** — multi-week drift catch-up. Preview first, decide how many sessions this is, then act.
+- **After bulk calsuite changes** — shipped a new lint pack or renamed a skill? Preview to see the blast radius before syncing.
+- **Debugging a "why is this file still flagged" loop** — the per-file reasons (`user-modified since <sha>` / `no _origin marker and content diverges`) show exactly which matrix row a file lands in.
+
+## When NOT to invoke
+
+- **Daily hygiene** — the post-commit auto-sync already handles the clean cases. Don't run this for routine commits; it's for divergence investigation.
+- **Inside a target** — sync-preview walks calsuite's `config/targets.json` and reads calsuite's source tree. Run from calsuite itself.
+
+## Step 0: Pre-flight
+
+The script lives at `scripts/sync-preview.cjs` inside calsuite and is tracked in the repo. You must run from a directory where calsuite is reachable.
+
+```bash
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/sync-preview.cjs" ]; then
+  echo "✗ sync-preview not found at $calsuite_dir/scripts/sync-preview.cjs"
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or run this skill from inside calsuite."
+  exit 1
+fi
+```
+
+## Step 1: Parse arguments
+
+`$ARGUMENTS` is optional. Supported flags, passed straight to the script:
+
+| Flag | Effect |
+|---|---|
+| `--target <name>` | Scope to a single target by basename (e.g. `verity`). |
+| `--json` | Machine-readable output. Useful when piping into another tool; humans should omit. |
+
+If no arguments, preview every target in `config/targets.json`.
+
+## Step 2: Run the script
+
+```bash
+node "$calsuite_dir/scripts/sync-preview.cjs" $ARGUMENTS
+```
+
+The script exits non-zero only on fatal errors (missing `targets.json`, malformed config). Any divergence count is still exit 0 — that's informational, not failure.
+
+## Step 3: Interpret the output
+
+Human output has three sections:
+
+1. **Header** — `Calsuite HEAD: <sha>` and `Targets: N`.
+2. **Per-target breakdown** — for each target: counts per action, then detail lists for `skip-diverged`, `skip-unknown`, `skip-claimed`, and up to 8 `write-new` files.
+3. **Grand total** — summed across all targets, plus a one-liner pointing to resolution commands.
+
+Action semantics (copy-paste into your summary if useful):
+
+| Action | Meaning | Action needed |
+|---|---|---|
+| `write-new` | File exists in calsuite but not yet at target. | None — `--sync` will create it. |
+| `write-update` | File carries `_origin: calsuite@<sha>` and still matches calsuite's content at that sha. | None — `--sync` will safely overwrite. |
+| `migrate` | Pre-protocol file byte-identical to current calsuite. | None — `--sync` will stamp `_origin` silently. |
+| `skip-diverged` | File has `_origin: calsuite@<sha>` but local edits on top. | `--reconcile <path>` (merge), `--claim <path>` (keep local), or `--force-adopt <path>` (take calsuite's). |
+| `skip-unknown` | File has no `_origin` AND differs from calsuite's current. Pre-protocol edit or stale copy — indistinguishable. | Same three commands as `skip-diverged`. Or `/reconcile-targets` for agentic handling. |
+| `skip-claimed` | File has `_origin: <target-name>`. Working as designed. | None — this is deliberate divergence. |
+
+## Step 4: Summarise for the user
+
+Produce a terse, actionable takeaway. Examples:
+
+- **"All clean"**: `No reconciliation needed across N targets.` Don't belabor it.
+- **"Small scope, manual-fixable"**: `3 files stuck across 2 targets. Suggested commands: ...` with the exact `--reconcile`/`--claim`/`--force-adopt` invocations.
+- **"Large scope"**: `28 files stuck across 3 targets. Scope makes /reconcile-targets the right next step. Before invoking, review the top-N files to spot obvious intentional divergences (e.g. verity's /ship customisations) — those should be --claim, not --reconcile.`
+- **"Concentrated on one target"**: call that out explicitly. If verity has 20/28, the user's real question is about verity — say so.
+
+Don't repaste the full script output — the user already saw it. Add the interpretation layer that turns counts into decisions.
+
+## Arguments
+
+- `--target <name>` — optional. Filter to one target by basename (the last segment of its path in `config/targets.json`).
+- `--json` — optional. Emit machine-readable output instead of human-readable. Set when piping into scripts or other skills.
+
+## Related
+
+- `/reconcile-targets` — the agentic per-file reconciler this skill front-runs. Preview first, then reconcile.
+- `configure-claude.js --reconcile <path>` — single-file three-way merge. Use when the scope is tiny.
+- `configure-claude.js --claim <path>` — mark a file user-owned. Use when you've intentionally diverged (cross-ref `/customise` which fuses edit + claim).
+- `configure-claude.js --force-adopt <path>` — discard local edits, take calsuite's. Use when you know the local edits were accidental.
+- `configure-claude.js --prune-stale` — different operation: DELETES stale row-6 files rather than reconciling them. Use sparingly; destructive.
+
+## Gotchas
+
+- **`write-new` counts can overshoot.** The preview enumerates every calsuite source file missing from a target, but at real sync time the profile resolver filters — a `python`-profile target won't actually receive every `typescript` skill. The preview intentionally overcounts because its job is to reveal max possible drift, not reproduce the installer's filter logic. Trust the `skip-*` buckets exactly; take `write-new` as an upper bound.
+- **Script path is calsuite-local.** Running sync-preview from inside a target will fail the Step 0 guard. That's the design — targets don't need a sync-preview; they're subjects of it.
+- **`_origin` parse tolerance.** Malformed frontmatter (e.g. hand-edited YAML that broke syntax) parses as "no `_origin`" and routes the file to `skip-unknown`. If a file shows up unexpectedly, check its frontmatter block by eye.

--- a/skills/sync/SKILL.md
+++ b/skills/sync/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: sync
+description: |
+  Manually run calsuite's mechanical --sync across every target in config/targets.json,
+  then interpret the divergence summary and suggest next steps. Aliases: sync, run sync,
+  push calsuite to targets, flow calsuite changes, propagate calsuite, sync calsuite,
+  kick off sync. Supports `/sync preview` for a read-only dry run (delegates to
+  /sync-preview). Calsuite-internal: lives in this repo, not distributed.
+argument-hint: "[preview] [--target <name>]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Run calsuite --sync with interpretation
+
+Fires calsuite's mechanical sync protocol across every target in `config/targets.json`, then reads the end-of-sync summary and tells you what needs follow-up. Delegate to `/sync-preview` when you only want the read-only report.
+
+The post-commit hook already auto-syncs on every calsuite commit. This skill is for **manual** invocation: re-syncing after an out-of-band calsuite change, kicking the protocol after editing a target's `.claude/skills` file, or forcing a refresh when something drifted.
+
+## When to invoke
+
+- You edited a skill in calsuite and want it distributed immediately (before the next commit fires the post-commit hook).
+- A target's `.claude/` got mutated outside calsuite's flow and you want to reset it.
+- Post-commit hook was disabled for some reason and you're catching up manually.
+- **You want a dry-run first** — use `/sync preview`.
+
+## When NOT to invoke
+
+- **Daily development** — the post-commit hook handles routine sync for free. Don't double-fire.
+- **For reconciling diverged files** — `--sync` skips those. Use `/reconcile-targets`, `--reconcile <path>`, `--force-adopt`, or `--claim` instead.
+- **For deleting stale state** — that's `--prune-stale`.
+
+## Step 0: Pre-flight
+
+```bash
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/configure-claude.js" ]; then
+  echo "✗ Calsuite installer not found at $calsuite_dir/scripts/configure-claude.js"
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite"
+  exit 1
+fi
+```
+
+## Step 1: Parse arguments
+
+`$ARGUMENTS` is optional. Two modes:
+
+- **Preview mode** — if the first word is `preview`, delegate entirely to `/sync-preview` and stop here. Pass remaining arguments through:
+  ```bash
+  # user invoked /sync preview --target verity
+  node "$calsuite_dir/scripts/sync-preview.cjs" --target verity
+  ```
+  Preview never writes. Do not run the real `--sync` afterward.
+
+- **Real sync mode** — default. Proceed to Step 2.
+
+Any other flags (`--target <name>`, etc.) are not currently supported by `--sync`; reject with a helpful error if provided in real mode (`--sync` always walks every target).
+
+## Step 2: Run the sync
+
+```bash
+node "$calsuite_dir/scripts/configure-claude.js" --sync
+```
+
+Stream output directly to the user. Capture the last ~40 lines for Step 3 (the end-of-sync divergence summary, if any).
+
+## Step 3: Read the summary
+
+`--sync` prints a divergence summary when files were skipped pending reconciliation. Look for the block delimited by `───────────` separators — inside it:
+
+- `N file(s) skipped pending reconciliation:` — overall count
+- Per-file lines: `• <target>/.claude/skills/ship/SKILL.md` + reason (`skip-diverged: user-modified since <sha>` OR `skip-unknown: no _origin marker and content diverges`)
+
+If no summary block appeared, sync ran clean — say so and stop.
+
+## Step 4: Interpret and suggest next steps
+
+Pick the smallest-viable follow-up and propose exact commands. Rules of thumb:
+
+| Situation | Recommendation |
+|---|---|
+| 0 skipped | `All clean.` Don't belabor. |
+| 1–3 skipped, concentrated on one target | Suggest `--reconcile <path>` (or `--claim`/`--force-adopt`) for each specific file. Paste the exact commands. |
+| 4–10 skipped across multiple targets | Suggest `/reconcile-targets` for the agentic pass. Offer `/sync preview` first if the user wants the full picture before committing. |
+| 10+ skipped | Strongly recommend `/sync preview` then `/reconcile-targets`. Don't paste individual commands — the volume is not hand-fixable. |
+| Any `skip-diverged` files | Note that these are `_origin`-stamped + user-edited. Usually want `--reconcile` (merge) or `--claim` (keep local). |
+| Any `skip-unknown` files | Pre-protocol edits or stale copies — indistinguishable. `/reconcile-targets` can reason about each; blunt `--force-adopt` loses any intentional edits. |
+
+When suggesting commands, always use absolute paths so the user can copy-paste without re-resolving:
+
+```
+node "$calsuite_dir/scripts/configure-claude.js" --reconcile "/Users/me/Projects/verity/.claude/skills/ship/SKILL.md"
+```
+
+## Arguments
+
+- `preview` — first positional. Switches to read-only mode; delegates to `/sync-preview`. No other `--sync` args are respected when preview is set.
+- `--target <name>` — only respected in preview mode (passed through to `sync-preview.cjs`). Real `--sync` always walks every target.
+
+## Related
+
+- `/sync-preview` — the read-only dry-run. Invoked directly by `/sync preview`.
+- `/reconcile-targets` — agentic per-file reconciler for the skipped files.
+- `configure-claude.js --reconcile <path>` — single-file three-way merge.
+- `configure-claude.js --force-adopt <path>` / `--claim <path>` — single-file blunt resolvers.
+- `configure-claude.js --prune-stale` — **different** operation: deletes stale state rather than syncing.
+
+## Gotchas
+
+- **`--sync` only skips; it never destroys.** Whatever's flagged in the summary is still on disk exactly as it was. Resolving via `--claim` preserves content; `--force-adopt` is the only loss path and it's explicit.
+- **The post-commit hook runs this same command.** If you manually `/sync` immediately after a calsuite commit, the second run will be a no-op for everything the hook already wrote — that's fine.
+- **Target basename matters for `_origin: <target-name>`.** Under the hood, `--sync` uses each target's basename (e.g. `verity`). If you renamed a target directory, the next sync will see `_origin: old-name` as "claimed by a different target" and skip it. Use `--force-adopt` or `--claim` with the new name to recover.


### PR DESCRIPTION
## Summary
- New `scripts/sync-preview.cjs` — read-only preview of what `--sync` would do across every target in `config/targets.json`. Walks each target's installed skills/agents, calls `decideFileAction` per file, aggregates into buckets. `--target <name>`, `--json` supported. Writes nothing.
- New `/sync-preview` calsuite-internal skill — wraps the script, interprets output (suggests `/reconcile-targets` when scope is large, per-file `--reconcile`/`--claim`/`--force-adopt` when small).
- New `/sync` calsuite-internal skill — wraps `configure-claude.js --sync` with pre-flight + divergence-summary parsing + proactive next-step suggestions. `/sync preview` delegates to `/sync-preview`.
- Both skills added to `INTERNAL_SKILLS` in `configure-claude.js` so they're listed in `base`/`monorepo-root` profiles for completeness but filtered at install time — calsuite-only.
- Version bump 2.13 → 2.14.

> **Stacked on top of [#59](https://github.com/ckallum/calsuite/pull/59)** (`chore/gitignore-targets-json`). Base branch is `chore/gitignore-targets-json` — rebase-merging #59 first will leave this PR clean against main. If this merges before #59, that's fine too — only the version header will need a rebase on #59.

## How It Works

```mermaid
flowchart TD
    A[/sync preview/] --> B[/sync-preview/]
    B --> C[scripts/sync-preview.cjs]
    C --> D[Read config/targets.json]
    D --> E[walkMd per target]
    E --> F[originProtocol.decideFileAction]
    F --> G[Aggregate buckets]
    G --> H[Human or --json output]

    I[/sync/] --> J[configure-claude.js --sync]
    J --> K[Mechanical sync writes]
    K --> L[End-of-sync divergence summary on stdout]
    L --> M[Skill parses summary]
    M --> N{Scope?}
    N -- 0 --> O[All clean]
    N -- 1-3 --> P[Paste exact per-file commands]
    N -- 4+ --> Q[Suggest /reconcile-targets]
```

## Important Files
| File | Change |
|------|--------|
| `scripts/sync-preview.cjs` | New 200-line read-only preview script. Uses `decideFileAction` from origin-protocol; never writes. |
| `skills/sync-preview/SKILL.md` | New skill. Pre-flight, runs script, interprets buckets, produces actionable summary. |
| `skills/sync/SKILL.md` | New skill. Wraps `--sync`; `preview` arg delegates to `/sync-preview`. |
| `scripts/configure-claude.js` | Added `sync`, `sync-preview` to `INTERNAL_SKILLS`. One-line change. |
| `config/profiles.json` | Added `sync`, `sync-preview` to `base.skills` and `monorepo-root.skills` for completeness. Filtered at install time. |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md` | Version bump 2.13 → 2.14 + changelog entry. |

No changes to `scripts/lib/origin-protocol.cjs`.

## Test Results
| Scenario | Result |
|----------|--------|
| `node scripts/sync-preview.cjs` (all targets) | ✅ Produces per-target + grand-total report |
| `node scripts/sync-preview.cjs --target verity` | ✅ Filters to single target |
| `node scripts/sync-preview.cjs --json` | ✅ Valid JSON with totals + per-file lists |
| `rm -rf /tmp/test-project && node scripts/configure-claude.js /tmp/test-project` | ✅ Normal install — no regression |
| `ls /tmp/test-project/.claude/skills/ \| grep -E "^(sync\|sync-preview)$"` | ✅ Empty — INTERNAL_SKILLS filter working |

## Pre-Landing Review
No issues found. Scope limited to new skill files + script + one-line INTERNAL_SKILLS update + profile list additions + version bump.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md + README.md
- [x] Both skills added to `base` and `monorepo-root` profile skill arrays (consistent with `configure-claude` / `skill-builder` pattern)