### PR TITLE
fix(claude): commit harness internal skills to .claude/skills

### DIFF
--- a/.claude/skills/configure-claude/SKILL.md
+++ b/.claude/skills/configure-claude/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: configure-claude
+description: Install Claude Code hooks, scripts, plugins, and config into a project. Use when setting up a new project or syncing config to an existing one.
+disable-model-invocation: true
+allowed-tools: Bash(node *), Read, Glob
+---
+
+Install all Claude Code configs from this repository into a project's `.claude/` directory.
+
+## What it does
+
+1. Copies `scripts/hooks/` and `scripts/lib/` into the target project's `.claude/scripts/`
+2. Reads `hooks/hooks.json`, resolves `${CLAUDE_CONFIG_DIR}` paths, and merges the `hooks` key into the target's `.claude/settings.json` (preserving existing keys)
+3. Enables all manifest plugins in the project's `.claude/settings.json`
+4. Checks global settings against `config/global-settings.json` and warns about missing marketplaces, plugins, MCP servers, or statusLine config
+
+## Instructions
+
+When this skill is invoked:
+
+1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/calsuite`), ask the user which project to configure. Otherwise, use the current working directory.
+
+2. Run the installer script:
+   ```bash
+   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js <target-directory>
+   ```
+
+3. Review the output and report what was installed to the user, including any global settings warnings.
+
+4. If ccstatusline config is missing or outdated, offer to install it:
+   ```bash
+   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js --install-ccstatusline
+   ```

--- a/.claude/skills/reconcile/SKILL.md
+++ b/.claude/skills/reconcile/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: reconcile
+description: |
+  Wrap configure-claude.js --reconcile <path> for a single divergent skill/agent file.
+  Aliases: reconcile <path>, three-way merge <path>, resolve divergence <path>,
+  merge calsuite changes into <path>, fix this divergent file, merge this file,
+  reconcile one file, single-file reconciliation. Pre-flights path validity,
+  calsuite location, and `$EDITOR`; runs the interactive 3-way merge; interprets
+  the exit state. For cross-target bulk reconciliation use /reconcile-targets
+  instead. Calsuite-internal: lives in this repo, not distributed to targets.
+argument-hint: "[<path>]  # omit for interactive picker"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+# Reconcile one divergent skill/agent file
+
+Thin wrapper around `configure-claude.js --reconcile <path>` — the interactive three-way merge primitive. This skill adds pre-flight (calsuite reachable, `$EDITOR` set, file is actually divergent) and post-run interpretation. The real merge UI is the installer's; this is just the polished entry point.
+
+Use when **one specific file** needs reconciling. For bulk handling across multiple targets or files, use `/reconcile-targets`. For "I just want to claim this file and keep my edits," use `/customise` (which fuses edit + claim).
+
+## When to invoke
+
+- `/sync` surfaced a single flagged file (`skip-diverged` or `skip-unknown`) and you want to merge calsuite's newer version with your local edits.
+- You've been notified of a specific divergence and don't want the overhead of an agentic pass.
+- You know which file is stuck and want the shortest path from "stuck" to "merged."
+
+## When NOT to invoke
+
+- **Multiple divergent files** — run `/reconcile-targets` for the agentic cross-target pass, or `/sync-preview` to see scope first.
+- **You want to take calsuite's version wholesale** — use `--force-adopt <path> --yes`. No merge UI needed.
+- **You want to keep your version verbatim** — use `--claim <path>` (or `/customise <skill-name>` for edit-and-claim).
+- **The file isn't actually divergent** — `--reconcile` on a pristine file is a waste of `$EDITOR` time. Step 2 warns you.
+
+## Step 0: Pre-flight
+
+```bash
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/configure-claude.js" ]; then
+  echo "✗ Calsuite installer not found at $calsuite_dir/scripts/configure-claude.js"
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite"
+  exit 1
+fi
+
+# $EDITOR is required for the 3-way merge pane. vi is the installer's fallback,
+# but warn if the user hasn't set anything — vi panic is a bad first experience.
+if [ -z "$EDITOR" ] && [ -z "$VISUAL" ]; then
+  echo "⚠ Neither \$EDITOR nor \$VISUAL is set. The installer will fall back to vi."
+  echo "  If that's not what you want, Ctrl-C now, export EDITOR=<your-editor>, and re-run."
+fi
+```
+
+## Step 1: Resolve the path
+
+`$ARGUMENTS` contains the path — absolute or relative to the current working directory. If absent, fall back to interactive mode.
+
+**Path provided:**
+
+Resolve the parent dir to an absolute path, checking existence explicitly. A plain `cd … 2>/dev/null && pwd` would silently yield an empty string on failure, producing a bogus `/<basename>` abs_path that only blows up two steps later — error up front instead.
+
+```bash
+raw_path="$ARGUMENTS"
+parent_dir="$(dirname "$raw_path")"
+if [ ! -d "$parent_dir" ]; then
+  echo "✗ $raw_path — parent directory not found ($parent_dir)"
+  exit 1
+fi
+abs_path="$(cd "$parent_dir" && pwd)/$(basename "$raw_path")"
+```
+
+The `-d` guard means the `cd` inside the command substitution cannot fail, so no `&&` fallback gymnastics needed.
+
+**No arguments — interactive mode:**
+
+Run the sync preview in JSON, extract skip-diverged + skip-unknown candidates across all targets, prompt the user with `AskUserQuestion` to pick one:
+
+```bash
+node "$calsuite_dir/scripts/sync-preview.cjs" --json
+```
+
+Parse the output: for each target, concatenate `files["skip-diverged"]` and `files["skip-unknown"]`. Build a picker list like:
+
+```
+A) verity/.claude/skills/ship/SKILL.md (skip-unknown — no _origin)
+B) verity/.claude/skills/review/SKILL.md (skip-diverged — since a49a827)
+C) timeline/.claude/skills/ship/SKILL.md (skip-unknown)
+...
+```
+
+Prefix each option with the target name + relative path. If the list is empty, tell the user "No divergent files across any target. Nothing to reconcile." and stop — don't open an empty `--reconcile`.
+
+## Step 2: Validate and check state
+
+Before invoking, assert the path is reconcile-eligible. The installer does these same checks, but doing them in the skill lets you explain each failure in plain English:
+
+| Check | Failure message |
+|---|---|
+| File exists | `✗ <abs_path> does not exist` |
+| Ends in `.md` | `✗ --reconcile only supports markdown files` |
+| Path contains `/.claude/skills/` or `/.claude/agents/` | `✗ File is not under a target's .claude/skills or .claude/agents` |
+
+If all three pass, peek at the file's `_origin` to set expectations:
+
+- **No `_origin` + content differs from calsuite current** (`skip-unknown`) — 2-way merge. Warn: "No `_origin` marker; merging with calsuite's current only (no ancestor pane)."
+- **`_origin: calsuite@<sha>`** — check `git show <sha>:<calsuite-rel-path>` in calsuite. If present → full 3-way. If not → "install sha unknown to calsuite; falling back to 2-way merge."
+- **`_origin: <non-calsuite>`** — tell user: "File is claimed (`_origin: <value>`). `--reconcile` will short-circuit. Use `--force-adopt` to overwrite or leave as-is."
+- **`_origin: calsuite@<sha>` + byte-identical to that sha** (would route to `write-update`) — `--reconcile` still works but there's nothing to merge. Ask via `AskUserQuestion`: "File is currently pristine. Proceed with reconcile anyway?" Default no.
+
+## Step 3: Run --reconcile
+
+```bash
+node "$calsuite_dir/scripts/configure-claude.js" --reconcile "$abs_path"
+```
+
+Stream stdout to the user; the installer takes over the TTY during the editor phase. Claude Code will pause while `$EDITOR` has the terminal.
+
+When the command returns, capture its exit code. Possible outcomes:
+
+| Exit code | Stdout marker | Meaning |
+|---|---|---|
+| 0 | `✓ Merged. <path> ← calsuite@<sha> (user-resolved)` | Merge completed, file stamped. |
+| 0 | `✓ Kept target's version.` | User picked [k] — same as `--claim`. |
+| 0 | `✓ Adopted calsuite's current version.` | User picked [a] — same as `--force-adopt`. |
+| 0 | `⊘ Skipped.` | User picked [s] — file untouched, still flagged. |
+| 0 | `⊘ File is claimed (_origin: <x>).` | Short-circuited; nothing happened. |
+| 1 | `✗ Editor exited with status N` | Editor crashed or user `:cq`'d; original file untouched. |
+| 1 | `✗ Conflict markers still present` | User saved without resolving; tmp file preserved, path in the message. |
+| 1 | Any other `✗ ...` | Validation error (missing path, non-md, etc.) — should be prevented by Step 2. |
+
+## Step 4: Summarise
+
+Produce a short, factual report:
+
+- **Success**: `Merged <rel-path>. _origin now: calsuite@<current-sha>.`
+- **Kept**: `Kept your version. <rel-path> is now user-claimed (_origin: <target-name>). Subsequent --sync will leave it alone.`
+- **Adopted**: `Adopted calsuite's version. Your previous edits to <rel-path> are gone.`
+- **Skipped**: `Skipped. <rel-path> is still flagged — re-run /reconcile or /reconcile-targets when ready.`
+- **Aborted (editor nonzero)**: `Editor exited non-zero. Original <rel-path> untouched. Conflict-marked tmp file kept at /tmp/calsuite-reconcile-... — resume from there or delete it.`
+- **Aborted (markers left)**: `Conflict markers still present. Original <rel-path> untouched. Re-run /reconcile when you're ready to finish.`
+
+Don't re-print the full `--reconcile` output the user already saw. Just interpret.
+
+## Arguments
+
+- `<path>` — optional. Absolute or relative path to the divergent file inside a target's `.claude/skills/<name>/*.md` or `.claude/agents/*.md`. Omit to enter interactive picker mode (lists all divergent files across targets via `/sync-preview`).
+
+## Related
+
+- `/sync-preview` — surfaces the list of divergent files. Run this before deciding to reconcile.
+- `/reconcile-targets` — agentic cross-target pass for when scope is large.
+- `/customise <skill-name>` — the edit-then-claim workflow. Use when you're intentionally diverging, not merging.
+- `configure-claude.js --force-adopt <path> --yes` — take calsuite's version; destroys local edits.
+- `configure-claude.js --claim <path>` — keep your version; stamps `_origin: <target-name>`.
+
+## Gotchas
+
+- **Interactive mode TTY requirement.** `--reconcile` requires a TTY for the `$EDITOR` handoff and the k/a/m/s prompt. This skill's interactive picker (Step 1) also needs a TTY for `AskUserQuestion`. If you're running inside a pipeline or non-interactive shell, provide `<path>` explicitly.
+- **`$EDITOR` pitfalls.** The installer uses `$EDITOR` → `$VISUAL` → `vi`. If your editor is a GUI that forks (e.g. `code` without `--wait`), the merge will proceed before you've actually saved. Use `code --wait`, `subl -w`, or set `$EDITOR=vim`/`nano`/`emacs -nw` for a blocking terminal editor.
+- **Running from a target vs calsuite.** Step 1's path resolution uses `pwd`. Relative paths work from any cwd as long as they resolve to a real file under some target's `.claude/`. Absolute paths always work.
+- **Nested targets.** If one target repo contains a submodule with its own `.claude/skills/` (unusual), `--reconcile` will treat the submodule path as a valid target path. That's probably not what you want — pass absolute paths to be unambiguous.

--- a/.claude/skills/skill-builder/SKILL.md
+++ b/.claude/skills/skill-builder/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: skill-builder
+version: 1.0.0
+description: |
+  Create a skill, new skill, build a skill, scaffold skill, make a skill, skill template,
+  generate Claude Code skill, skill authoring, create slash command. Scaffolds production-quality
+  Claude Code skills with proper folder structure, progressive disclosure, gotchas, and config
+  patterns following Anthropic's best practices.
+argument-hint: [skill-name] [--category <type>]
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+  - Glob
+  - Grep
+---
+
+# /skill-builder: Scaffold a New Claude Code Skill
+
+Creates a production-ready Claude Code skill with proper structure, trigger-phrase descriptions, gotcha sections, progressive disclosure, and config patterns.
+
+Read `skills/skill-builder/references/best-practices.md` before generating any skill content — it contains the authoring rules that govern how SKILL.md files should be written.
+
+Read `skills/skill-builder/references/category-templates.md` after the user selects a category — it contains category-specific guidance for folder structure, tools, and sections.
+
+## Step 0: Determine Skill Name and Target Directory
+
+Parse `$ARGUMENTS` for a skill name (first positional arg) and optional `--category <type>`.
+
+If no skill name is provided, use AskUserQuestion:
+> What should the skill be called? This becomes the slash command name (e.g., "deploy" becomes `/deploy`).
+
+**Target directory resolution:**
+1. If the current working directory contains `.claude/skills/`, create the skill there (project-local skill).
+2. If the current working directory contains `config/profiles.json` (i.e., it's the claude config repo), create in `skills/` (global skill).
+3. Otherwise, use AskUserQuestion to ask whether this should be a project-local or global skill, then create accordingly.
+
+## Step 1: Category Selection
+
+Use AskUserQuestion to present the skill categories. If `--category` was provided in arguments, skip this step and use that category.
+
+> What type of skill is this? Pick the closest category:
+>
+> 1. **Library & API Reference** — How to use a library, CLI, or SDK correctly
+> 2. **Product Verification** — Test or verify code is working (Playwright, tmux, simulators)
+> 3. **Data Fetching & Analysis** — Connect to data sources, monitoring, or analytics
+> 4. **Business Process & Team Automation** — Automate repetitive workflows (PRs, tickets, comms)
+> 5. **Code Scaffolding & Templates** — Generate framework boilerplate or project structures
+> 6. **Code Quality & Review** — Enforce standards, review code, lint, refactor
+> 7. **CI/CD & Deployment** — Build, test, deploy pipelines
+> 8. **Runbooks** — Symptom to investigation to structured report
+> 9. **Infrastructure Operations** — Maintenance, migrations, operational procedures
+
+## Step 2: Interview
+
+Based on the selected category, ask 3-5 targeted questions using AskUserQuestion. Ask one question at a time.
+
+**Universal questions (pick 2-3):**
+- What problem does this skill solve? When would someone reach for it?
+- What external tools, CLIs, or APIs does it depend on?
+- What are the known gotchas or failure modes you've already hit?
+
+**Category-specific questions (pick 2-3 from the category template):**
+Read `skills/skill-builder/references/category-templates.md` and use the interview questions listed for the selected category.
+
+After the interview, confirm the plan with the user:
+> Here's what I'll create: [summary of skill name, category, key features, folder structure]. Proceed?
+
+## Step 3: Scaffold the Folder Structure
+
+Create the skill directory. Not every skill needs every subfolder — only create what the category and interview answers call for.
+
+```
+skills/<name>/
+  SKILL.md              # Always created
+  references/           # If the skill needs reference docs (API details, gotchas, examples)
+  templates/            # If the skill produces reports, files, or structured output
+  scripts/              # If the skill needs helper scripts (Node.js, shell)
+  config.json           # If the skill needs persistent user configuration
+```
+
+**When to include each:**
+- `references/` — The skill involves a complex domain, has API details, or needs progressive disclosure of lengthy content. Most skills benefit from at least a `gotchas.md` file here.
+- `templates/` — The skill generates files, reports, or structured output that follows a pattern.
+- `scripts/` — The skill orchestrates external tools and benefits from a reusable script rather than inline bash.
+- `config.json` — The skill needs user-specific settings (API keys, paths, preferences) that persist between runs.
+
+## Step 4: Generate SKILL.md
+
+Read `skills/skill-builder/templates/skill-template.md` as the starting skeleton. Customize it based on the category template and interview answers.
+
+**SKILL.md authoring rules** (from `references/best-practices.md`):
+
+1. **Description field is for the model, not the user.** Write 5-8 trigger phrases that describe when this skill should activate. Include the category name. Do not write a paragraph summary.
+
+2. **Do not state the obvious.** Only include instructions that push Claude out of its defaults. Never tell Claude how to read files, use git, or write code — it already knows. Focus on domain-specific knowledge, ordering constraints, and non-obvious decisions.
+
+3. **Gotchas section is mandatory.** Even if empty at first, include `## Gotchas` with a note to add failure modes as they're discovered. Pre-populate with any gotchas from the interview.
+
+4. **Progressive disclosure over inlining.** If a section would exceed ~30 lines of reference material, put it in `references/` and tell Claude when to read it. Example: "Read `references/api.md` before making API calls."
+
+5. **Config setup pattern.** If the skill needs user input, include a `## Setup` section that checks for `config.json` on startup and prompts for missing values via AskUserQuestion. Store answers in the skill's `config.json`.
+
+6. **Flexibility over rigidity.** Use "prefer" and "consider" for style guidance. Use "must" and "never" only for correctness constraints (things that would break if violated). Give Claude goals and context, not mechanical step-by-step scripts.
+
+7. **Memory and data storage.** If the skill produces data between runs (logs, history, state), store it in a stable location: the skill directory, `${CLAUDE_PLUGIN_DATA}`, or `.context/<skill-name>/` in the project root.
+
+## Step 5: Register the Skill
+
+After creating all files:
+
+1. Read `config/profiles.json` from the claude config repo (find it by walking up from cwd looking for `config/profiles.json`).
+2. Add the new skill name to the `base.skills` array.
+3. Add the new skill name to the `monorepo-root.skills` array (since monorepo-root declares its own `skills` array, it does not inherit from base).
+4. Write the updated `profiles.json`.
+
+**Only register if the skill was created in the global skills directory** (the `skills/` folder next to `config/profiles.json`). Project-local skills should not be registered in the global profiles.
+
+## Step 6: Confirm
+
+Report to the user:
+- Files created (with paths)
+- Category used
+- Whether it was registered in profiles.json
+- Suggest next steps: "Try invoking `/<skill-name>` to test it. Add gotchas as you discover failure modes."
+
+## Gotchas
+
+- The `description` field in SKILL.md frontmatter is parsed by the model for skill activation — write it as trigger phrases, not prose. If you write a paragraph, the skill won't activate reliably on natural language requests.
+- `profiles.json` has profiles with explicit `skills` arrays that override (not merge with) the parent. When adding a skill to `base`, you must also add it to `monorepo-root` and any other profile that declares its own `skills` list.
+- Do not create a `references/` folder with a single tiny file. If all reference content fits in SKILL.md without exceeding ~50 lines, inline it.
+- The `allowed-tools` frontmatter field controls which tools the skill can use. Omitting a needed tool means Claude cannot call it during skill execution. Check the category template for recommended tools.
+- Skill names become slash commands — use lowercase kebab-case, no spaces, no underscores.
+- **Heredoc quoting in shell snippets:** Use unquoted delimiters (`<<EOF`) when the body needs `$(cmd)` or `${VAR}` expansion. Single-quoted (`<<'EOF'`) suppresses ALL expansion — variables are sent as literal text. This is the #1 cause of broken shell in skills.
+- **Background PID capture:** `PID=$!` must come AFTER the heredoc closing delimiter, not inside the body. Everything between open/close delimiters is content, not shell code.
+- **Temp file paths in skills:** Never hardcode `/tmp/foo.txt` — concurrent invocations collide. Use `mktemp -d /tmp/prefix-XXXXXX` and clean up with `rm -rf "$TMPDIR"`.
+
+## References
+
+- `skills/skill-builder/references/best-practices.md` — Skill authoring best practices (read before generating)
+- `skills/skill-builder/references/category-templates.md` — Per-category guidance, folder structures, and interview questions
+- `skills/skill-builder/templates/skill-template.md` — Blank SKILL.md skeleton used as starting point

--- a/.claude/skills/skill-builder/references/best-practices.md
+++ b/.claude/skills/skill-builder/references/best-practices.md
@@ -1,0 +1,145 @@
+# Skill Authoring Best Practices
+
+Distilled from Anthropic's internal skill authoring guidelines and real-world usage patterns. Read this before generating any SKILL.md content.
+
+## 1. Description Field Is for the Model
+
+The `description` field in SKILL.md frontmatter is how Claude decides whether to activate a skill. Write it as a list of trigger phrases — the natural language ways a user might ask for this capability.
+
+**Good:**
+```yaml
+description: |
+  Deploy code, push to production, release to staging, ship deployment,
+  deploy service, roll out changes. Manages deployment pipelines with
+  pre-flight checks and rollback support.
+```
+
+**Bad:**
+```yaml
+description: "This skill helps users deploy their code to various environments."
+```
+
+Include 5-8 trigger phrases. Include the category name (e.g., "deployment", "code review", "data analysis") so the skill activates on category-level requests too.
+
+## 2. Do Not State the Obvious
+
+Claude already knows how to read files, write code, use git, parse JSON, and navigate codebases. Only include instructions that push it out of its defaults:
+
+- Domain-specific knowledge it wouldn't have (API quirks, tool flags, undocumented behavior)
+- Ordering constraints (what must happen before what)
+- Non-obvious decisions (when to use X vs Y)
+- Failure modes and recovery steps
+
+**Remove any instruction that Claude would follow anyway.** If you find yourself writing "Read the file to understand its contents" — delete it.
+
+## 3. Build Gotchas Sections Over Time
+
+Every skill should have a `## Gotchas` section. Start with known failure modes from the interview, but expect this section to grow:
+
+- After each failure during skill usage, add the gotcha
+- Include the symptom, cause, and fix
+- Be specific: file paths, error messages, version numbers
+
+A mature skill's gotchas section is its most valuable part. It encodes hard-won knowledge that prevents repeated failures.
+
+## 4. Progressive Disclosure
+
+Do not inline large reference material into SKILL.md. Instead:
+
+1. Create files in `references/` for API documentation, detailed examples, long gotcha lists, or complex configuration guides
+2. In SKILL.md, tell Claude *what* each file contains and *when* to read it
+3. Claude will load the reference on demand, keeping the main skill file focused
+
+**Rule of thumb:** If a section would exceed ~30 lines of reference content, extract it to `references/`.
+
+```markdown
+## API Reference
+
+Read `references/api.md` before making any API calls. It documents the current
+endpoint signatures and known quirks with error responses.
+```
+
+## 5. Avoid Railroading
+
+Skills should give Claude information, goals, and constraints — not rigid step-by-step scripts that remove all judgment.
+
+- Use "prefer" and "consider" for style and approach guidance
+- Use "must" and "never" only for correctness constraints (things that break if violated)
+- Describe the *goal* of each step, not just the mechanics
+- Leave room for Claude to adapt to the specific situation
+
+**Exception:** Some workflows genuinely need strict ordering (deployment pipelines, review gates). Use rigid steps there, but explain *why* the order matters.
+
+## 6. Config Setup Pattern
+
+If a skill needs user-specific settings (API keys, paths, preferences):
+
+1. On first run, check for `config.json` in the skill directory
+2. If missing, prompt the user via AskUserQuestion for each required value
+3. Write the config file
+4. On subsequent runs, read the config silently
+
+```markdown
+## Setup
+
+Check for `config.json` in this skill's directory. If missing, ask the user:
+- API endpoint URL
+- Authentication token (store as reference, actual secret in env var)
+- Default output format (json/markdown/csv)
+
+Store answers in `config.json`. On subsequent runs, load config silently.
+```
+
+Never store actual secrets in config.json — store a reference to an environment variable name instead.
+
+## 7. Memory and Data Storage
+
+Skills that produce data between runs need a stable storage location:
+
+| Use Case | Location | Example |
+|----------|----------|---------|
+| Skill-specific state | Skill directory | `skills/<name>/history.json` |
+| Plugin data | `${CLAUDE_PLUGIN_DATA}` | Per-session data |
+| Project-scoped data | `.context/<skill-name>/` | Audit logs, reports |
+
+Prefer the skill directory for small state files. Use `.context/` for project-specific output that should be git-tracked. Use `${CLAUDE_PLUGIN_DATA}` for ephemeral session data.
+
+## 8. On-Demand Hooks
+
+Some skills benefit from Claude Code hooks (PreToolUse, PostToolUse, session lifecycle). If a skill needs hooks:
+
+- Document the hook in SKILL.md's setup section
+- Provide the hook configuration for `.claude/hooks.json`
+- Keep hooks lightweight — they run on every tool call
+
+Only suggest hooks when the skill genuinely needs to intercept or augment tool behavior. Most skills don't need hooks.
+
+## 9. Measuring Skill Usage
+
+Consider adding lightweight usage tracking to skills that run frequently:
+
+- Append to a JSONL log file in the skill directory
+- Track: timestamp, arguments, outcome (success/failure), duration
+- This data helps identify gotchas and optimize the skill over time
+
+This is optional — only include for skills where usage patterns would inform improvements.
+
+## 10. Naming Conventions
+
+- Skill names: lowercase kebab-case (`my-skill`, not `mySkill` or `my_skill`)
+- Slash commands: derived from skill name (`/my-skill`)
+- Directory: matches skill name (`skills/my-skill/`)
+- Files: use descriptive names (`gotchas.md` not `notes.md`, `api.md` not `ref.md`)
+
+## 11. Allowed Tools
+
+The `allowed-tools` frontmatter field is a whitelist. If you omit a tool, Claude cannot use it during skill execution. Common patterns:
+
+| Category | Typical Tools |
+|----------|--------------|
+| Read-only skills | Read, Glob, Grep, Bash |
+| Code generation | Read, Write, Edit, Bash, Glob, Grep |
+| Interactive skills | All above + AskUserQuestion |
+| Orchestration skills | All above + Skill, Agent |
+
+When in doubt, include the tool. An overly restrictive tool list causes silent failures that are hard to debug.

--- a/.claude/skills/skill-builder/references/category-templates.md
+++ b/.claude/skills/skill-builder/references/category-templates.md
@@ -1,0 +1,430 @@
+# Category Templates
+
+Per-category guidance for skill scaffolding. Read the relevant category section after the user selects their category in Step 1.
+
+---
+
+## 1. Library & API Reference
+
+**Purpose:** Teach Claude how to use a specific library, CLI, or SDK correctly — especially when it has undocumented behavior, version-specific APIs, or common pitfalls.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  references/
+    api.md              # Current API signatures and usage patterns
+    gotchas.md          # Version-specific quirks, deprecated methods
+    examples.md         # Annotated usage examples
+```
+
+**Key SKILL.md sections:**
+- Quick reference table of most-used functions/commands
+- Version compatibility notes
+- When to use this library vs alternatives
+- Gotchas (critical for this category)
+
+**Interview questions:**
+- Which version of this library are you targeting?
+- What are the most common mistakes people make with it?
+- Are there deprecated APIs that Claude might hallucinate?
+- What's the typical import/setup pattern?
+
+**Recommended tools:** `Read, Glob, Grep, Bash, Edit, Write`
+
+**Example description:**
+```yaml
+description: |
+  Use Prisma, Prisma ORM, Prisma migrations, Prisma schema, Prisma client,
+  database queries with Prisma. Library reference for Prisma ORM with migration
+  patterns, schema design, and query optimization.
+```
+
+**Tips:**
+- Pair with Context7 MCP for live documentation lookup
+- Focus gotchas on things Claude gets wrong by default (outdated API patterns from training data)
+- Include version checks in the workflow so Claude validates it's using the right API
+
+---
+
+## 2. Product Verification
+
+**Purpose:** Test or verify that code works correctly using external tools (Playwright, tmux, simulators, real browsers).
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  scripts/
+    setup.sh            # Environment setup (install deps, start servers)
+    verify.sh           # Main verification script
+  references/
+    tool-usage.md       # How to use the verification tool correctly
+  templates/
+    report.md           # Verification report template
+```
+
+**Key SKILL.md sections:**
+- Environment prerequisites
+- Setup steps (what to start before verifying)
+- Verification workflow (what to check and in what order)
+- How to interpret results
+- Teardown steps
+
+**Interview questions:**
+- What tool do you use for verification (Playwright, Cypress, tmux, etc.)?
+- What needs to be running before verification starts (servers, databases)?
+- What does a passing verification look like vs a failing one?
+- Should verification be interactive or fully automated?
+
+**Recommended tools:** `Bash, Read, Write, Glob, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Test the app, verify it works, run verification, check the UI, browser test,
+  end-to-end test, smoke test. Launches the app and verifies core user flows
+  using Playwright browser automation.
+```
+
+**Tips:**
+- Include server startup and teardown in the workflow
+- Add timeouts for browser/server operations
+- Screenshot or log capture on failure helps debugging
+- Consider a "quick check" mode vs "full verification" mode
+
+---
+
+## 3. Data Fetching & Analysis
+
+**Purpose:** Connect to data sources, monitoring stacks, or analytics platforms. Fetch, transform, and present data.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  config.json           # Connection strings, API keys (references only)
+  references/
+    schema.md           # Data schemas, table definitions
+    queries.md          # Common query patterns
+  templates/
+    report.md           # Analysis report template
+```
+
+**Key SKILL.md sections:**
+- Setup (config with connection details)
+- Available data sources
+- Common queries / analysis patterns
+- Output format options
+
+**Interview questions:**
+- What data source are you connecting to (database, API, monitoring tool)?
+- What authentication is required?
+- What are the most common queries or analyses you run?
+- Should results be formatted as tables, charts, markdown, or raw data?
+- Are there rate limits or data size concerns?
+
+**Recommended tools:** `Bash, Read, Write, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Query database, fetch metrics, analyze data, pull analytics, check monitoring,
+  data report, dashboard data. Connects to project data sources and produces
+  formatted analysis reports.
+```
+
+**Tips:**
+- Never store actual credentials in config.json — reference environment variables
+- Include query timeouts and result size limits
+- Consider caching frequently-accessed data
+- Template the output so reports are consistent
+
+---
+
+## 4. Business Process & Team Automation
+
+**Purpose:** Automate repetitive team workflows — PR management, ticket updates, communication, status reports.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  config.json           # Team settings, channel IDs, repo names
+  templates/
+    output.md           # Structured output template
+  references/
+    workflow.md         # Detailed workflow documentation
+```
+
+**Key SKILL.md sections:**
+- Setup (team-specific configuration)
+- Trigger conditions (when to use this)
+- Workflow steps
+- Integration points (GitHub, Slack, Jira, etc.)
+
+**Interview questions:**
+- What workflow are you automating? Walk through the manual steps today.
+- What systems does it touch (GitHub, Slack, Jira, email)?
+- Who are the stakeholders? What do they need to see?
+- How often does this run? On-demand or scheduled?
+- What are the failure modes? What happens if a system is down?
+
+**Recommended tools:** `Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Weekly standup, team status, generate status report, PR summary, sprint review,
+  team automation, weekly report. Automates weekly team status collection and
+  report generation.
+```
+
+**Tips:**
+- Make the skill idempotent — safe to run multiple times
+- Include dry-run mode for workflows that send notifications
+- Store history of past runs for trend tracking
+- Use AskUserQuestion for confirmation before external side effects (posting to Slack, etc.)
+
+---
+
+## 5. Code Scaffolding & Templates
+
+**Purpose:** Generate boilerplate code, project structures, or framework-specific file sets.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  templates/
+    component.md        # Template for generated files
+    route.md
+    service.md
+  references/
+    conventions.md      # Project conventions to follow
+```
+
+**Key SKILL.md sections:**
+- Available templates and when to use each
+- Convention rules (naming, file placement, imports)
+- Customization options
+- Post-generation steps (what to do after scaffolding)
+
+**Interview questions:**
+- What framework or stack is this for?
+- What are the project's naming conventions?
+- What files are typically created together (e.g., component + test + story)?
+- Are there project-specific patterns that differ from framework defaults?
+- What should happen after scaffolding (run formatter, add to index, etc.)?
+
+**Recommended tools:** `Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Scaffold component, new page, create route, generate service, add feature,
+  boilerplate, template code. Generates framework-compliant file sets following
+  project conventions.
+```
+
+**Tips:**
+- Read existing code to match project conventions rather than using generic templates
+- Include the test file in the scaffold
+- Run the project's formatter/linter after generation
+- Verify imports resolve correctly
+
+---
+
+## 6. Code Quality & Review
+
+**Purpose:** Enforce coding standards, review code for issues, refactor, or perform systematic quality checks.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  references/
+    standards.md        # Coding standards and rules
+    checklist.md        # Review checklist
+  templates/
+    review-report.md    # Review output format
+```
+
+**Key SKILL.md sections:**
+- What standards are enforced
+- Review workflow (automated checks then manual review)
+- Severity levels and how to handle each
+- Integration with existing linters/CI
+
+**Interview questions:**
+- What coding standards or conventions should be enforced?
+- What are the most common code quality issues in this codebase?
+- Should the skill auto-fix issues or just report them?
+- What's the severity model (critical/warning/info)?
+- Does this integrate with existing CI checks?
+
+**Recommended tools:** `Read, Bash, Glob, Grep, Edit, Write, AskUserQuestion, Agent`
+
+**Example description:**
+```yaml
+description: |
+  Review code, code review, check quality, lint code, enforce standards,
+  refactor review, quality check. Systematic code quality review with
+  auto-fix for safe patterns.
+```
+
+**Tips:**
+- Dispatch parallel agents for independent review dimensions (architecture, style, tests)
+- Distinguish between auto-fixable issues and issues requiring human judgment
+- Include a severity system so users can filter noise
+- Store review history to track improvement over time
+
+---
+
+## 7. CI/CD & Deployment
+
+**Purpose:** Build, test, deploy, or manage release pipelines.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  config.json           # Environment configs, deploy targets
+  scripts/
+    deploy.sh           # Deployment script
+    rollback.sh         # Rollback script
+  references/
+    environments.md     # Environment details and access
+    runbook.md          # Deployment procedures
+```
+
+**Key SKILL.md sections:**
+- Pre-flight checks (what must be true before deploying)
+- Deploy workflow with explicit ordering
+- Verification steps (how to confirm deployment succeeded)
+- Rollback procedure
+- Environment-specific notes
+
+**Interview questions:**
+- What environments exist (staging, production, etc.)?
+- What's the deployment mechanism (git push, CLI tool, API call)?
+- What pre-flight checks are required?
+- How do you verify a deployment succeeded?
+- What's the rollback procedure?
+
+**Recommended tools:** `Bash, Read, Write, Glob, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Deploy, push to production, release, ship to staging, deploy service,
+  roll out, CI/CD pipeline. Manages deployment pipeline with pre-flight
+  checks, staged rollout, and rollback support.
+```
+
+**Tips:**
+- Always include pre-flight checks (clean git state, tests pass, correct branch)
+- Require explicit confirmation before production deploys
+- Include rollback as a first-class workflow, not an afterthought
+- Log every deployment with timestamp, commit SHA, deployer, outcome
+
+---
+
+## 8. Runbooks
+
+**Purpose:** Guide Claude through investigating a symptom, performing diagnostic steps, and producing a structured incident report.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  references/
+    symptoms.md         # Known symptoms and diagnostic trees
+    commands.md         # Diagnostic commands reference
+  templates/
+    incident-report.md  # Structured report template
+    postmortem.md       # Postmortem template
+```
+
+**Key SKILL.md sections:**
+- Symptom identification
+- Diagnostic decision tree (if X, check Y)
+- Common fixes for known issues
+- Report template with required fields
+- Escalation criteria
+
+**Interview questions:**
+- What system or service does this runbook cover?
+- What are the most common symptoms or alerts?
+- What diagnostic commands or tools are available?
+- What does the incident report need to include?
+- When should the skill escalate vs attempt a fix?
+
+**Recommended tools:** `Bash, Read, Write, Grep, Glob, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Investigate incident, debug issue, troubleshoot error, runbook, diagnose problem,
+  incident response, check service health. Structured investigation runbook for
+  service issues with diagnostic trees and incident reports.
+```
+
+**Tips:**
+- Structure as a decision tree, not a linear list
+- Include "check this first" quick diagnostics before deep investigation
+- Template the report so it's consistent across incidents
+- Store past incident reports for pattern matching
+- Include safe vs unsafe diagnostic commands (read-only first)
+
+---
+
+## 9. Infrastructure Operations
+
+**Purpose:** Perform maintenance tasks, migrations, infrastructure changes, or operational procedures.
+
+**Recommended structure:**
+```
+skills/<name>/
+  SKILL.md
+  config.json           # Infrastructure targets and settings
+  scripts/
+    migrate.sh          # Migration script
+    validate.sh         # Post-operation validation
+  references/
+    infrastructure.md   # System architecture and access
+    procedures.md       # Standard operating procedures
+  templates/
+    change-log.md       # Change documentation template
+```
+
+**Key SKILL.md sections:**
+- Pre-operation checklist
+- Step-by-step procedure with verification at each step
+- Rollback procedure for each step
+- Post-operation validation
+- Change documentation requirements
+
+**Interview questions:**
+- What infrastructure or system is this for?
+- What's the blast radius if something goes wrong?
+- What are the rollback options at each step?
+- What validation confirms the operation succeeded?
+- Are there maintenance windows or coordination requirements?
+
+**Recommended tools:** `Bash, Read, Write, Glob, Grep, AskUserQuestion`
+
+**Example description:**
+```yaml
+description: |
+  Run migration, database maintenance, infrastructure update, system operation,
+  maintenance procedure, operational task. Guides infrastructure operations with
+  step-by-step validation and rollback support.
+```
+
+**Tips:**
+- Every step should be independently verifiable and reversible
+- Include explicit rollback for each step, not just the overall operation
+- Require confirmation before destructive operations
+- Log every action taken for audit trail
+- Include a "dry run" mode that validates without executing

--- a/.claude/skills/skill-builder/templates/skill-template.md
+++ b/.claude/skills/skill-builder/templates/skill-template.md
@@ -1,0 +1,50 @@
+---
+name: {{SKILL_NAME}}
+version: 1.0.0
+description: |
+  {{TRIGGER_PHRASES}}
+argument-hint: {{ARGUMENT_HINT}}
+allowed-tools:
+  - {{TOOL_1}}
+  - {{TOOL_2}}
+---
+
+# /{{SKILL_NAME}}: {{SHORT_TITLE}}
+
+{{ONE_LINE_DESCRIPTION — what this skill does and when to use it.}}
+
+{{PROGRESSIVE_DISCLOSURE — if reference files exist, tell Claude what they contain and when to read them. Example:}}
+{{Read `references/api.md` before making API calls — it documents current endpoint signatures and known quirks.}}
+
+## Setup
+
+{{IF_CONFIG_NEEDED:}}
+Check for `config.json` in this skill's directory. If missing, use AskUserQuestion to prompt for:
+- {{CONFIG_VALUE_1}} — {{description}}
+- {{CONFIG_VALUE_2}} — {{description}}
+
+Store answers in `config.json`. On subsequent runs, load config silently.
+
+{{IF_NO_CONFIG: Remove this section entirely.}}
+
+## Workflow
+
+{{STEP_1_HEADING}}
+
+{{Describe the goal of this step. Include domain-specific knowledge, ordering constraints, and non-obvious decisions. Do not describe obvious operations like "read the file" — Claude already knows how.}}
+
+{{STEP_2_HEADING}}
+
+{{Continue with additional steps. Use "prefer" and "consider" for style guidance. Use "must" and "never" only for correctness constraints.}}
+
+## Gotchas
+
+<!-- Add gotchas here as you discover failure modes. Format: -->
+<!-- - **Symptom**: description. **Cause**: why it happens. **Fix**: what to do. -->
+
+## References
+
+{{IF_REFERENCE_FILES_EXIST:}}
+- `references/{{FILE}}.md` — {{what it contains and when to read it}}
+
+{{IF_NO_REFERENCES: Remove this section entirely.}}

--- a/.claude/skills/sync-preview/SKILL.md
+++ b/.claude/skills/sync-preview/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sync-preview
+description: |
+  Read-only preview of calsuite --sync across every target in config/targets.json.
+  Aliases: sync-preview, sync --preview, what would sync do, preview sync, dry-run sync,
+  show divergence, divergence report, which skills have diverged, what will --sync change,
+  check target drift, target drift report.
+  Reports per-target counts of files that would be written/updated/migrated/skipped,
+  plus a full list of diverged files with reasons. Writes nothing — safe any time.
+  Run BEFORE /reconcile-targets to understand scope. Calsuite-internal: lives in
+  this repo, not distributed to targets.
+argument-hint: "[--target <name>] [--json]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Preview what calsuite --sync would do
+
+Read-only snapshot of every target's divergence state against calsuite's current HEAD. Tells you:
+
+- How many files are pristine (would safely update)
+- How many are pre-protocol but byte-identical to current calsuite (auto-migrate silently)
+- How many **need reconciliation** (diverged or pre-protocol with local edits) — the ones stuck on every `--sync` until resolved
+
+This skill never writes. Its only job is to produce a readable report.
+
+## When to invoke
+
+- **Before `/reconcile-targets`** — scope check. If `skip-unknown` + `skip-diverged` sum to 3, you can handle it manually; if they sum to 30, you want the agentic pass.
+- **After a long absence** — multi-week drift catch-up. Preview first, decide how many sessions this is, then act.
+- **After bulk calsuite changes** — shipped a new lint pack or renamed a skill? Preview to see the blast radius before syncing.
+- **Debugging a "why is this file still flagged" loop** — the per-file reasons (`user-modified since <sha>` / `no _origin marker and content diverges`) show exactly which matrix row a file lands in.
+
+## When NOT to invoke
+
+- **Daily hygiene** — the post-commit auto-sync already handles the clean cases. Don't run this for routine commits; it's for divergence investigation.
+- **Inside a target** — sync-preview walks calsuite's `config/targets.json` and reads calsuite's source tree. Run from calsuite itself.
+
+## Step 0: Pre-flight
+
+The script lives at `scripts/sync-preview.cjs` inside calsuite and is tracked in the repo. You must run from a directory where calsuite is reachable.
+
+```bash
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/sync-preview.cjs" ]; then
+  echo "✗ sync-preview not found at $calsuite_dir/scripts/sync-preview.cjs"
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or run this skill from inside calsuite."
+  exit 1
+fi
+```
+
+## Step 1: Parse arguments
+
+`$ARGUMENTS` is optional. Supported flags, passed straight to the script:
+
+| Flag | Effect |
+|---|---|
+| `--target <name>` | Scope to a single target by basename (e.g. `verity`). |
+| `--json` | Machine-readable output. Useful when piping into another tool; humans should omit. |
+
+If no arguments, preview every target in `config/targets.json`.
+
+## Step 2: Run the script
+
+```bash
+node "$calsuite_dir/scripts/sync-preview.cjs" $ARGUMENTS
+```
+
+The script exits non-zero only on fatal errors (missing `targets.json`, malformed config). Any divergence count is still exit 0 — that's informational, not failure.
+
+## Step 3: Interpret the output
+
+Human output has three sections:
+
+1. **Header** — `Calsuite HEAD: <sha>` and `Targets: N`.
+2. **Per-target breakdown** — for each target: counts per action, then detail lists for `skip-diverged`, `skip-unknown`, `skip-claimed`, and up to 8 `write-new` files.
+3. **Grand total** — summed across all targets, plus a one-liner pointing to resolution commands.
+
+Action semantics (copy-paste into your summary if useful):
+
+| Action | Meaning | Action needed |
+|---|---|---|
+| `write-new` | File exists in calsuite but not yet at target. | None — `--sync` will create it. |
+| `write-update` | File carries `_origin: calsuite@<sha>` and still matches calsuite's content at that sha. | None — `--sync` will safely overwrite. |
+| `migrate` | Pre-protocol file byte-identical to current calsuite. | None — `--sync` will stamp `_origin` silently. |
+| `skip-diverged` | File has `_origin: calsuite@<sha>` but local edits on top. | `--reconcile <path>` (merge), `--claim <path>` (keep local), or `--force-adopt <path>` (take calsuite's). |
+| `skip-unknown` | File has no `_origin` AND differs from calsuite's current. Pre-protocol edit or stale copy — indistinguishable. | Same three commands as `skip-diverged`. Or `/reconcile-targets` for agentic handling. |
+| `skip-claimed` | File has `_origin: <target-name>`. Working as designed. | None — this is deliberate divergence. |
+
+## Step 4: Summarise for the user
+
+Produce a terse, actionable takeaway. Examples:
+
+- **"All clean"**: `No reconciliation needed across N targets.` Don't belabor it.
+- **"Small scope, manual-fixable"**: `3 files stuck across 2 targets. Suggested commands: ...` with the exact `--reconcile`/`--claim`/`--force-adopt` invocations.
+- **"Large scope"**: `28 files stuck across 3 targets. Scope makes /reconcile-targets the right next step. Before invoking, review the top-N files to spot obvious intentional divergences (e.g. verity's /ship customisations) — those should be --claim, not --reconcile.`
+- **"Concentrated on one target"**: call that out explicitly. If verity has 20/28, the user's real question is about verity — say so.
+
+Don't repaste the full script output — the user already saw it. Add the interpretation layer that turns counts into decisions.
+
+## Arguments
+
+- `--target <name>` — optional. Filter to one target by basename (the last segment of its path in `config/targets.json`).
+- `--json` — optional. Emit machine-readable output instead of human-readable. Set when piping into scripts or other skills.
+
+## Related
+
+- `/reconcile-targets` — the agentic per-file reconciler this skill front-runs. Preview first, then reconcile.
+- `configure-claude.js --reconcile <path>` — single-file three-way merge. Use when the scope is tiny.
+- `configure-claude.js --claim <path>` — mark a file user-owned. Use when you've intentionally diverged (cross-ref `/customise` which fuses edit + claim).
+- `configure-claude.js --force-adopt <path>` — discard local edits, take calsuite's. Use when you know the local edits were accidental.
+- `configure-claude.js --prune-stale` — different operation: DELETES stale row-6 files rather than reconciling them. Use sparingly; destructive.
+
+## Gotchas
+
+- **`write-new` counts can overshoot.** The preview enumerates every calsuite source file missing from a target, but at real sync time the profile resolver filters — a `python`-profile target won't actually receive every `typescript` skill. The preview intentionally overcounts because its job is to reveal max possible drift, not reproduce the installer's filter logic. Trust the `skip-*` buckets exactly; take `write-new` as an upper bound.
+- **Script path is calsuite-local.** Running sync-preview from inside a target will fail the Step 0 guard. That's the design — targets don't need a sync-preview; they're subjects of it.
+- **`_origin` parse tolerance.** Malformed frontmatter (e.g. hand-edited YAML that broke syntax) parses as "no `_origin`" and routes the file to `skip-unknown`. If a file shows up unexpectedly, check its frontmatter block by eye.

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: sync
+description: |
+  Manually run calsuite's mechanical --sync across every target in config/targets.json,
+  then interpret the divergence summary and suggest next steps. Aliases: sync, run sync,
+  push calsuite to targets, flow calsuite changes, propagate calsuite, sync calsuite,
+  kick off sync. Supports `/sync preview` for a read-only dry run (delegates to
+  /sync-preview). Calsuite-internal: lives in this repo, not distributed.
+argument-hint: "[preview] [--target <name>]"
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# Run calsuite --sync with interpretation
+
+Fires calsuite's mechanical sync protocol across every target in `config/targets.json`, then reads the end-of-sync summary and tells you what needs follow-up. Delegate to `/sync-preview` when you only want the read-only report.
+
+The post-commit hook already auto-syncs on every calsuite commit. This skill is for **manual** invocation: re-syncing after an out-of-band calsuite change, kicking the protocol after editing a target's `.claude/skills` file, or forcing a refresh when something drifted.
+
+## When to invoke
+
+- You edited a skill in calsuite and want it distributed immediately (before the next commit fires the post-commit hook).
+- A target's `.claude/` got mutated outside calsuite's flow and you want to reset it.
+- Post-commit hook was disabled for some reason and you're catching up manually.
+- **You want a dry-run first** — use `/sync preview`.
+
+## When NOT to invoke
+
+- **Daily development** — the post-commit hook handles routine sync for free. Don't double-fire.
+- **For reconciling diverged files** — `--sync` skips those. Use `/reconcile-targets`, `--reconcile <path>`, `--force-adopt`, or `--claim` instead.
+- **For deleting stale state** — that's `--prune-stale`.
+
+## Step 0: Pre-flight
+
+```bash
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/configure-claude.js" ]; then
+  echo "✗ Calsuite installer not found at $calsuite_dir/scripts/configure-claude.js"
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite"
+  exit 1
+fi
+```
+
+## Step 1: Parse arguments
+
+`$ARGUMENTS` is optional. Two modes:
+
+- **Preview mode** — if the first word is `preview`, delegate entirely to `/sync-preview` and stop here. Pass remaining arguments through:
+  ```bash
+  # user invoked /sync preview --target verity
+  node "$calsuite_dir/scripts/sync-preview.cjs" --target verity
+  ```
+  Preview never writes. Do not run the real `--sync` afterward.
+
+- **Real sync mode** — default. Proceed to Step 2.
+
+Any other flags (`--target <name>`, etc.) are not currently supported by `--sync`; reject with a helpful error if provided in real mode (`--sync` always walks every target).
+
+## Step 2: Run the sync
+
+```bash
+node "$calsuite_dir/scripts/configure-claude.js" --sync
+```
+
+Stream output directly to the user. Capture the last ~40 lines for Step 3 (the end-of-sync divergence summary, if any).
+
+## Step 3: Read the summary
+
+`--sync` prints a divergence summary when files were skipped pending reconciliation. Look for the block delimited by `───────────` separators — inside it:
+
+- `N file(s) skipped pending reconciliation:` — overall count
+- Per-file lines: `• <target>/.claude/skills/ship/SKILL.md` + reason (`skip-diverged: user-modified since <sha>` OR `skip-unknown: no _origin marker and content diverges`)
+
+If no summary block appeared, sync ran clean — say so and stop.
+
+## Step 4: Interpret and suggest next steps
+
+Pick the smallest-viable follow-up and propose exact commands. Rules of thumb:
+
+| Situation | Recommendation |
+|---|---|
+| 0 skipped | `All clean.` Don't belabor. |
+| 1–3 skipped, concentrated on one target | Suggest `--reconcile <path>` (or `--claim`/`--force-adopt`) for each specific file. Paste the exact commands. |
+| 4–10 skipped across multiple targets | Suggest `/reconcile-targets` for the agentic pass. Offer `/sync preview` first if the user wants the full picture before committing. |
+| 10+ skipped | Strongly recommend `/sync preview` then `/reconcile-targets`. Don't paste individual commands — the volume is not hand-fixable. |
+| Any `skip-diverged` files | Note that these are `_origin`-stamped + user-edited. Usually want `--reconcile` (merge) or `--claim` (keep local). |
+| Any `skip-unknown` files | Pre-protocol edits or stale copies — indistinguishable. `/reconcile-targets` can reason about each; blunt `--force-adopt` loses any intentional edits. |
+
+When suggesting commands, always use absolute paths so the user can copy-paste without re-resolving:
+
+```
+node "$calsuite_dir/scripts/configure-claude.js" --reconcile "/Users/me/Projects/verity/.claude/skills/ship/SKILL.md"
+```
+
+## Arguments
+
+- `preview` — first positional. Switches to read-only mode; delegates to `/sync-preview`. No other `--sync` args are respected when preview is set.
+- `--target <name>` — only respected in preview mode (passed through to `sync-preview.cjs`). Real `--sync` always walks every target.
+
+## Related
+
+- `/sync-preview` — the read-only dry-run. Invoked directly by `/sync preview`.
+- `/reconcile-targets` — agentic per-file reconciler for the skipped files.
+- `configure-claude.js --reconcile <path>` — single-file three-way merge.
+- `configure-claude.js --force-adopt <path>` / `--claim <path>` — single-file blunt resolvers.
+- `configure-claude.js --prune-stale` — **different** operation: deletes stale state rather than syncing.
+
+## Gotchas
+
+- **`--sync` only skips; it never destroys.** Whatever's flagged in the summary is still on disk exactly as it was. Resolving via `--claim` preserves content; `--force-adopt` is the only loss path and it's explicit.
+- **The post-commit hook runs this same command.** If you manually `/sync` immediately after a calsuite commit, the second run will be a no-op for everything the hook already wrote — that's fine.
+- **Target basename matters for `_origin: <target-name>`.** Under the hood, `--sync` uses each target's basename (e.g. `verity`). If you renamed a target directory, the next sync will see `_origin: old-name` as "claimed by a different target" and skip it. Use `--force-adopt` or `--claim` with the new name to recover.


### PR DESCRIPTION
## Summary

- `configure-claude.js` filters `INTERNAL_SKILLS` (`reconcile`, `sync`, `sync-preview`, `skill-builder`, `configure-claude`) out of every target — including calsuite itself.
- Claude Code only discovers skills from `<cwd>/.claude/skills`, so running `/reconcile` or `/sync` from within calsuite silently did nothing.
- This force-adds the five internal skill dirs to git so calsuite self-hosts its own harness.

## Why force-add

`.gitignore` has a blanket `.claude/` rule. Existing tracked files under `.claude/` (e.g. `settings.json`, `flow/`, `ship/`) were already force-added historically; this follows the same pattern. Tracked files override the ignore.

## Follow-up

Longer-term, `configure-claude.js` could be taught to self-install internal skills when the target == calsuite itself, but that's a larger refactor. Committing the files is the smallest change that fixes the discoverability bug.

## Test plan

- [ ] Clone calsuite fresh → `/reconcile`, `/sync`, `/sync-preview`, `/skill-builder` all appear in skill list
- [ ] Existing target repos unaffected (internal skills still filtered out of `--sync`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)