### PR TITLE
chore(profiles): mark reconcile-targets internal, clean dup lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 All notable changes to this repository.
 
-Current version: **2.15**
+Current version: **2.16**
+
+## [2.16] — 2026-04-22
+
+### Changed
+
+- Added `reconcile-targets` to the `INTERNAL_SKILLS` allowlist in `scripts/configure-claude.js`. v2.11 shipped the skill but forgot to mark it internal, so the last syncs distributed a broken skill to every target (a target invoking `/reconcile-targets` would fail at phase 0 — no `config/targets.json` to walk).
+- Removed all six internal skills (`configure-claude`, `skill-builder`, `sync`, `sync-preview`, `reconcile`, `reconcile-targets`) from `config/profiles.json` `base.skills` and `monorepo-root.skills`. They were dead data there — filtered via `INTERNAL_SKILLS` at install time — but v2.14 described that as "listed for completeness". The completeness framing invited the exact confusion that made this PR necessary: "is this skill getting distributed or not?" was answerable only by reading the installer. Now the two lists are disjoint: `profiles.json` is the opt-in distribution roster, `INTERNAL_SKILLS` is the calsuite-only marker.
+
+### Why
+
+Every hub-level skill added to calsuite (installer wrappers, cross-target orchestrators) needs the same two edits: append to `INTERNAL_SKILLS`, append to `profiles.json`. Forgetting either one is invisible at commit time and surfaces as either (a) a broken skill in every downstream repo or (b) dead data in the config. Making the lists non-overlapping removes half the footgun and makes the remaining rule — "if internal, add ONLY to `INTERNAL_SKILLS`" — trivially enforceable.
+
+### Manual target cleanup
+
+Existing target repos still carry `<target>/.claude/skills/reconcile-targets/` on disk from the v2.11 sync. The installer no longer touches it — remove manually when convenient:
+
+```bash
+rm -rf ~/Projects/{verity,timeline,museli}/.claude/skills/reconcile-targets
+```
 
 ## [2.15] — 2026-04-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.15** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.16** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.15**
+**Version: 2.16**
 
 ## Getting started
 

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["configure-claude", "strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets", "sync", "sync-preview", "reconcile"],
+      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["configure-claude", "strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "skill-builder", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "reconcile-targets", "sync", "sync-preview", "reconcile"],
+      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -59,8 +59,18 @@ const HOME_SETTINGS = path.join(HOME_DIR, '.claude', 'settings.json');
 const HOME_SETTINGS_LOCAL = path.join(HOME_DIR, '.claude', 'settings.local.json');
 const HOME_MCP_JSON = path.join(HOME_DIR, '.mcp.json');
 const KNOWN_MARKETPLACES = path.join(HOME_DIR, '.claude', 'plugins', 'known_marketplaces.json');
-// Skills that only make sense in the config repo itself — never export to target repos
-const INTERNAL_SKILLS = new Set(['configure-claude', 'skill-builder', 'sync', 'sync-preview', 'reconcile']);
+// Skills that only make sense in the config repo itself — never export to target repos.
+// These orchestrate calsuite's own workflow (installer, sync, cross-target reconciliation)
+// and read files that only exist here (config/targets.json, scripts/configure-claude.js).
+// Distributing them to targets is a no-op at best, misleading at worst.
+const INTERNAL_SKILLS = new Set([
+  'configure-claude',
+  'skill-builder',
+  'sync',
+  'sync-preview',
+  'reconcile',
+  'reconcile-targets',
+]);
 
 /**
  * Resolve the absolute path to the calsuite checkout on this machine.


### PR DESCRIPTION
## Summary
- Add `reconcile-targets` to `INTERNAL_SKILLS` in `scripts/configure-claude.js`. v2.11 shipped the skill but missed the internal marker — last syncs distributed a broken skill to every target (phase 0 fails without `config/targets.json`).
- Remove all six internal skills (`configure-claude`, `skill-builder`, `sync`, `sync-preview`, `reconcile`, `reconcile-targets`) from `config/profiles.json` `base.skills` and `monorepo-root.skills`. They were dead data — filtered by `INTERNAL_SKILLS` at install time — but listing them invited the exact "is this distributed?" confusion that made this PR necessary.
- `profiles.json` and `INTERNAL_SKILLS` are now **disjoint**: one is the opt-in distribution roster, the other is the calsuite-only marker. Future hub-level skills only need the `INTERNAL_SKILLS` edit.
- Version bump 2.15 → 2.16. Manual per-target cleanup noted in CHANGELOG (orphan `<target>/.claude/skills/reconcile-targets/` dirs from the prior sync).

## How It Works
```mermaid
flowchart LR
    subgraph BEFORE["Before (v2.15)"]
        direction TB
        P1["profiles.json:<br/>+ configure-claude<br/>+ skill-builder<br/>+ sync<br/>+ sync-preview<br/>+ reconcile<br/>+ reconcile-targets<br/>+ user skills..."]
        I1["INTERNAL_SKILLS:<br/>5 of the above<br/>(reconcile-targets missing)"]
        I1 -.->|filter on install| P1
        P1 -->|install| T1["Target<br/>(gets reconcile-targets<br/>— broken)"]
    end
    subgraph AFTER["After (v2.16)"]
        direction TB
        P2["profiles.json:<br/>user skills only"]
        I2["INTERNAL_SKILLS:<br/>6 internal skills"]
        P2 -->|install| T2["Target<br/>(clean)"]
    end
```

## Important Files
| File | Change |
|------|--------|
| `scripts/configure-claude.js` | Add `reconcile-targets` to `INTERNAL_SKILLS`. Expand the set literal across multiple lines with an explanatory comment. |
| `config/profiles.json` | Remove the six internal skills from `base.skills` and `monorepo-root.skills`. |
| `CHANGELOG.md` | New `[2.16]` entry documenting the change + manual cleanup command for existing target repos. |
| `CLAUDE.md`, `README.md` | Version bump 2.15 → 2.16. |

## Test Results
| Scenario | Result |
|----------|--------|
| `rm -rf /tmp/test-project && node scripts/configure-claude.js /tmp/test-project` | ✅ 27 skills written (down from 28 — `reconcile-targets` no longer distributed) |
| Grep for internal skills in installed skills dir | ✅ None present |

## Manual follow-up (per user decision)
Existing target repos carry `<target>/.claude/skills/reconcile-targets/` from the v2.11 sync. User cleans up manually — no installer-driven removal:
```bash
rm -rf ~/Projects/{verity,timeline,museli}/.claude/skills/reconcile-targets
```

## Pre-Landing Review
No issues found.

## Doc Completeness
- [x] CHANGELOG.md updated (with manual cleanup command)
- [x] Version bumped in CLAUDE.md + README.md
- [x] `INTERNAL_SKILLS` comment updated to explain the rationale