### PR TITLE
docs(retro): upstream opt-in telemetry framing from verity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.18**
+Current version: **2.19**
+
+## [2.19] — 2026-04-23
+
+### Changed
+
+- `skills/retro/SKILL.md` — telemetry framing upgrades ported from verity. Step 13 now explicitly labels skill-usage telemetry as "an additive signal, not a dependency" (clarifies that missing telemetry is not a bug). Step 14 "Learning Loop" header renamed to "Learning Loop (opt-in)" so the opt-in nature is discoverable from the outline. Step 1 fetch+RETRO_AUTHOR resolution collapsed into one block with an added note about `config.json` overriding `git config user.email`. Version bump `1.0.0 → 1.1.0`.
+
+### Why
+
+Verity's retro fork made the optional telemetry framing explicit after users repeatedly treated missing telemetry as a broken-skill signal. Same clarifications make sense upstream: telemetry is best-effort observability, not a hard dependency, and that should be readable from the skill source without having to trace through the code paths.
 
 ## [2.18] — 2026-04-23
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.17** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.19** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.17**
+**Version: 2.19**
 
 ## Getting started
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: retro
-version: 1.0.0
+version: 1.1.0
 description: |
   retro, retrospective, what did I ship, weekly summary, how was my week,
   shipping velocity, commit stats, engineering metrics.
@@ -67,16 +67,14 @@ Usage: /retro [window]
 
 ### Step 1: Gather Raw Data — PARALLEL AGENTS
 
-First, fetch origin:
+First, fetch origin and resolve the retrospective subject. For a personal retro (default), scope all queries to the current user:
+
 ```bash
 git fetch origin main --quiet
-```
-
-Resolve the retrospective subject first. For a personal retro (default), scope all queries to the current user:
-
-```bash
 RETRO_AUTHOR="$(git config user.email)"
 ```
+
+If `.claude/skills/retro/config.json` exists and sets `author_email`, it overrides `git config user.email` — load the config value into `RETRO_AUTHOR` instead.
 
 Then dispatch **3 parallel agents** in a single message to gather data concurrently. Pass the author email to each agent.
 
@@ -274,7 +272,7 @@ Save JSON snapshot with this schema:
 
 ### Step 13: Skill Usage Telemetry
 
-Read `~/.claude/analytics/skill-usage.jsonl` (written by `skill-usage-tracker.cjs`). Filter entries by timestamp within the retro window. Skip this step silently if the file doesn't exist.
+Read `~/.claude/analytics/skill-usage.jsonl` (written by `skill-usage-tracker.cjs`). Filter entries by timestamp within the retro window. Skip this step silently if the file doesn't exist — skill-usage telemetry is an additive signal, not a dependency.
 
 Compute:
 - **Top skills by invocation count** (top 5)
@@ -290,7 +288,7 @@ Heavy use → consider automating: /babysit-pr (7× — run via /loop?)
 Never used in window: /plan-ceo, /retro — keep or drop from profile?
 ```
 
-### Step 14: Learning Loop
+### Step 14: Learning Loop (opt-in)
 
 For each item in **3 Things to Improve** (Step 13's narrative), propose one concrete rule update to the most likely-responsible skill file. Format:
 
@@ -354,7 +352,7 @@ Small, practical, realistic. Each takes <5 minutes to adopt.
 (if applicable, from Step 9)
 
 ### Skill Usage
-(from Step 13)
+(from Step 13 — omit if telemetry file missing)
 
 ### Proposed Skill Updates
 (from Step 14 — opt-in)


### PR DESCRIPTION
## Summary

- Label skill-usage telemetry as "additive signal, not a dependency"
- Rename Step 14 "Learning Loop" → "Learning Loop (opt-in)" so opt-in nature is discoverable from outline
- Collapse Step 1 fetch + RETRO_AUTHOR into one block; note `config.json` overrides `git config user.email`
- Bump skill version 1.0.0 → 1.1.0

## Why

Verity users kept treating missing telemetry as a broken-skill signal. The telemetry is best-effort observability, not a required dependency — making that readable from the skill source avoids the confusion.

## Important Files

| File | Change |
|------|--------|
| `skills/retro/SKILL.md` | Framing tweaks: telemetry label, (opt-in) suffix, config.json override note, frontmatter version bump |
| `CHANGELOG.md` | Entry for 2.17 |
| `CLAUDE.md`, `README.md` | Version bump 2.16 → 2.17 |

## Test Results

| Suite | Result |
|-------|--------|
| Markdown-only PR | No CI suite affected |

## Pre-Landing Review

Md-only — review gate bypass applies.

## Doc Completeness

- [x] CHANGELOG.md updated
- [x] Version bumped

## Note

Stacked with [#64](https://github.com/ckallum/calsuite/pull/64) and PRs #66–#68 (upcoming). Both bump to 2.17; first-merged wins, others rebase to the next minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)