### PR TITLE
feat(code-reviewer): Doc Completeness Checklist (informational)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.21**
+Current version: **2.22**
+
+## [2.22] — 2026-04-25
+
+### Added
+
+- `agents/code-reviewer.md` — **Doc Completeness Checklist** (informational) ported from verity's fork. New Step 6 cross-checks newly added files and architectural changes against project CLAUDE.md files at relevant layers (root + per-package in monorepos). Flags new public modules without CLAUDE.md updates, architectural changes without diagrams, new patterns without review-checklist rules, new env vars without doc updates, new specs under `.claude/specs/`. Step 1 adds `git diff --cached --name-only --diff-filter=A` to surface newly added files; Step 2 retains discovered CLAUDE.md paths for cross-reference. Findings are always `info` severity — surface in PASS Notes or as trailing `[info]` entries under BLOCKED, never block on their own. All existing PASS/BLOCKED verdict machinery, review-stamp write, severity tiers, and generic checklist preserved.
+
+### Why
+
+The Doc Completeness pattern is a generic insight from verity: layered CLAUDE.mds (root + workspace-specific) drift out of sync with code changes without a deliberate prompt during review. Surfacing this as a non-blocking check nudges the reviewer to notice missed doc updates without gating the commit on stylistic judgment. Fully generic — verity's specific CLAUDE.md paths, helper names, and ID formats excluded.
 
 ## [2.21] — 2026-04-24
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.21** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.22** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.21**
+**Version: 2.22**
 
 ## Getting started
 

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -82,7 +82,7 @@ For each newly added path, identify the **nearest enclosing** `CLAUDE.md` (root 
 - **New environment variables or external dependencies** — code references a new env var or a new external service/integration, but no `CLAUDE.md` section listing env vars or external dependencies is updated.
 - **New specs** — files added under `.claude/specs/` with no mention in a `CLAUDE.md`'s project-structure / specs listing.
 
-Only consider **additions**. Modifications to existing files do not trigger this check.
+Bullets 1 (new modules/dirs) and 5 (new specs) only fire on file **additions** (`--diff-filter=A`). Bullets 2–4 (architectural changes, new patterns, new env vars / external deps) can fire on **modifications** too — adding `process.env.NEW_VAR` to an existing file or introducing a new helper inside an existing module both warrant a doc update without creating any new file. Use the staged file list from step 1 for those bullets, and the `--diff-filter=A` list for the structural-addition ones.
 
 Report each hit as an `info` finding with:
 - The new path that triggered it.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -19,8 +19,11 @@ Run these commands to understand the change:
 ```bash
 git diff --cached
 git diff --cached --name-only
+git diff --cached --name-only --diff-filter=A
 git log --oneline -5
 ```
+
+The `--diff-filter=A` invocation lists only **newly added** files — you'll use this in the Doc Completeness check.
 
 ### 2. Load Conventions
 
@@ -31,6 +34,8 @@ find . -name "CLAUDE.md" -not -path "*/node_modules/*" -not -path "*/.git/*" 2>/
 ```
 
 Extract conventions, gotchas, patterns, and coding standards. If no CLAUDE.md exists, fall back to general best practices.
+
+Keep the list of discovered `CLAUDE.md` paths — the Doc Completeness check in step 6 cross-references them.
 
 ### 3. Detect Active Spec (if applicable)
 
@@ -60,11 +65,37 @@ Check the staged diff against:
 - **Pattern consistency** — Do changes match sibling file patterns?
 - **Security** — No obvious injection vectors, unsafe eval, or OWASP top-10 issues
 
-### 6. Verdict
+### 6. Doc Completeness Checklist (informational)
+
+Cross-check the diff against the project's layered `CLAUDE.md` files (root + per-package if a monorepo) to catch structural additions that likely need a doc update. This runs **after** the main review and contributes **informational** findings only — it never BLOCKs on its own.
+
+Inputs:
+- The list of `CLAUDE.md` paths from step 2.
+- Newly added files from `git diff --cached --name-only --diff-filter=A`.
+- The staged file list from step 1.
+
+For each newly added path, identify the **nearest enclosing** `CLAUDE.md` (root in a flat repo, or the closest per-package `CLAUDE.md` in a monorepo). Then ask whether this addition is the kind of structural change the docs should mention:
+
+- **New public modules / packages / top-level directories** — a new first-class unit of the codebase (a new package, a new top-level source directory, a new route group, a new schema file, a new long-lived script) is added, but the nearest `CLAUDE.md` is **not** in the staged diff.
+- **Architectural changes without diagrams** — the diff introduces or significantly reshapes cross-module data flow, a new service boundary, or a new background/async pipeline, and no diagram, flow description, or structural section in a `CLAUDE.md` has been updated to reflect it.
+- **New patterns without a rule added** — the diff establishes a new convention that future code should follow (a new error-shape, a new auth helper, a new naming rule, a new testing pattern), but no corresponding entry has been added to the Conventions / Gotchas / Review Checklist section of any `CLAUDE.md`.
+- **New environment variables or external dependencies** — code references a new env var or a new external service/integration, but no `CLAUDE.md` section listing env vars or external dependencies is updated.
+- **New specs** — files added under `.claude/specs/` with no mention in a `CLAUDE.md`'s project-structure / specs listing.
+
+Only consider **additions**. Modifications to existing files do not trigger this check.
+
+Report each hit as an `info` finding with:
+- The new path that triggered it.
+- The `CLAUDE.md` that most plausibly should be updated.
+- A one-line hint on what to add (e.g. "list this module under Structure", "document the new env var", "add a rule so future diffs follow this pattern").
+
+These findings are surfaced under the **Notes** section of a PASS verdict, or alongside other findings in a BLOCKED verdict, but they never by themselves cause a BLOCK.
+
+### 7. Verdict
 
 #### PASS
 
-If all checks pass:
+If all checks in step 5 pass (Doc Completeness findings are informational and do not block):
 
 1. Print a structured summary:
    ```text
@@ -72,7 +103,7 @@ If all checks pass:
 
    **Files reviewed:** <list>
    **Summary:** <1-2 sentence description of changes>
-   **Notes:** <any minor observations, optional>
+   **Notes:** <any minor observations, optional — include any Doc Completeness [info] findings here>
    ```
 
 2. Compute the diff hash and write the review stamp:
@@ -97,19 +128,22 @@ If all checks pass:
 
 #### BLOCKED
 
-If any issues are found:
+If any `critical` issues are found in step 5:
 
-1. Print findings with `file:line` references and fix suggestions:
+1. Print findings with `file:line` references and fix suggestions. Include any Doc Completeness `info` findings at the end of the list — they do not cause the block but are still worth surfacing:
    ```text
    ## Review: BLOCKED
 
    ### Findings
 
-   1. **[severity]** `file.ts:42` — Description of issue
+   1. **[critical]** `file.ts:42` — Description of issue
       **Fix:** Suggested resolution
 
-   2. **[severity]** `file.ts:87` — Description of issue
+   2. **[warning]** `file.ts:87` — Description of issue
       **Fix:** Suggested resolution
+
+   3. **[info]** `src/new-module/foo.ts` — New module added without update to `src/CLAUDE.md`
+      **Fix:** Add an entry under Structure describing this module's role.
    ```
 
 2. Do **NOT** write the review stamp.
@@ -119,5 +153,6 @@ If any issues are found:
 - Be concise — focus on real issues, not style preferences already handled by formatters
 - Severity levels: `critical` (must fix), `warning` (should fix), `info` (consider)
 - Only BLOCK on `critical` findings — `warning` and `info` can pass with notes
+- Doc Completeness findings are always `info` — they surface missed docs without gating the commit
 - When unsure if something is a real issue, check the codebase for precedent before flagging
 - The review stamp file (`.claude/.last-review`) should be in `.gitignore`


### PR DESCRIPTION
## Summary

- New Step 6: Doc Completeness Checklist — cross-checks newly added files and architectural changes against project CLAUDE.md files at relevant layers (root + per-package in monorepos)
- Always \`info\` severity — never blocks. Surfaces in PASS Notes or as trailing \`[info]\` entries under BLOCKED
- Step 1 now runs \`git diff --cached --name-only --diff-filter=A\` to enumerate newly added files
- Existing PASS/BLOCKED machinery, review-stamp, severity tiers preserved

## Why

Layered CLAUDE.md files (root + workspace-specific) drift out of sync with code changes without a deliberate prompt during review. Non-blocking check nudges reviewers to notice missed doc updates without gating commits on stylistic judgment.

## What it flags

- New public modules, packages, or top-level directories without corresponding CLAUDE.md updates
- Architectural changes without diagrams
- New patterns without a corresponding rule in review checklist or a CLAUDE.md
- New env vars / external dependencies without documentation
- New specs under \`.claude/specs/\`

## Important Files

| File | Change |
|------|--------|
| \`agents/code-reviewer.md\` | +55/−10 — new Step 6, Step 1/2 refinements, PASS/BLOCKED templates extended |
| \`CHANGELOG.md\` | Entry for 2.17 |
| \`CLAUDE.md\`, \`README.md\` | Version bump 2.16 → 2.17 |

## Test Results

| Suite | Result |
|-------|--------|
| Markdown-only PR | No CI suite affected |

## Pre-Landing Review

Md-only — review gate bypass applies.

## Doc Completeness

- [x] CHANGELOG.md updated
- [x] Version bumped

## Note on version bumps

Stacked with #64, #65, #66, #67. All bump to 2.17; first-merged wins, others rebase to the next minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an informational documentation completeness checklist that identifies newly added content potentially lacking documentation, surfaced as notes without blocking reviews.

* **Chores**
  * Version bumped to 2.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->