### PR TITLE
docs(readme): document full sync/reconcile toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.16**
+Current version: **2.17**
+
+## [2.17] — 2026-04-22
+
+### Changed
+
+- `README.md` refreshed to document the full sync/reconcile toolchain in one place. Adds `targets.json` setup to **Getting started**; replaces the thin "when a sync flags divergence" block with a proper **Syncing and reconciling** section covering `/sync`, `/sync-preview`, `/reconcile`, `/reconcile-targets`, `/customise`, `--force-adopt`, `--claim`, and `--prune-stale` with intent-based routing tables; new **Internal vs distributed skills** subsection explains the `INTERNAL_SKILLS` / `profiles.json` split from v2.16. Removes the stale `(issue #42, planned)` marker on `--reconcile` — it shipped in v2.8.
+
+### Why
+
+The reconcile/sync toolchain shipped across v2.8–v2.16 (8 versions, 6 PRs) without a cross-cutting narrative in the top-level README. The README was both outdated (`--reconcile planned`) and underdocumented — any skill shipped after v2.7 was invisible to a new reader. This refresh makes the README the single landing point for both *what* exists and *when to use what*.
 
 ## [2.16] — 2026-04-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.16** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.17** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.16**
+**Version: 2.17**
 
 ## Getting started
 
@@ -11,6 +11,14 @@ Clone this repo. By default, place it at `~/Projects/calsuite`; if you keep it e
 ```bash
 node scripts/configure-claude.js /path/to/target-repo
 ```
+
+For multi-target workflows (`--sync`, `/sync`, `/reconcile-targets`), copy `config/targets.example.json` to `config/targets.json` and list your target repos:
+
+```json
+{ "targets": [{ "path": "~/Projects/my-repo" }] }
+```
+
+`targets.json` is gitignored — each user maintains their own list.
 
 Repo layout:
 
@@ -35,7 +43,7 @@ flowchart LR
     subgraph SRC["calsuite/ (source of truth)"]
         direction TB
         S1["scripts/hooks/*.cjs<br/>scripts/lib/*.cjs"]
-        S2["hooks/hooks.json<br/>(template, \${CALSUITE_DIR})"]
+        S2["hooks/hooks.json<br/>(template, ${CALSUITE_DIR})"]
         S3["skills/*/*.md<br/>agents/*.md"]
         S4["config/*.json<br/>config/lint-configs/*<br/>templates/specs/"]
     end
@@ -55,7 +63,7 @@ flowchart LR
     end
 
     S1 -.->|referenced at runtime| H1
-    S2 -->|installer resolves \${CALSUITE_DIR}| L1
+    S2 -->|installer resolves ${CALSUITE_DIR}| L1
     S3 -->|copy + _origin stamp<br/>safe-overwrite protocol| T1
     S4 -->|copy-no-overwrite| T2
     L1 -->|hook runs| H1
@@ -65,16 +73,50 @@ flowchart LR
 |---|---|---|---|
 | Hook wiring (`hooks/hooks.json`) | Installer resolves `${CALSUITE_DIR}` and merges into target's `settings.local.json` (gitignored). Hook runner reads literal absolute paths. | `<target>/.claude/settings.local.json` (per-user) | Edit freely; merge preserves `_origin=calsuite` tags and project-specific entries |
 | Hook scripts (`scripts/hooks/*.cjs`) | Not copied, not symlinked. Referenced directly from `$CALSUITE_DIR`. | `<calsuite>/scripts/hooks/` | Edit calsuite — changes propagate instantly |
-| Skills, agents | Copied with `_origin: calsuite@<sha>` frontmatter. Re-syncs safely overwrite pristine files; skip locally-edited files; never touch user-claimed ones. | `<target>/.claude/skills/`, `agents/` (committed) | `--claim <path>` to keep local, `--force-adopt <path>` to take calsuite's version |
+| Skills, agents | Copied with `_origin: calsuite@<sha>` frontmatter. Re-syncs safely overwrite pristine files; skip locally-edited files; never touch user-claimed ones. | `<target>/.claude/skills/`, `agents/` (committed) | `/reconcile`, `/customise`, `--claim`, `--force-adopt` — see [Syncing and reconciling](#syncing-and-reconciling) |
 | Configs, templates, ESLint | Copy-no-overwrite. Seeded once, never refreshed. | `<target>/.claude/config/`, `.eslintrc.json`, `.claude/specs/` | Just edit — the installer never overwrites |
 | Plugins, permissions | Merged into `settings.json` (portable strings, no paths). | `<target>/.claude/settings.json` (committed) | Edit; re-install preserves additions |
 | MCP servers (`config/global-settings.json`) | Installer adds missing entries to `~/.mcp.json` + user settings. | `~/.claude/` and `~/.mcp.json` (per-user global) | Edit either file; installer only adds missing |
 
-**When a sync flags divergence** — e.g. you've edited `<target>/.claude/skills/ship/SKILL.md` locally — the installer skips that file and logs it. Resolve with:
+## Syncing and reconciling
 
-- `node scripts/configure-claude.js --force-adopt <path>` — take calsuite's current version.
-- `node scripts/configure-claude.js --claim <path>` — stamp `_origin: <target>`, keep local content. Sync never touches it again.
-- `node scripts/configure-claude.js --reconcile <path>` — (issue [#42](https://github.com/ckallum/calsuite/issues/42), planned) three-way merge in `$EDITOR`.
+`--sync` flows calsuite's current state into every target in `config/targets.json`. Pristine files get rewritten with a fresh `_origin: calsuite@<sha>` stamp; diverged files are skipped and surfaced for resolution. Three tiers handle both directions — mechanical, wrapped, agentic.
+
+### Flowing calsuite → targets
+
+From the calsuite root:
+
+| Command | What it does |
+|---|---|
+| `/sync` | Mechanical `--sync` across every target, then interprets the divergence summary and suggests the smallest-viable follow-up |
+| `/sync preview` or `/sync-preview` | Dry-run — reports what would change, writes nothing |
+| `node scripts/configure-claude.js --sync` | Raw installer; `/sync` wraps this |
+
+### Resolving divergence per file
+
+Pick the right tool by **intent**, not by file count:
+
+| Intent | Command | Notes |
+|---|---|---|
+| Take calsuite's version (discard local edits) | `--force-adopt <path>` | Re-stamps `_origin` to current calsuite sha |
+| Keep target's version (mark user-owned forever) | `--claim <path>` | Stamps `_origin: <target>`; sync ignores it forever |
+| Merge both sides | `/reconcile <path>` | 3-way merge in `$EDITOR` with git-style conflict markers; middle pane is the install-sha ancestor when available |
+| Edit-then-claim atomically | `/customise <skill>` | Intentional per-target fork of a calsuite skill |
+| Bulk, LLM-mediated | `/reconcile-targets` | Walks every target's divergences; prompts per file for upstream / cross-port / keep-local / adopt / merge; opens PRs where agreed |
+
+### Orphan cleanup
+
+`configure-claude.js --prune-stale [path]` — opt-in cleanup of three categories:
+
+- **[A]** Parent-level orphan symlinks under `~/Projects/.claude/{skills,agents}` (pre-refactor load-bearing; nothing reads them now)
+- **[B]** Mixed `<target>/.claude/scripts/{hooks,lib}` dirs where calsuite symlinks coexist with user files
+- **[C]** Stale skill/agent `.md` files without `_origin` that diverge from current calsuite
+
+Dry-run by default; `--yes` to apply. Category C always prompts per-file regardless of `--yes` — deleting potentially-edited files is irreversible.
+
+### Internal vs distributed skills
+
+Calsuite's own workflow skills (`/sync`, `/sync-preview`, `/reconcile`, `/reconcile-targets`, plus installer wrappers like `/configure-claude` and `/skill-builder`) are listed in `INTERNAL_SKILLS` in `scripts/configure-claude.js` and never ship to targets — they read files that only exist in calsuite (`config/targets.json`, `scripts/configure-claude.js`). Distributed skills appear only in `config/profiles.json`. The two sets are disjoint by design; any skill that reads calsuite-root files belongs in `INTERNAL_SKILLS`.
 
 ## Mono-repo Support
 


### PR DESCRIPTION
## Summary
- Refresh `README.md` to document the full reconcile+sync toolchain shipped across v2.8–v2.16 (8 versions, 6 PRs).
- Add `targets.json` setup step to **Getting started**.
- New **Syncing and reconciling** section: covers `/sync`, `/sync-preview`, `/reconcile`, `/reconcile-targets`, `/customise`, `--force-adopt`, `--claim`, `--prune-stale`. Routes by intent, not file count.
- New **Internal vs distributed skills** subsection explains the `INTERNAL_SKILLS` / `profiles.json` split from v2.16.
- Remove stale `(issue #42, planned)` marker on `--reconcile` — it shipped in v2.8.
- Version bump 2.16 → 2.17.

## How It Works
```mermaid
flowchart TD
    A[User reads README] --> B{Need?}
    B -- Install once --> C[Getting started]
    B -- Multi-target --> D[New: targets.json setup]
    B -- Push changes to targets --> E[New: Flowing calsuite → targets]
    B -- Resolve divergence --> F[New: intent-based routing table]
    B -- Clean orphans --> G[New: --prune-stale section]
    B -- Why some skills don't ship --> H[New: Internal vs distributed]
    C & D & E & F & G & H --> Z[One landing page, nothing planned-but-undocumented]
```

## Important Files
| File | Change |
|------|--------|
| `README.md` | New **Syncing and reconciling** section (3 subsections + routing tables). Updated `targets.json` setup block in Getting started. Updated distribution table's skills/agents row to reference new tools. |
| `CLAUDE.md` | Version header 2.16 → 2.17. |
| `CHANGELOG.md` | New `[2.17]` entry describing the README refresh + rationale. |

## Test Results
| Check | Result |
|---|---|
| `grep 'issue #42.*planned' README.md` | ✅ No matches (stale marker gone) |
| `grep -c '/reconcile\|/sync\|--prune-stale\|--force-adopt\|--claim' README.md` | ✅ 11 references to the toolchain |
| `git diff main..HEAD --stat` | ✅ Only README.md, CLAUDE.md, CHANGELOG.md |

## Note
Built in an isolated worktree because concurrent upstream/\* branches kept clobbering the main working tree. If another PR bumps to 2.17 first, this needs a trivial rebase to 2.18.

## Pre-Landing Review
No issues found. Docs-only change; no functional edits.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md + README.md
- [x] README is now current with shipped toolchain