### PR TITLE
feat(installer): add workspaces:skip option to stop workspace harness regen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,18 @@ All notable changes to this repository.
 
 Current version: **2.17**
 
-## [2.17] — 2026-04-22
+## [2.17] — 2026-04-23
 
 ### Added
 
-- Per-target `workspaces: "skip"` option in `config/targets.json`. When set, `--sync` (and direct `node configure-claude.js <target>` invocations) install the harness only at the monorepo root — workspace subdirs (`backend/`, `frontend/`) are left alone. Default remains `"full"` (every workspace gets a mirrored `.claude/`), so existing target configs are unaffected. Documented in `config/targets.example.json`.
+- Per-target `workspaces: "skip"` option in `config/targets.json`. When set, `--sync`, `--only`, and direct `node configure-claude.js <target>` invocations install the harness only at the monorepo root — workspace subdirs (`backend/`, `frontend/`) are left alone. Default remains `"full"` (every workspace gets a mirrored `.claude/`), so existing target configs are unaffected. Documented in `config/targets.example.json`.
+- `--prune-stale` Category D — sweeps orphan workspace `.claude/` dirs on targets opted into `workspaces: "skip"`. Single-target and all-targets modes both consult `targets.json` for the `workspaces` field. Dry-run by default; `--yes` prompts per-dir like Category C (irreversible recursive delete, TTY required).
 
 ### Why
 
 Claude Code uses the nearest `.claude/` walking up from cwd, so a monorepo root `.claude/` already covers commands run from `backend/` or `frontend/`. The workspace mirror was distributing a second copy of every skill, agent, and permissions block — drift was guaranteed and the duplicates added nothing. Before this flag, removing workspace harness content in a target repo (e.g., [verity#463](https://github.com/verityaml/verity/pull/463)) didn't stick — the next calsuite commit's post-commit `--sync` regenerated the files via `write-new` (skills with no destination file are always written fresh; the `_origin` safe-overwrite protocol can't short-circuit a missing file). `workspaces: "skip"` stops the installer iterating workspaces at all, so deletions stay deleted.
 
-### Manual target cleanup
-
-After opting a target into `workspaces: "skip"`, existing workspace harness content is left on disk (the installer never deletes). Remove manually when convenient:
-
-```bash
-rm -rf ~/Projects/<target>/{backend,frontend}/.claude
-```
+Category D closes the loop: opting a target into `workspaces: "skip"` doesn't delete the pre-existing workspace dirs, but `--prune-stale` now surfaces them as orphan calsuite state and prompts to remove them interactively. No `--yes` bulk delete — recursive directory removal always prompts.
 
 ## [2.16] — 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,25 @@
 
 All notable changes to this repository.
 
-Current version: **2.16**
+Current version: **2.17**
+
+## [2.17] — 2026-04-22
+
+### Added
+
+- Per-target `workspaces: "skip"` option in `config/targets.json`. When set, `--sync` (and direct `node configure-claude.js <target>` invocations) install the harness only at the monorepo root — workspace subdirs (`backend/`, `frontend/`) are left alone. Default remains `"full"` (every workspace gets a mirrored `.claude/`), so existing target configs are unaffected. Documented in `config/targets.example.json`.
+
+### Why
+
+Claude Code uses the nearest `.claude/` walking up from cwd, so a monorepo root `.claude/` already covers commands run from `backend/` or `frontend/`. The workspace mirror was distributing a second copy of every skill, agent, and permissions block — drift was guaranteed and the duplicates added nothing. Before this flag, removing workspace harness content in a target repo (e.g., [verity#463](https://github.com/verityaml/verity/pull/463)) didn't stick — the next calsuite commit's post-commit `--sync` regenerated the files via `write-new` (skills with no destination file are always written fresh; the `_origin` safe-overwrite protocol can't short-circuit a missing file). `workspaces: "skip"` stops the installer iterating workspaces at all, so deletions stay deleted.
+
+### Manual target cleanup
+
+After opting a target into `workspaces: "skip"`, existing workspace harness content is left on disk (the installer never deletes). Remove manually when convenient:
+
+```bash
+rm -rf ~/Projects/<target>/{backend,frontend}/.claude
+```
 
 ## [2.16] — 2026-04-22
 

--- a/config/targets.example.json
+++ b/config/targets.example.json
@@ -1,7 +1,8 @@
 {
   "_comment": "Copy this file to config/targets.json and replace the paths with your own target repos. targets.json is gitignored — it stays local and is never committed. Paths may use '~' for your home directory; the installer expands it.",
+  "_workspaces_comment": "For monorepo targets (backend/ + frontend/ subdirs), set `workspaces: \"skip\"` to install the harness only at the repo root. Default is `\"full\"` — every workspace gets its own mirrored .claude/ skills/agents/config/permissions. Use `\"skip\"` when only the root should be the Claude Code harness (recommended for most monorepos — avoids duplicated skill definitions and drift).",
   "targets": [
     { "path": "~/Projects/my-first-repo" },
-    { "path": "~/Projects/my-second-repo" }
+    { "path": "~/Projects/my-monorepo", "workspaces": "skip" }
   ]
 }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -14,7 +14,11 @@
  *   --only skill1,skill2,...     Install only specific skills (skips hooks/plugins/settings)
  *   --agents agent1,agent2,...   Install only specific agents (use with --only)
  *   --install-ccstatusline       Install ccstatusline config only
- *   --sync                       Re-run install against all targets in config/targets.json
+ *   --sync                       Re-run install against all targets in config/targets.json.
+ *                                Each target may set `workspaces: "skip"` to install the
+ *                                harness only at the repo root — workspace subdirs
+ *                                (backend/, frontend/) are left alone. Default is "full"
+ *                                (every workspace gets a mirrored .claude/).
  *   --force-adopt <path>         Overwrite a target skill/agent file with calsuite's
  *                                current version. Discards local edits. Stamps fresh
  *                                `_origin: calsuite@<sha>`. Prompts for confirmation;
@@ -842,6 +846,17 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
     const rootResolved = resolveProfile(rootProfileNames, profilesConfig);
     installForProfile(targetDir, rootResolved, `monorepo root [${rootProfileNames.join(', ')}]`, opts);
 
+    // `workspaces: "skip"` in targets.json means this target treats only the
+    // monorepo root as the harness — workspace subdirs (backend/, frontend/)
+    // don't get their own `.claude/` skills, agents, config, or permissions.
+    // Default is `"full"` for backward compat: every workspace gets a mirror.
+    if (opts.skipWorkspaces) {
+      if (opts.logProfiles) {
+        console.log(`\n  Skipping workspace harness install (targets.json: workspaces = "skip")`);
+      }
+      return { detectedProfiles, isMonorepo, rootProfileNames };
+    }
+
     const workspaces = findWorkspaces(targetDir);
     for (const ws of workspaces) {
       const wsProfiles = detectProfiles(ws.path);
@@ -1626,7 +1641,8 @@ function main() {
         console.log(`  ⚠ Skipping ${target.path} (not found)`);
         continue;
       }
-      installTarget(targetPath, profilesConfig, { divergences });
+      const skipWorkspaces = target.workspaces === 'skip';
+      installTarget(targetPath, profilesConfig, { divergences, skipWorkspaces });
     }
 
     console.log('\nSync complete!\n');
@@ -1659,10 +1675,21 @@ function main() {
   console.log(`\nConfiguring Claude Code for: ${targetDir}\n`);
   const divergences = [];
 
+  // Look up per-target config in targets.json so single-target invocations
+  // honor the same `workspaces: "skip"` setting that --sync respects. Without
+  // this, `node configure-claude.js ~/Projects/verity` would reinstall the
+  // workspace harness even though the user configured the target otherwise.
+  const targetsConfig = readJsonSync(TARGETS_JSON);
+  const matchingTarget = targetsConfig?.targets?.find(
+    t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === targetDir
+  );
+  const skipWorkspaces = matchingTarget?.workspaces === 'skip';
+
   const { isMonorepo } = installTarget(targetDir, profilesConfig, {
     logProfiles: true,
     copyWorkspaceDocs: true,
     divergences,
+    skipWorkspaces,
   });
 
   // Global settings check
@@ -1672,7 +1699,7 @@ function main() {
     console.log('  ⚠ Could not read global manifest, skipping global check');
   } else {
     const settingsPaths = [path.join(targetDir, '.claude', 'settings.json')];
-    if (isMonorepo) {
+    if (isMonorepo && !skipWorkspaces) {
       const workspaces = findWorkspaces(targetDir);
       for (const ws of workspaces) {
         settingsPaths.push(path.join(ws.path, '.claude', 'settings.json'));

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -814,14 +814,24 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
     console.log(`  → ${count} agent(s): ${summary.written} written, ${summary.skipped} skipped`);
   }
 
-  // Also install into workspaces if monorepo
+  // Also install into workspaces if monorepo, unless the target opted out
+  // via `workspaces: "skip"` in targets.json. Mirrors the same lookup used
+  // by installTarget so --only stays consistent with --sync and the
+  // single-target direct-invocation path.
   const detectedProfiles = detectProfiles(targetDir);
   if (detectedProfiles.includes('monorepo')) {
-    const workspaces = findWorkspaces(targetDir);
-    for (const ws of workspaces) {
-      console.log(`\n  Workspace: ${ws.name}`);
-      const wsMissing = installOnly(ws.path, onlySkills, onlyAgents, divergences);
-      missing.push(...wsMissing);
+    const targetsConfig = readJsonSync(TARGETS_JSON);
+    const matchingTarget = targetsConfig?.targets?.find(
+      t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === targetDir
+    );
+    const skipWorkspaces = matchingTarget?.workspaces === 'skip';
+    if (!skipWorkspaces) {
+      const workspaces = findWorkspaces(targetDir);
+      for (const ws of workspaces) {
+        console.log(`\n  Workspace: ${ws.name}`);
+        const wsMissing = installOnly(ws.path, onlySkills, onlyAgents, divergences);
+        missing.push(...wsMissing);
+      }
     }
   }
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -1197,7 +1197,7 @@ function walkFilesRecursive(dir) {
 
 /**
  * Opt-in cleanup of orphaned calsuite state left behind by prior
- * distribution models. Three categories:
+ * distribution models. Four categories:
  *   [A] Parent-level symlinks under ~/Projects/.claude/{skills,agents}
  *       pointing into calsuite. Nothing reads these since the refactor
  *       (Claude Code doesn't discover parent .claude/ skill dirs).
@@ -1208,10 +1208,15 @@ function walkFilesRecursive(dir) {
  *       current (decideFileAction → 'skip-unknown'). Only those whose
  *       filename matches a calsuite source — foreign files are treated
  *       as user-added and left alone (stand-in for honoring .gitignore).
+ *   [D] Workspace `.claude/` dirs on targets opted into `workspaces: "skip"`
+ *       (monorepos where only the root is a harness). The installer no
+ *       longer writes to these dirs, so any content is orphan. Only runs
+ *       for targets with an explicit `workspaces: "skip"` entry in
+ *       targets.json — a missing or `"full"` config leaves the dirs alone.
  *
- * Dry-run by default. `--yes` applies A & B automatically; C always
- * prompts per-file, since deleting a potentially-edited file is
- * irreversible. Non-TTY + apply mode + category C candidates errors out.
+ * Dry-run by default. `--yes` applies A & B automatically; C & D always
+ * prompt per-file/per-dir, since deletions are irreversible. Non-TTY +
+ * apply mode + C/D candidates errors out.
  *
  * Without `<path>`, iterates every target in config/targets.json and
  * treats category A as a global one-shot before the per-target loop.
@@ -1219,7 +1224,10 @@ function walkFilesRecursive(dir) {
 function handlePruneStale(targetPath, { assumeYes = false } = {}) {
   const calsuiteDir = resolveCalsuiteDir();
 
-  // Resolve which targets to walk.
+  // Resolve which targets to walk. Always read targets.json (when it exists)
+  // so single-target invocations can still pick up the `workspaces` config —
+  // Category D gates on that field.
+  const targetsJson = readJsonSync(TARGETS_JSON);
   let targets;
   if (targetPath) {
     const resolved = path.resolve(targetPath);
@@ -1227,9 +1235,11 @@ function handlePruneStale(targetPath, { assumeYes = false } = {}) {
       console.error(`  ✗ ${resolved} does not exist`);
       process.exit(1);
     }
-    targets = [{ path: resolved, label: path.basename(resolved) }];
+    const matching = targetsJson?.targets?.find(
+      t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === resolved
+    );
+    targets = [{ path: resolved, label: path.basename(resolved), workspaces: matching?.workspaces }];
   } else {
-    const targetsJson = readJsonSync(TARGETS_JSON);
     if (!targetsJson) {
       console.error('  ✗ config/targets.json not found.');
       console.error('    Copy config/targets.example.json to config/targets.json and add your target repo paths.');
@@ -1247,7 +1257,7 @@ function handlePruneStale(targetPath, { assumeYes = false } = {}) {
         console.log(`  ⚠ Skipping ${t.path} (not found)`);
         continue;
       }
-      targets.push({ path: resolved, label: path.basename(resolved) });
+      targets.push({ path: resolved, label: path.basename(resolved), workspaces: t.workspaces });
     }
     if (!targets.length) {
       console.error('  ✗ No reachable targets to prune.');
@@ -1503,6 +1513,48 @@ function handlePruneStale(targetPath, { assumeYes = false } = {}) {
         } else {
           console.log(`  ⊘ Kept ${destFile}`);
           totalKeptByUser++;
+        }
+      }
+    }
+
+    // Category D: workspace .claude/ dirs on targets opted into
+    // `workspaces: "skip"`. Only fires when the target's targets.json entry
+    // explicitly sets the flag — unflagged (or "full") targets skip this
+    // category so the pre-existing "workspaces are harnesses" behavior
+    // remains untouched.
+    if (target.workspaces === 'skip') {
+      console.log('\n  [D] Orphan workspace .claude/ dirs (workspaces: "skip")');
+      const workspaces = findWorkspaces(target.path);
+      const orphanDirs = workspaces
+        .map(ws => path.join(ws.path, '.claude'))
+        .filter(dir => fs.existsSync(dir));
+
+      if (orphanDirs.length === 0) {
+        console.log('  (none)');
+      } else if (!assumeYes) {
+        for (const dir of orphanDirs) {
+          console.log(`  · would remove: ${dir}`);
+        }
+      } else {
+        if (!process.stdin.isTTY) {
+          console.error(`  ✗ --prune-stale --yes found category D candidate(s) but stdin is not a TTY.`);
+          console.error(`    Category D deletions require per-dir confirmation — re-run interactively.`);
+          process.exit(1);
+        }
+        for (const dir of orphanDirs) {
+          const confirmed = promptYesNo(`Remove ${dir} (recursive)?`);
+          if (confirmed) {
+            try {
+              fs.rmSync(dir, { recursive: true, force: true });
+              console.log(`  ✓ Removed ${dir}`);
+              totalRemoved++;
+            } catch (err) {
+              console.log(`  ✗ Failed to remove ${dir}: ${err.message}`);
+            }
+          } else {
+            console.log(`  ⊘ Kept ${dir}`);
+            totalKeptByUser++;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- Adds `workspaces: "skip"` per-target option to `config/targets.json` (documented in `config/targets.example.json`).
- When set, `--sync`, `--only`, and direct `node configure-claude.js <target>` installs the harness only at the monorepo root. Workspace subdirs (`backend/`, `frontend/`) are left alone.
- `--prune-stale` grows a Category D that sweeps orphan workspace `.claude/` dirs on targets opted into `workspaces: "skip"`. Closes #71.
- Default remains `"full"` (unchanged behavior for existing configs).

## Why

verityaml/verity#463 landed a cleanup declaring monorepo workspaces are not harnesses — only the repo root is. But the cleanup wouldn't stick: the next calsuite post-commit fired `--sync`, which regenerated workspace `.claude/skills/`, `.claude/agents/`, and the `permissions.allow` block via `write-new`.

The `_origin` safe-overwrite protocol protects against overwriting user-modified files at the destination. It cannot short-circuit a missing destination file — `installProtectedFile` unconditionally writes `write-new` when the target doesn't exist. So "delete and walk away" was never a viable strategy; the installer had to stop iterating workspaces in the first place.

`workspaces: "skip"` provides that opt-out. Claude Code uses the nearest `.claude/` walking up from cwd anyway, so the monorepo root already covers commands run from workspace subdirs — the workspace mirror was pure duplication.

Category D closes the loop on the lifecycle: opting a target in doesn't delete the pre-existing workspace dirs, but `--prune-stale` now surfaces them as orphan calsuite state. Single-target and all-targets modes both consult `targets.json` for the gating flag.

## Changes

| File | Change |
|------|--------|
| `scripts/configure-claude.js` | `installTarget()` + `installOnly()` honor new `workspaces: "skip"` from `targets.json`; `--prune-stale` grows Category D with TTY-guarded per-dir prompts; single-target `--prune-stale <path>` also reads `targets.json` for the `workspaces` field. |
| `config/targets.example.json` | Documents the flag with an example monorepo entry. |
| `CHANGELOG.md` | 2.17 entry covering both the install-side skip and prune-side Category D. |

## Verification

**Install side:**
1. Set `workspaces: "skip"` on verity in local `config/targets.json`.
2. `rm -rf ~/Projects/verity/{backend,frontend}/.claude`.
3. Ran `node scripts/configure-claude.js --sync` — output shows only root installed, workspace sections absent.
4. Ran `node scripts/configure-claude.js ~/Projects/verity --only ship` — no workspace iteration output.
5. Confirmed `backend/.claude` and `frontend/.claude` stayed deleted across multiple `--sync` runs.
6. Timeline and museli (unflagged targets) installed workspaces as before.

**Prune-stale Category D:**
1. Seeded fake orphans: `mkdir -p ~/Projects/verity/{backend,frontend}/.claude/fake`.
2. `node scripts/configure-claude.js --prune-stale` — dry-run listed both dirs under `[D]` for verity; timeline/museli had no `[D]` block.
3. `--prune-stale --yes` with non-TTY stdin: exited with the expected "Category D requires per-dir confirmation" error.
4. `--prune-stale ~/Projects/verity` (single-target) — picked up `workspaces: "skip"` from `targets.json` and surfaced the same candidates.
5. `--prune-stale ~/Projects/timeline` (non-skip target) — no `[D]` block, as designed.

## Test plan

- [x] Set flag, delete workspace dirs, run --sync, confirm deletions stick
- [x] `--only` on a `workspaces: "skip"` target skips workspace iteration
- [x] Confirm unflagged targets still install workspace harness (backward compat)
- [x] Direct single-target invocation honors the flag via targets.json lookup
- [x] `--prune-stale` Category D dry-run lists workspace dirs only on opted-in targets
- [x] `--prune-stale --yes` refuses to proceed without a TTY when Category D candidates exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
