### PR TITLE
feat(skills): CONTEXT.md, ADR, /grill, /improve-architecture, AFK/HITL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 All notable changes to this repository.
 
-Current version: **2.22**
+Current version: **2.23**
+
+## [2.23] — 2026-04-28
+
+### Added
+
+- **`skills/zoom-out/SKILL.md`** — new single-purpose skill: agent goes one layer up and produces a callers/collaborators/peers/entry-points map for an unfamiliar area. Reads `CONTEXT.md` if present and uses its vocabulary verbatim. No grilling, no proposing changes — orientation only.
+- **`skills/improve-architecture/SKILL.md` + `LANGUAGE.md`** — new periodic codebase-health skill. Surfaces deepening opportunities (shallow modules → deep modules) using the deletion test. Fixed architectural vocabulary (Module / Interface / Implementation / Depth / Seam / Adapter / Leverage / Locality) lives in `LANGUAGE.md` with a "Rejected framings" section. Read-and-decide tool — hands off to `/plan review` → `/execute` for implementation. Writes audit notes to `.context/architecture-audits/YYYY-MM-DD.md`.
+- **`skills/plan/SKILL.md`** — `--grill` modifier flag. Switches INTERVIEW/BRAINSTORM/REVIEW questioning into one-question-at-a-time decision-tree-walking mode: always lead with the recommended answer, prefer codebase exploration over asking, challenge user terms against `CONTEXT.md` inline, propose ADRs only for hard-to-reverse / surprising / real-tradeoff decisions.
+- **`templates/CONTEXT.md`** — template for the per-repo domain glossary. Lazy-create when the first term is resolved; opinionated single-sentence definitions, `_Avoid_` aliases, relationships, example domain dialogue, flagged ambiguities. Multi-context repos keep `CONTEXT-MAP.md` at root.
+- **`templates/adr/0000-template.md`** — template for Architecture Decision Records. Hard rule: only write when **all three** are true (hard to reverse, surprising without context, real trade-off). Filename `NNNN-kebab-title.md`, verb-led titles, immutable once accepted, supersession via new ADRs.
+- **`skills/sweep-issues/SKILL.md`** — `.out-of-scope/` durable rejection knowledge base. Step 2 now searches both GitHub issues and `.out-of-scope/<slug>.md` rejection records before creating duplicates. New section explains how to record rejections with format frontmatter (`slug`, `rejected`, `related-issues`) and a "What would change our minds" trigger for re-opening.
+- **AFK / HITL labelling** across `/guardian`, `/sweep-issues`, `/execute`. AFK = agent can complete unattended; HITL = needs human-in-the-loop. `/guardian` adopts AFK/HITL as aliases for autonomous/supervised. `/sweep-issues` tags every created issue with one of `afk` / `hitl` labels (auto-creates the labels if missing) and uses them as the routing signal for downstream skills.
+- **CONTEXT.md / ADR awareness** wired into `/plan`, `/execute`, `/review`, `/debug`, `/learn`. Each skill now reads `CONTEXT.md` (and `CONTEXT-MAP.md` for multi-context repos) plus relevant `docs/adr/` files before doing its work and uses the glossary vocabulary verbatim. `/learn` distinguishes learnings (small-scale durable facts) from CONTEXT.md updates (domain terms) from ADRs (hard-to-reverse architectural decisions).
+- **`skills/skill-builder/SKILL.md`** — Step 6 review checklist: 10 concrete checks (description has triggers, names modes, body length, no time-sensitive info, consistent terminology, concrete examples, references one level deep, gotchas section exists, allowed-tools minimal, no redundant instructions). Step 7 confirmation reports outcome.
+- **`skills/debug/SKILL.md`** — Phase 1 reframed as "Build a feedback loop" with the explicit principle that **the loop IS the skill**. Adds the 10-tactic ladder (failing test → curl → CLI → headless browser → trace replay → throwaway harness → fuzz → bisect → differential → HITL script), iterate-the-loop discipline (faster / sharper / more deterministic), non-deterministic bug guidance (raise the rate, don't chase clean repro), and explicit "stop and ask" path when no loop is buildable. Don't proceed to Phase 2 until you have a loop you believe in.
+- **`README.md`** — bucketed Skills overview section: Daily code work, Daily workflow, Occasional, Calsuite-internal. Replaces flat skill discovery with usage-frequency triage.
+
+### Why
+
+Adopted patterns from [mattpocock/skills](https://github.com/mattpocock/skills) that fill gaps calsuite had no answer for: vocabulary infrastructure (`CONTEXT.md` + ADRs), pre-implementation grilling (`/plan --grill`), proactive codebase health (`/improve-architecture`), durable rejection memory (`.out-of-scope/`), AFK/HITL labelling, orientation micro-skill (`/zoom-out`), feedback-loop framing in `/debug`, and skill-builder review checklist. Pulled the philosophy stack (domain glossary discipline, deletion test, deepening over abstraction) without adopting his distribution model — calsuite keeps the `_origin` protocol and multi-target sync since those serve different goals.
 
 ## [2.22] — 2026-04-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.22** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.23** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.22**
+**Version: 2.23**
 
 ## Getting started
 
@@ -130,6 +130,47 @@ The installer auto-detects project type via `config/profiles.json`:
 # Install into a mono-repo with backend/ and frontend/
 node scripts/configure-claude.js /path/to/monorepo
 ```
+
+## Skills overview
+
+Skills are invoked as `/<name>`. Bucketed by how often you'll reach for them.
+
+### Daily — code work
+- **`/plan`** — interview / brainstorm / review / visualize before implementing. Use `--grill` for relentless one-question-at-a-time decision-tree walking.
+- **`/execute`** — implement from conversation context, a spec, or a GitHub issue. Multi-pane variant for parallel work.
+- **`/debug`** — systematic debugging built around a fast, deterministic feedback loop.
+- **`/review`** — pre-landing review with up to 9 parallel agents, confidence scoring, optional adversarial converse mode.
+- **`/ship`** — merge main, test, review, push, open PR. Docs-only / config-only PR-only mode for lightweight changes.
+- **`/zoom-out`** — map an unfamiliar area: callers, collaborators, peers, entry points. One layer up.
+- **`/improve-architecture`** — find shallow modules and propose deepening opportunities. Run every few days.
+
+### Daily — workflow
+- **`/session-start`** — load full project context: CLAUDE.md, specs, changelog, git history.
+- **`/strategic-compact`** — hook-driven compaction suggestions at logical session breakpoints.
+- **`/learn`** — durable per-project learnings that compound across sessions.
+- **`/babysit-pr`**, **`/receiving-pr-feedback`** — PR lifecycle helpers.
+
+### Occasional
+- **`/qa`** — systematic QA testing.
+- **`/simplify`** — review changed code for reuse, quality, efficiency.
+- **`/sweep-issues`** — auto-create GitHub issues from session context (deferred items, fast-follows, tech debt). Records `wontfix` enhancements to `.out-of-scope/`.
+- **`/retro`** — weekly engineering retrospective.
+- **`/new-spec`** — scaffold a spec directory with requirements / design / tasks templates.
+- **`/worktrees`** — isolated git worktrees with auto-detected setup.
+- **`/loop`** — run a prompt or skill on a recurring interval.
+- **`/schedule`** — create scheduled remote agents (cron or one-shot).
+- **`/guardian`** — autonomous-mode rules, audit log, mode switching.
+- **`/lint-rule-gen`** — generate lint rules from review feedback patterns.
+- **`/prevent`** — analyse a mistake and add the most deterministic guardrail.
+- **`/plan-ceo`** — founder-mode plan review: scope expansion / hold / reduction.
+
+### Calsuite-internal
+Live in this repo, never distributed to targets:
+**`/sync`**, **`/sync-preview`**, **`/reconcile`**, **`/reconcile-targets`**, **`/skill-builder`**.
+
+`/customise` is calsuite-aware but *is* distributed — it ships to every target so users can claim divergent skills atomically without coming back to calsuite.
+
+Full skill source: `skills/<name>/SKILL.md`.
 
 ## Agents
 

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise"],
+      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise"],
+      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -4,7 +4,9 @@ version: 1.0.0
 description: |
   debug this, fix this bug, why is this failing, investigate error, trace the issue,
   something is broken, test failure, systematic debugging, diagnose, root cause.
-  Four-phase systematic debugging: investigate → analyze patterns → hypothesis test → fix.
+  Four-phase systematic debugging built around a fast, deterministic feedback loop:
+  Phase 1 build the loop, Phase 2 analyze patterns, Phase 3 test hypotheses, Phase 4 implement fix.
+  The feedback loop IS the skill — every later phase just consumes its signal.
   Parallel investigation for independent failures.
 argument-hint: [error-description]
 allowed-tools:
@@ -22,7 +24,13 @@ allowed-tools:
 
 Four mandatory phases. Do not skip ahead to fixing — understand first.
 
-## Phase 1: Investigate
+## Domain awareness (before Phase 1)
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files), read it for the area you're debugging — getting the right mental model of the modules in play often shortens Phase 1 dramatically. If `docs/adr/` exists and an ADR covers the area, read it: many "weird" behaviors are deliberate decisions an ADR explains, and the bug is somewhere else.
+
+> **Phase 1 IS the skill.** A fast, deterministic, agent-runnable pass/fail signal for the bug is the difference between debugging and guessing. Everything in Phases 2–4 just consumes that signal. Spend disproportionate effort here. Be aggressive. Be creative. Refuse to give up.
+
+## Phase 1: Build a feedback loop
 
 ### Read the error carefully
 
@@ -31,23 +39,50 @@ Don't skim. Read the full error output, stack trace, and surrounding logs. Extra
 - **Where** it failed (file, line, function)
 - **When** it started failing (recent change? always broken?)
 
-### Reproduce consistently
+### Construct a loop — try these in roughly this order
+
+1. **Failing test** at whatever seam reaches the bug — unit, integration, e2e.
+2. **Curl / HTTP script** against a running dev server.
+3. **CLI invocation** with a fixture input, diffing stdout against a known-good snapshot.
+4. **Headless browser script** (Playwright / Puppeteer) — drives the UI, asserts on DOM/console/network.
+5. **Replay a captured trace.** Save a real network request / payload / event log to disk; replay it through the code path in isolation.
+6. **Throwaway harness.** Spin up a minimal subset of the system (one service, mocked deps) that exercises the bug code path with a single function call.
+7. **Property / fuzz loop.** If the bug is "sometimes wrong output", run 1000 random inputs and look for the failure mode.
+8. **Bisection harness.** If the bug appeared between two known states (commit, dataset, version), automate "boot at state X, check, repeat" so you can `git bisect run` it.
+9. **Differential loop.** Run the same input through old-version vs new-version (or two configs) and diff outputs.
+10. **HITL bash script.** Last resort. If a human must click, drive the loop with a script and capture output — keep the loop structured even when it's not headless.
 
 ```bash
 # Run the failing command/test
 <reproduce command>
 ```
 
-If it doesn't reproduce, it's likely a race condition, environment issue, or flaky test. Investigate those vectors specifically.
+### Iterate on the loop itself
 
-### Check recent changes
+Treat the loop as a product. Once you have *a* loop, ask:
+
+- Can I make it faster? (Cache setup, skip unrelated init, narrow the test scope.)
+- Can I make the signal sharper? (Assert on the specific symptom, not "didn't crash".)
+- Can I make it more deterministic? (Pin time, seed RNG, isolate filesystem, freeze network.)
+
+A 30-second flaky loop is barely better than no loop. A 2-second deterministic loop is a debugging superpower.
+
+### Non-deterministic bugs
+
+The goal is not a clean repro but a **higher reproduction rate**. Loop the trigger 100×, parallelize, add stress, narrow timing windows, inject sleeps. A 50%-flake bug is debuggable; 1% is not — keep raising the rate until it's debuggable.
+
+### Check recent changes (still relevant)
 
 ```bash
 git log --oneline -10
 git diff HEAD~3 --stat
 ```
 
-Did a recent commit touch the failing area? If so, read that diff first.
+Did a recent commit touch the failing area? Use that to inform Phase 3 hypothesis ranking, not as a substitute for the loop.
+
+### When you genuinely cannot build a loop
+
+Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesize without a loop — guessing without a signal wastes more time than building the loop ever would.
 
 ### Gather evidence in multi-component systems
 
@@ -56,7 +91,9 @@ If the failure spans multiple components, trace the data flow:
 2. What transformations happen?
 3. Where does the output diverge from expected?
 
-Add temporary logging if needed to narrow down the boundary.
+Add temporary logging if needed to narrow down the boundary — but tag every log with a unique prefix (e.g. `[DEBUG-a4f2]`) so cleanup at the end is a single grep.
+
+**Do not proceed to Phase 2 until you have a loop you believe in.**
 
 ## Phase 2: Pattern Analysis
 
@@ -170,7 +207,7 @@ Rules for parallel dispatch:
 
 ## Gotchas
 
-- **Reproduce FIRST.** If you can't reproduce it, you can't verify the fix. Don't guess.
+- **Build a loop FIRST.** Without a fast pass/fail signal you cannot verify any fix. Don't guess. Reproduction is item 1 of the 10-tactic ladder, not the headline — the headline is "any deterministic signal".
 - **Check the test, not just the code.** Sometimes the test itself is wrong — asserting the wrong thing, using stale fixtures, or having a race condition.
 - **Environment differences matter.** CI vs local, Node version, env vars, database state. Ask if the failure is environment-specific.
 - **Flaky tests need special treatment.** If it fails intermittently, it's likely timing, ordering, or shared state. Run it 5x in a row to confirm.

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -33,6 +33,29 @@ See `/guardian`'s "How AFK/HITL composes across skills" section for the authorit
 - **HITL-labelled task**: pause at each decision point and ask via AskUserQuestion before proceeding.
 - **Unlabelled**: behave as HITL — only escalate to AFK when explicitly marked or when the user is running under `/guardian mode autonomous`.
 
+### Resolving the mode (compute once, use everywhere)
+
+Compute a single `MODE` value at the start of execution and reuse it at every AskUserQuestion call site below:
+
+```bash
+# Pseudocode — adapt to the actual decision flow
+MODE=hitl                                          # default
+issue_has_label_afk && MODE=afk                    # ISSUE mode: read labels
+spec_or_user_marks_afk && MODE=afk                 # SPEC / RAW mode: explicit marker
+guardian_mode_is_autonomous && MODE=afk            # session-wide override
+```
+
+### AskUserQuestion gating rule
+
+Every AskUserQuestion call below falls into one of two categories:
+
+| Category | AFK behavior | HITL behavior |
+|---|---|---|
+| **Phase confirmation** — "proceed?", "continue?", "raise concerns?" between phases | **Skip** the prompt; proceed automatically and log the auto-decision in the batch report | Ask normally |
+| **User-owned decision** — actions that change shared state outside this run (close issue, post comment, push to remote, send notification) | **Always ask** regardless of mode — AFK does not authorize state changes the user hasn't explicitly delegated | Ask normally |
+
+Each AskUserQuestion call site below explicitly states which category it belongs to. The default for ambiguous calls is **phase confirmation** (skippable in AFK) — be conservative about marking a call user-owned, but never auto-execute issue-close, force-push, or external-system writes without explicit user confirmation.
+
 ## Domain awareness (shared, runs before any mode)
 
 If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` at the root pointing to per-module `CONTEXT.md` files), read it. **Use its vocabulary verbatim** in commit messages, test names, function/variable names, PR descriptions, and any user-facing text. The glossary is the project's source of truth for naming — drift defeats the point.
@@ -117,7 +140,7 @@ Otherwise, parse `$ARGUMENTS`:
 1. Summarize what the user wants from conversation context into a concrete task list.
 2. Explore the codebase to understand relevant files, patterns, and conventions.
 3. Break the work into discrete, ordered tasks (same format as `tasks.md`).
-4. Present via AskUserQuestion:
+4. **Phase confirmation** — present via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, accept the derived task list and the 2-3 sentence intent summary as `COMPLIANCE_REFERENCE` automatically and log the auto-decision in the eventual batch report:
 
 > Here's what I understand you want to implement:
 > - Task 1: [description]
@@ -129,7 +152,7 @@ Otherwise, parse `$ARGUMENTS`:
 >
 > A) Proceed  B) Let me clarify
 
-Store the confirmed summary as `COMPLIANCE_REFERENCE`.
+Store the confirmed (or auto-accepted) summary as `COMPLIANCE_REFERENCE`.
 
 ### SPEC Mode
 
@@ -154,7 +177,7 @@ gh issue view <number> --json title,body,labels,comments,assignees
    - If it contains checklists (`- [ ]` items), extract them as tasks directly.
    - If prose only, derive discrete tasks (same approach as RAW mode).
 
-3. Present via AskUserQuestion:
+3. **Phase confirmation** — present via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, accept the derived task list automatically:
 
 > Issue #N: **<title>**
 > Tasks derived from the issue:
@@ -175,7 +198,7 @@ gh issue view <number> --json title,body,labels,comments,assignees
    - **SPEC:** `feat/<slug>`
    - **ISSUE:** `feat/<issue-number>-<slugified-title>` (max 50 chars)
    - **RAW:** Ask user or derive from first task description
-4. Raise any concerns via AskUserQuestion before starting.
+4. **Phase confirmation** — raise any concerns via AskUserQuestion before starting **only if `MODE=hitl`**. In AFK mode, log concerns to the batch report and proceed; if a concern is severe enough that proceeding would corrupt state (uncommitted changes that conflict, missing dependencies, branch-protection issues), STOP regardless of mode and report — that's a hard blocker, not a phase prompt.
 
 ---
 
@@ -210,7 +233,7 @@ Return: what you implemented, what tests you wrote, test results, any concerns."
 description: "Implement task: <task title>"
 ```
 
-**If the agent has questions:** Present them to the user via AskUserQuestion. Answer, then re-dispatch.
+**If the agent has questions:** treat as a hard blocker. In `MODE=hitl`, present via AskUserQuestion, answer, then re-dispatch. In `MODE=afk`, the orchestrator does **not** have the user's input — STOP and report: *"Task `<title>` requires HITL clarification: `<questions>`. Re-run as HITL or label the issue `hitl` and re-execute."* Do not guess; do not skip; do not silently stall waiting for input that won't come.
 
 ### 3b: Dispatch compliance reviewer
 
@@ -271,7 +294,7 @@ After quality review passes, run `/simplify` to clean up the changed code — re
 
 ## Step 4: Batch Checkpoint (shared)
 
-After each batch of 3 tasks, report to the user:
+After each batch of 3 tasks, report to the user. **Phase confirmation** — present the "Continue?" prompt via AskUserQuestion **only if `MODE=hitl`**; in AFK mode, log the batch report and continue automatically to the next batch:
 
 ```text
 Batch N complete: tasks X-Y done
@@ -281,7 +304,7 @@ Batch N complete: tasks X-Y done
   Tests: all passing
 
 Next batch: tasks Y+1 to Z
-Continue? (A) Yes  (B) Review changes first  (C) Stop here
+Continue? (A) Yes  (B) Review changes first  (C) Stop here     ← MODE=hitl only
 ```
 
 ---
@@ -297,7 +320,7 @@ After all tasks are done:
      ```bash
      gh issue comment <number> --body "Implementation complete on branch \`$(git branch --show-current)\`. Changes: <summary of files changed and tests written>"
      ```
-     Ask user: "Close this issue? (A) Yes (B) No, keep open until PR merges"
+     **User-owned decision** — always ask via AskUserQuestion regardless of `MODE`: "Close this issue? (A) Yes (B) No, keep open until PR merges". Closing an issue is a state change visible outside this run; AFK does not authorize it.
    - **RAW:** No external updates.
 3. Report final status:
 

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -25,6 +25,18 @@ allowed-tools:
 
 Flexible execution skill with three modes plus a parallel multi-pane launcher. All modes share the same execution engine — the only difference is how tasks are sourced and what the compliance reviewer checks against.
 
+## AFK vs HITL handling (shared)
+
+If the source task is labeled **AFK** (e.g. issue carries the `afk` label, or the spec/conversation marks it AFK), proceed end-to-end through the execution loop without pausing for confirmation between phases — that's what AFK means. If labeled **HITL**, the implementer pauses at each decision point and asks via AskUserQuestion before proceeding. Default when unlabeled: behave as HITL — only escalate to AFK behavior when explicitly marked or when the user is running under `/guardian mode autonomous`.
+
+## Domain awareness (shared, runs before any mode)
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` at the root pointing to per-module `CONTEXT.md` files), read it. **Use its vocabulary verbatim** in commit messages, test names, function/variable names, PR descriptions, and any user-facing text. The glossary is the project's source of truth for naming — drift defeats the point.
+
+If `docs/adr/` (or `<context>/docs/adr/`) exists and contains ADRs touching the area you're modifying, read them. Do not implement changes that contradict an accepted ADR without first surfacing the conflict to the user.
+
+Pass any relevant `CONTEXT.md` excerpts and ADR references into the implementer-agent prompt as part of `COMPLIANCE_REFERENCE` so the agent uses the same vocabulary.
+
 ```
 /execute                              → RAW mode   (execute from conversation context)
 /execute spec <slug>                  → SPEC mode  (execute from .claude/specs/<slug>/)

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -27,7 +27,11 @@ Flexible execution skill with three modes plus a parallel multi-pane launcher. A
 
 ## AFK vs HITL handling (shared)
 
-If the source task is labeled **AFK** (e.g. issue carries the `afk` label, or the spec/conversation marks it AFK), proceed end-to-end through the execution loop without pausing for confirmation between phases — that's what AFK means. If labeled **HITL**, the implementer pauses at each decision point and asks via AskUserQuestion before proceeding. Default when unlabeled: behave as HITL — only escalate to AFK behavior when explicitly marked or when the user is running under `/guardian mode autonomous`.
+See `/guardian`'s "How AFK/HITL composes across skills" section for the authoritative definitions and how the label cascades from `/sweep-issues` (classification) through here (execution) to `/guardian` (permissions). At this layer:
+
+- **AFK-labelled task** (issue carries `afk`, or spec/conversation marks it AFK): proceed end-to-end through the execution loop without pausing for confirmation between phases.
+- **HITL-labelled task**: pause at each decision point and ask via AskUserQuestion before proceeding.
+- **Unlabelled**: behave as HITL — only escalate to AFK when explicitly marked or when the user is running under `/guardian mode autonomous`.
 
 ## Domain awareness (shared, runs before any mode)
 

--- a/skills/guardian/SKILL.md
+++ b/skills/guardian/SKILL.md
@@ -25,9 +25,11 @@ Switch Guardian's operating mode:
 5. Report what changed
 
 **Modes:**
-- **autonomous** — Broad permissions, guardian blocks only dangerous ops. Best for unattended work.
-- **supervised** — Read-only tools + safe git. Good for review/exploration sessions.
+- **autonomous** (alias: **AFK**) — Broad permissions, guardian blocks only dangerous ops. Best for unattended work — work that can run end-to-end without human input.
+- **supervised** (alias: **HITL**) — Read-only tools + safe git. Human-in-the-loop work where the user wants to approve each meaningful action.
 - **lockdown** — Minimal read-only access. For auditing or untrusted environments.
+
+**AFK vs HITL is the same axis as autonomous vs supervised.** The aliases exist because `/sweep-issues` (labelling) and `/execute` (running labelled work) use AFK/HITL — those labels map directly onto these modes when an agent picks up the work.
 
 ### `log [N]`
 

--- a/skills/guardian/SKILL.md
+++ b/skills/guardian/SKILL.md
@@ -16,13 +16,16 @@ Parse `$ARGUMENTS` to determine the subcommand:
 
 ### `mode <autonomous|supervised|lockdown>`
 
+Accepted aliases (case-insensitive): `AFK` → `autonomous`, `HITL` → `supervised`. Both `/guardian mode AFK` and `/guardian mode autonomous` resolve to the same canonical value.
+
 Switch Guardian's operating mode:
 
-1. Read the project's `.claude/config/guardian-rules.json` (or fall back to the repo's `config/guardian-rules.json`)
-2. Update the `"mode"` field to the requested value
-3. Read the `permissions` object for the new mode
-4. Update the project's `.claude/settings.json` — merge the mode's `allow` list into `permissions.allow`
-5. Report what changed
+1. **Normalize the mode argument.** Lowercase the input. If it equals `afk`, rewrite to `autonomous`. If it equals `hitl`, rewrite to `supervised`. Otherwise validate against `{autonomous, supervised, lockdown}` and abort if it doesn't match.
+2. Read the project's `.claude/config/guardian-rules.json` (or fall back to the repo's `config/guardian-rules.json`)
+3. Update the `"mode"` field to the **normalized canonical** value (never the alias — the on-disk config stores the canonical form so other tooling reads one value, not three).
+4. Read the `permissions` object for the new mode
+5. Update the project's `.claude/settings.json` — merge the mode's `allow` list into `permissions.allow`
+6. Report what changed (include the alias the user typed if it was normalized: *"Switched to `autonomous` (alias `AFK`)."*)
 
 **Modes:**
 - **autonomous** (alias: **AFK**) — Broad permissions, guardian blocks only dangerous ops. Best for unattended work — work that can run end-to-end without human input.

--- a/skills/guardian/SKILL.md
+++ b/skills/guardian/SKILL.md
@@ -31,6 +31,20 @@ Switch Guardian's operating mode:
 
 **AFK vs HITL is the same axis as autonomous vs supervised.** The aliases exist because `/sweep-issues` (labelling) and `/execute` (running labelled work) use AFK/HITL — those labels map directly onto these modes when an agent picks up the work.
 
+## How AFK / HITL composes across skills
+
+AFK and HITL appear in three skills at three different layers. They compose; they don't contradict.
+
+| Layer | Skill | Question it answers |
+|---|---|---|
+| **Classification** | `/sweep-issues` | "Does this piece of work need a human in the loop?" Tags issue with `afk` or `hitl` label. |
+| **Execution** | `/execute` | "Given a labelled task, how do I run it?" AFK = end-to-end without pausing; HITL = pause at decision points and ask. |
+| **Permissions** | `/guardian` | "Which tools are even allowed in the current session?" AFK mode broadens permissions; HITL mode narrows them. |
+
+A typical flow: `/sweep-issues` files an `afk`-labelled issue → `/execute issue <n>` reads the label and runs end-to-end → `/guardian mode autonomous` is the matching permission posture for that run.
+
+**Authoritative definitions live here.** `/sweep-issues` and `/execute` reference this section rather than redefining the terms — when in doubt about how AFK/HITL behaves at a layer not visible from your current skill, read this table.
+
 ### `log [N]`
 
 View the Guardian audit log:

--- a/skills/improve-architecture/LANGUAGE.md
+++ b/skills/improve-architecture/LANGUAGE.md
@@ -1,0 +1,55 @@
+# Architectural Language
+
+Shared vocabulary for every suggestion `/improve-architecture` makes. Use these terms exactly — don't substitute "component", "service", "API", "layer", or "boundary." Consistent language is the whole point: the user reads many audits over the lifetime of the codebase, and drift makes them harder to compare.
+
+## Terms
+
+**Module**
+Anything with an interface and an implementation. Deliberately scale-agnostic — applies equally to a function, class, package, or tier-spanning slice.
+_Avoid_: unit, component, service.
+
+**Interface**
+Everything a caller must know to use the module correctly. Includes the type signature, but also invariants, ordering constraints, error modes, required configuration, and performance characteristics.
+_Avoid_: API, signature (too narrow — those refer only to the type-level surface).
+
+**Implementation**
+What's inside a module — its body of code. Distinct from **Adapter**: a thing can be a small adapter with a large implementation (a Postgres repo) or a large adapter with a small implementation (an in-memory fake). Reach for "adapter" when the seam is the topic; "implementation" otherwise.
+
+**Depth**
+Leverage at the interface — the amount of behaviour a caller (or test) can exercise per unit of interface they have to learn. A module is **deep** when a large amount of behaviour sits behind a small interface. A module is **shallow** when the interface is nearly as complex as the implementation.
+
+**Seam** _(from Michael Feathers)_
+A place where you can alter behaviour without editing in that place. The *location* at which a module's interface lives. Choosing where to put the seam is its own design decision, distinct from what goes behind it.
+_Avoid_: boundary (overloaded with DDD's bounded context).
+
+**Adapter**
+A concrete thing that satisfies an interface at a seam. Describes *role* (what slot it fills), not substance (what's inside).
+
+**Leverage**
+What callers get from depth. More capability per unit of interface they have to learn. One implementation pays back across N call sites and M tests.
+
+**Locality**
+What maintainers get from depth. Change, bugs, knowledge, and verification concentrate at one place rather than spreading across callers. Fix once, fixed everywhere.
+
+## Principles
+
+- **Depth is a property of the interface, not the implementation.** A deep module can be internally composed of small, mockable, swappable parts — they just aren't part of the interface. A module can have **internal seams** (private to its implementation, used by its own tests) as well as the **external seam** at its interface.
+- **The deletion test.** Imagine deleting the module. If complexity vanishes, the module wasn't hiding anything (it was a pass-through). If complexity reappears across N callers, the module was earning its keep.
+- **The interface is the test surface.** Callers and tests cross the same seam. If you want to test *past* the interface, the module is probably the wrong shape.
+- **One adapter means a hypothetical seam. Two adapters means a real one.** Don't introduce a seam unless something actually varies across it.
+
+## Relationships
+
+- A **Module** has exactly one **Interface** (the surface it presents to callers and tests).
+- **Depth** is a property of a **Module**, measured against its **Interface**.
+- A **Seam** is where a **Module**'s **Interface** lives.
+- An **Adapter** sits at a **Seam** and satisfies the **Interface**.
+- **Depth** produces **Leverage** for callers and **Locality** for maintainers.
+
+## Rejected framings
+
+- **Depth as ratio of implementation-lines to interface-lines** (Ousterhout's original framing): rewards padding the implementation with dead code. We use depth-as-leverage instead.
+- **"Interface" as the TypeScript `interface` keyword or a class's public methods**: too narrow — interface here includes every fact a caller must know.
+- **"Boundary"** as a synonym for seam: overloaded with DDD's bounded context. Say **seam** or **interface**.
+- **"Layer"** for module: too horizontal — modules can span layers (a vertical slice).
+- **"Abstraction"** for interface: too vague. Specify *what kind* of abstraction — interface, seam, adapter.

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: improve-architecture
+version: 1.0.0
+description: |
+  improve architecture, codebase health check, find refactor opportunities, identify shallow modules,
+  deepen this code, ball of mud rescue, ai navigability audit, codebase entropy review,
+  proactive refactor pass, find seams, surface architectural friction.
+  Periodic codebase-wide review that finds shallow modules and proposes deepening opportunities —
+  refactors that turn shallow modules into deep ones for testability and AI-navigability.
+  Informed by CONTEXT.md (domain) and docs/adr/ (locked-in decisions).
+user-invocable: true
+argument-hint: "[path-or-module] [--candidates-only]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - Agent
+  - AskUserQuestion
+  - Edit
+  - Write
+---
+
+# /improve-architecture
+
+Surface architectural friction and propose **deepening opportunities** — refactors that turn shallow modules into deep ones. The goal is testability and AI-navigability: a codebase a fresh agent can navigate quickly, with bugs concentrated in one place, not scattered.
+
+Run periodically — every few weeks, or when the codebase starts to feel like a ball of mud. Pairs with `/simplify` (per-change cleanup) and `/review` (pre-merge) — `/improve-architecture` is the **codebase-wide health check** the others don't do.
+
+## Vocabulary
+
+This skill uses a fixed architectural vocabulary. Read [LANGUAGE.md](./LANGUAGE.md) **before generating any suggestions** and use these terms exactly. Drift to "component", "service", "API", "boundary", "layer", or "abstraction" defeats the point of having shared language. Quick reference:
+
+- **Module** — anything with an interface and an implementation (function, class, package, slice).
+- **Interface** — everything a caller must know: types, invariants, ordering, error modes, config. Not just the type signature.
+- **Implementation** — the code inside.
+- **Depth** — leverage at the interface. **Deep** = lots of behaviour behind a small interface. **Shallow** = interface nearly as complex as the implementation.
+- **Seam** — where an interface lives; a place behaviour can be altered without editing in place.
+- **Adapter** — a concrete thing satisfying an interface at a seam.
+- **Leverage** — what callers get from depth.
+- **Locality** — what maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+Key principles (full list in LANGUAGE.md):
+
+- **Deletion test:** imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.
+- **The interface is the test surface.**
+- **One adapter = hypothetical seam. Two adapters = real seam.**
+
+## Arguments
+
+- `/improve-architecture` — full codebase pass.
+- `/improve-architecture <path>` — restrict the audit to a path or module (e.g. `/improve-architecture src/billing/`).
+- `--candidates-only` — present the numbered list of deepening opportunities and stop. Don't drop into the grilling loop.
+
+## Process
+
+### Step 1: Read the project's domain artifacts
+
+Before exploring code, load context:
+
+- **`CONTEXT.md`** at the repo root (or `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files). The domain glossary names good seams — refactors that align with domain boundaries are worth more than ones that cut across them. If no `CONTEXT.md` exists, that itself is informative — note it; you may surface it as a candidate ("the codebase lacks a domain glossary, propose creating one").
+- **`docs/adr/`** (or `<context>/docs/adr/`) — read every ADR touching the area you'll audit. Don't propose refactors that contradict an accepted ADR unless the friction is real enough to warrant revisiting it (in which case mark the suggestion `contradicts ADR-NNNN — but worth reopening because…`).
+- **`.out-of-scope/`** — if it exists, read prior rejections (written by `/sweep-issues` when an enhancement is closed `wontfix`). Don't re-surface candidates already rejected for durable reasons. If a prior rejection seems wrong now because conditions changed, surface that reasoning rather than silently re-suggesting.
+
+### Step 2: Explore
+
+Dispatch an `Explore` agent to walk the codebase (or the path argument if scoped):
+
+```text
+prompt: "Walk the codebase at <path or repo root>. Read CLAUDE.md and CONTEXT.md if they exist.
+
+Don't follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small modules?
+- Where are modules **shallow** — interface nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called (no **locality**)?
+- Where do tightly-coupled modules leak across their seams?
+- Which parts of the codebase are untested, or hard to test through their current interface?
+- Are there pass-through modules that just forward calls (failing the deletion test)?
+
+For each spot of friction, capture: file/module path, what's friction-y, an initial hypothesis about whether deepening would help. Don't propose solutions yet — just report observations.
+
+Return a structured list of friction observations grouped by area."
+description: "Architectural friction scan"
+```
+
+Use Grep / Glob yourself to verify a few of the agent's claims before passing them through.
+
+### Step 3: Apply the deletion test
+
+For every candidate the explore agent flagged as a shallow module, apply the **deletion test**:
+
+> Imagine deleting this module. Does complexity vanish? Or does it reappear across N callers?
+
+- **Vanishes** → the module was a pass-through, doesn't pay its way. Strong deepen-or-inline candidate.
+- **Reappears across many callers** → the module is earning its keep, even if its current interface is awkward. Probably keep, possibly redesign the interface.
+- **Reappears in one caller** → consider inlining; one-caller modules rarely earn their interface tax.
+
+This is the most important filter — most "shallow" complaints are just preferences. The deletion test is a real argument.
+
+### Step 4: Present candidates
+
+Present a numbered list of deepening opportunities. For each:
+
+- **Files** — which files / modules are involved.
+- **Problem** — why the current architecture causes friction (in vocabulary terms — depth, leverage, locality, seam).
+- **Solution** — plain-English description of the proposed deepening. Don't propose a concrete interface yet.
+- **Benefits** — explained in terms of locality and leverage, plus how tests would improve. Reference the deletion test outcome.
+- **Risk / cost** — what would the refactor touch, and roughly how big.
+- **ADR conflicts** — flag any contradiction with existing ADRs.
+
+Use `CONTEXT.md` vocabulary for **domain** ("the Order intake module", not "the FooBarHandler"), and LANGUAGE.md vocabulary for **architecture** ("shallow seam", not "thin abstraction layer").
+
+If `--candidates-only` is set, stop here.
+
+Otherwise ask the user via AskUserQuestion: *"Which of these would you like to explore? A) #N B) #M C) None — close the audit"*.
+
+### Step 5: Grilling loop (per chosen candidate)
+
+Once the user picks a candidate, drop into a `/plan --grill`-style conversation. Walk the design tree with them — constraints, dependencies, the shape of the deepened module, what sits behind the seam, what tests survive.
+
+**Side effects happen inline as decisions crystallize:**
+
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
+- **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
+- **User rejects the candidate with a load-bearing reason?** Offer an ADR (at `docs/adr/NNNN-kebab-title.md`) **only if all three ADR criteria apply** — hard to reverse, surprising without context, real trade-off. Frame as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"* If the rejection doesn't meet all three (e.g. ephemeral "not worth it right now", or self-evident reasoning), skip the ADR and instead let `/sweep-issues` write a `.out-of-scope/<slug>.md` rejection record — the lighter-weight knowledge base.
+
+### `CONTEXT.md` format (when adding terms inline)
+
+```md
+**{Term}**:
+{One-sentence definition.}
+_Avoid_: {alias 1}, {alias 2}
+```
+
+Be opinionated, one canonical word per concept. Group under `## Language`, with `## Relationships`, `## Example dialogue`, and `## Flagged ambiguities` sections. Domain-only — no general programming concepts.
+
+### ADR format (at `docs/adr/NNNN-kebab-title.md`)
+
+```md
+# ADR-{NNNN}: {Verb-led title}
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+
+## Context
+{What forced the decision.}
+
+## Decision
+{What we decided.}
+
+## Consequences
+**Positive:** {what gets easier}
+**Negative:** {what gets harder}
+
+## Alternatives considered
+- **{Alternative}** — rejected because {reason}
+```
+
+Filename zero-padded sequential, verb-led title. Immutable once accepted — supersede with a new ADR rather than editing.
+- **User accepts the candidate and wants to implement?** Stop here — do **not** start coding inside `/improve-architecture`. Hand off: *"Run `/plan review` on this candidate, then `/execute`. I'll keep audit notes in CONTEXT.md / docs/adr/."* The skill is a surfacing-and-deciding tool, not an implementation tool.
+
+### Step 6: Write audit notes
+
+After the grilling loop, write a short audit summary to `.context/architecture-audits/YYYY-MM-DD.md`:
+
+```markdown
+# Architecture audit — YYYY-MM-DD
+
+Scope: <full codebase | path argument>
+
+## Candidates surfaced
+1. **<name>** — <one-line problem> — <decision: deepen / defer / rejected via ADR-NNNN>
+2. ...
+
+## Decisions
+- <bullet per resolved candidate>
+
+## CONTEXT.md updates
+- Added term: <term> — <reason>
+- Sharpened term: <term> — <reason>
+
+## ADRs written
+- ADR-NNNN: <title>
+
+## Next steps
+- /plan review <candidate slug>
+- /execute spec <slug>
+```
+
+This gives the next audit (in a few weeks) a starting point and prevents re-litigating the same candidates.
+
+## Gotchas
+
+- **Don't propose interfaces in Step 4.** Wait for the user to pick a candidate. Proposing concrete interfaces upfront is wasted work — most candidates won't be picked.
+- **Use the deletion test, not feel.** "This feels too shallow" is not a finding. "Deleting this module would push complexity into 5 callers, none of which would benefit from owning that complexity" is.
+- **Don't re-litigate ADRs unprompted.** If a candidate contradicts an ADR and the friction isn't severe, drop it silently. Only surface ADR-contradicting candidates when the friction is real and worth a discussion.
+- **Stay codebase-wide unless scoped.** This is the proactive health check — `/simplify` already covers per-change cleanup. If the user wants a focused review, they'll pass a path argument.
+- **The skill is read-and-decide, not write-and-implement.** When a candidate is approved, hand off to `/plan review` → `/execute`. Don't refactor inside this skill.
+- **AFK / HITL marking on follow-up issues.** When approved candidates spawn issues (via `/sweep-issues`), tag them AFK (clearly-spec'd refactor) or HITL (needs design decision) per the standard convention.

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -123,7 +123,11 @@ Once the user picks a candidate, drop into a `/plan --grill`-style conversation.
 
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
-- **User rejects the candidate with a load-bearing reason?** Offer an ADR (at `docs/adr/NNNN-kebab-title.md`) **only if all three ADR criteria apply** — hard to reverse, surprising without context, real trade-off. Frame as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"* If the rejection doesn't meet all three (e.g. ephemeral "not worth it right now", or self-evident reasoning), skip the ADR and instead let `/sweep-issues` write a `.out-of-scope/<slug>.md` rejection record — the lighter-weight knowledge base.
+- **User rejects the candidate?** Persist the rejection **immediately, here, at rejection time** — don't defer to `/sweep-issues` (it may never run, and the next audit will re-suggest the same candidate). Two paths:
+  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the format below. Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
+  2. **Durable reason that doesn't meet all three** (e.g. "we'd revisit if we add multi-tenancy"): write `.out-of-scope/<kebab-slug>.md` now (format documented in `/sweep-issues` SKILL.md — `slug`, `rejected`, `related-issues` frontmatter, plus "Why we rejected it" and "What would change our minds" body sections). The next audit reads this and skips the candidate.
+
+  Only skip persistence entirely if the user explicitly marks the rejection **ephemeral** (e.g. "not worth it right now", "ask me again next quarter") — those don't need durable records because the reasoning won't apply later.
 
 ### `CONTEXT.md` format (when adding terms inline)
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -31,7 +31,16 @@ Three sibling artifacts, three different purposes — pick the right one before 
 | **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
 | **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
 
-If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR at `docs/adr/NNNN-kebab-title.md`. ADRs commit to the repo and survive across teams in a way learnings don't. Learnings are for everything else: smaller-scale durable facts that don't merit either.
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
+
+If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR. Path depends on scope:
+
+- **System-wide decision** → `docs/adr/NNNN-kebab-title.md` at the repo root.
+- **Context-specific decision** (multi-context repos only) → `<context>/docs/adr/NNNN-kebab-title.md`, alongside that context's code.
+
+Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. ADRs commit to the repo and survive across teams in a way learnings don't.
+
+Learnings are for everything else: smaller-scale durable facts that don't merit either.
 
 ## Storage
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -21,6 +21,18 @@ allowed-tools:
 
 Durable memory for *this project*. Unlike `memory/` (which is about the user), `.context/learnings/` is about the *codebase* — patterns that worked, pitfalls encountered, preferences confirmed. Claude reads these at session start (via `/session-start`) and appends to them whenever something non-obvious surfaces.
 
+## Learnings vs ADRs vs CONTEXT.md
+
+Three sibling artifacts, three different purposes — pick the right one before saving:
+
+| Artifact | Scope | When |
+|---|---|---|
+| **Learning** (`.context/learnings/<slug>.md`) | Project-specific patterns, pitfalls, preferences | Non-obvious fact you want next session to remember |
+| **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
+| **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
+
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR at `docs/adr/NNNN-kebab-title.md`. ADRs commit to the repo and survive across teams in a way learnings don't. Learnings are for everything else: smaller-scale durable facts that don't merit either.
+
 ## Storage
 
 Per-project: `.context/learnings/` (in the current repo, gitignored or committed — user choice).

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -8,7 +8,7 @@ description: |
   Four modes: INTERVIEW (surface edge cases, write spec), BRAINSTORM (explore design),
   REVIEW (lock in architecture, data flow, edge cases, tests),
   VISUALIZE (diagram-based design validation, bug shakeout).
-argument-hint: "[mode] [spec-path] [--lifecycle]"
+argument-hint: "[mode] [spec-path] [--lifecycle] [--grill]"
 allowed-tools:
   - Read
   - Write
@@ -25,12 +25,76 @@ allowed-tools:
 
 Consolidated planning skill. Start here before writing code.
 
+## Domain awareness (shared)
+
+Before any mode runs, scan for the project's domain artifacts:
+
+- **`CONTEXT.md`** at the repo root (or `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files) — the domain glossary. If present, read it and **use its vocabulary verbatim** in spec text, interview questions, diagrams, and review findings. Don't drift to synonyms; don't rewrite "Order intake module" as "the order service." When the conversation resolves a new term or sharpens a fuzzy one, offer to update `CONTEXT.md` inline.
+- **`docs/adr/`** (or `<context>/docs/adr/` in multi-context repos) — read any ADRs in the area being touched and respect them. Don't re-litigate decisions an ADR already locked in.
+- **No artifacts yet?** Don't scaffold them empty. Create `CONTEXT.md` lazily when the first term is resolved; create an ADR only when a decision meets **all three** criteria (hard to reverse, surprising without context, result of a real trade-off). Use the formats below.
+
+When `--grill` mode is active (see below), this discipline tightens: grill mode **must** challenge user terms against `CONTEXT.md` and propose ADRs for load-bearing irreversible decisions surfaced during the interview.
+
+### `CONTEXT.md` format (write inline as terms resolve)
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**{Term}**:
+{One-sentence definition. What it IS, not what it does.}
+_Avoid_: {alias 1}, {alias 2}
+
+## Relationships
+
+- A **{Term A}** {verb} one or more **{Term B}**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**…"
+> **Domain expert:** "An **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "{ambiguous term}" was used to mean both **{Term A}** and **{Term B}** — resolved: distinct concepts.
+```
+
+Be opinionated (one canonical word per concept; aliases under `_Avoid_`). Domain-only — general programming concepts don't belong. One-sentence definitions. Multi-context repos use `CONTEXT-MAP.md` at root pointing to per-module `CONTEXT.md` files.
+
+### ADR format (write at `docs/adr/NNNN-kebab-title.md`)
+
+```md
+# ADR-{NNNN}: {Verb-led title}
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+
+## Context
+{What forced the decision. 2-5 sentences.}
+
+## Decision
+{What we decided.}
+
+## Consequences
+**Positive:** {what gets easier}
+**Negative:** {what gets harder}
+
+## Alternatives considered
+- **{Alternative}** — rejected because {specific reason}
+```
+
+Filename `NNNN-kebab-title.md` (zero-padded sequential). Verb-led titles. **Immutable once accepted** — when a decision changes, write a new ADR with `Status: Superseded by ADR-NNNN` rather than editing in place.
+
 ## Arguments
 
 - `/plan` — ask for mode via AskUserQuestion
 - `/plan [mode]` — where mode is `interview`, `brainstorm`, `review`, or `visualize`
 - `/plan [mode] [spec-path]` — e.g. `/plan review auth-flow`
 - `--lifecycle` — force state × event matrix emission even when auto-detection signals don't fire
+- `--grill` — switch interview/brainstorm/review questioning into **grill mode**: one question at a time, always lead with the recommended answer, walk the decision tree branch-by-branch, update `CONTEXT.md` inline as terms resolve, propose ADRs only for hard-to-reverse decisions. See "Grill mode (modifier)" below.
 
 ## Lifecycle Detection (shared — runs before mode dispatch)
 
@@ -79,6 +143,27 @@ event_3          clear     clear     reject    clear
 Every cell is a review target — missing or fuzzy cells are the bugs. Derive states from the system's actual state enum (or the enum you are designing) and events from command entry points.
 
 ---
+
+## Grill mode (modifier)
+
+`--grill` is a **modifier**, not a separate mode. It applies on top of INTERVIEW, BRAINSTORM, or REVIEW. Detect it once, near the top:
+
+```bash
+echo "$ARGUMENTS" | grep -q -- '--grill' && GRILL=1
+```
+
+**When `GRILL=1`, the questioning style changes:**
+
+1. **One question at a time.** No multi-dimension batching. No "let me ask 5 things in this round." Walk the decision tree branch-by-branch — resolve dependencies between decisions one-by-one. Wait for the user's answer before continuing.
+2. **Always lead with your recommended answer.** Format every question as: *"My recommendation: X. Reason: Y. But before I commit, [the actual question]."* Never ask open-ended questions without a recommendation — the user pushes back on yours instead of generating from scratch.
+3. **Prefer codebase exploration over asking.** If a question can be answered by reading the code, read the code instead of asking. Only ask the user when the answer genuinely requires their judgment (product intent, tradeoff weighting, future plans).
+4. **Read `.out-of-scope/` early.** If the repo has `.out-of-scope/<slug>.md` rejection records, scan them before you start asking — don't re-litigate decisions that were already rejected for durable reasons. If a candidate seems to fall under an existing rejection, surface that to the user up front rather than walking the whole tree to the same dead end.
+5. **Challenge against `CONTEXT.md` inline.** When the user uses a term that conflicts with the glossary, call it out immediately: *"`CONTEXT.md` defines 'cancellation' as X, but you seem to mean Y — which is it?"* When a fuzzy term gets sharpened, **update `CONTEXT.md` right there** — don't batch glossary updates to the end.
+6. **Cross-reference with code.** When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: *"Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"*
+7. **Propose ADRs sparingly.** Only offer to write an ADR when **all three** are true: hard to reverse, surprising without context, result of a real trade-off. If any is missing, skip — for non-ADR-worthy rejections, suggest `/sweep-issues` write a `.out-of-scope/<slug>.md` record instead. Decisions that are easy to revisit don't need an ADR — they create noise.
+8. **Stop only when the user says stop or the tree is fully resolved.** Grill mode is "relentless" by design — it's how you flush out misalignment before code is written. Don't wrap up just because you've run several rounds; wrap up when the decision tree has no unresolved branches.
+
+When `GRILL=0` (default), the existing INTERVIEW / BRAINSTORM / REVIEW question styles apply as written below.
 
 ## Mode Selection
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -24,6 +24,12 @@ allowed-tools:
 
 You are running the `/review` workflow. Analyze the current branch's diff against main for structural issues that tests don't catch.
 
+## Domain awareness
+
+If the repo has a `CONTEXT.md` (or a `CONTEXT-MAP.md` pointing to per-module `CONTEXT.md` files), read it before dispatching review agents. **Use its vocabulary verbatim** in findings — refer to the "Order intake module" if the glossary names it that, not "the order service." Inconsistent vocabulary in review feedback creates churn during execute/ship.
+
+If `docs/adr/` exists and the diff touches an area covered by an ADR, include "respect ADR-NNNN" in the relevant agent prompts so findings don't propose changes the ADR already rejected.
+
 ## Arguments
 
 - `/review` — full review of current branch vs main (default)

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -118,12 +118,30 @@ After creating all files:
 
 **Only register if the skill was created in the global skills directory** (the `skills/` folder next to `config/profiles.json`). Project-local skills should not be registered in the global profiles.
 
-## Step 6: Confirm
+## Step 6: Review Checklist
+
+Before finalizing, verify the skill against this checklist. Each item is non-negotiable — if any fails, fix before reporting completion.
+
+- [ ] **Description has triggers.** Frontmatter `description` includes 5-8 trigger phrases (verbs + objects users actually say). Not a paragraph summary.
+- [ ] **Description names the modes.** If the skill has multiple modes (e.g. RAW / SPEC / ISSUE), the description names them so the model knows when to invoke which.
+- [ ] **SKILL.md is reasonably tight.** Body excluding frontmatter is under 300 lines for simple skills, under 600 for multi-mode. If longer, content moves to `references/` or `templates/`.
+- [ ] **No time-sensitive info.** No "as of November 2025", no "the new version of X" — that rots. State invariants, not snapshots.
+- [ ] **Consistent terminology.** One word per concept. If the skill switches between "task", "step", and "operation" for the same thing, pick one and use it everywhere.
+- [ ] **Concrete examples, not just rules.** Each non-trivial instruction has at least one example showing the right shape.
+- [ ] **References one level deep.** SKILL.md links to `references/foo.md`; `foo.md` does not link to `references/foo/bar.md`. Flat, not nested.
+- [ ] **Gotchas section exists.** Even if currently empty, with a note to populate as failure modes surface.
+- [ ] **`allowed-tools` is minimal.** Only tools the skill actually uses. Adding `Bash` "just in case" defeats sandboxing.
+- [ ] **No redundant instructions.** Don't tell Claude how to read files, use git, or run tests — it already knows. Only include domain-specific or non-default behavior.
+
+If the skill bundles `references/`, also verify each reference file is used (linked from SKILL.md with a "read X before doing Y" instruction). Unused reference files are dead weight and should be deleted or inlined.
+
+## Step 7: Confirm
 
 Report to the user:
 - Files created (with paths)
 - Category used
 - Whether it was registered in profiles.json
+- Review checklist outcome (any items skipped and why)
 - Suggest next steps: "Try invoking `/<skill-name>` to test it. Add gotchas as you discover failure modes."
 
 ## Gotchas

--- a/skills/skill-builder/SKILL.md
+++ b/skills/skill-builder/SKILL.md
@@ -124,6 +124,7 @@ Before finalizing, verify the skill against this checklist. Each item is non-neg
 
 - [ ] **Description has triggers.** Frontmatter `description` includes 5-8 trigger phrases (verbs + objects users actually say). Not a paragraph summary.
 - [ ] **Description names the modes.** If the skill has multiple modes (e.g. RAW / SPEC / ISSUE), the description names them so the model knows when to invoke which.
+- [ ] **Has `## Arguments`.** If the skill declares `argument-hint:` in frontmatter, SKILL.md contains a `## Arguments` section enumerating each argument, whether it's optional, valid values or formats, and how it maps to the skill's main process. Skills with no parameters can omit this section.
 - [ ] **SKILL.md is reasonably tight.** Body excluding frontmatter is under 300 lines for simple skills, under 600 for multi-mode. If longer, content moves to `references/` or `templates/`.
 - [ ] **No time-sensitive info.** No "as of November 2025", no "the new version of X" — that rots. State invariants, not snapshots.
 - [ ] **Consistent terminology.** One word per concept. If the skill switches between "task", "step", and "operation" for the same thing, pick one and use it everywhere.

--- a/skills/skill-builder/templates/skill-template.md
+++ b/skills/skill-builder/templates/skill-template.md
@@ -27,6 +27,14 @@ Store answers in `config.json`. On subsequent runs, load config silently.
 
 {{IF_NO_CONFIG: Remove this section entirely.}}
 
+## Arguments
+
+{{IF_SKILL_TAKES_ARGUMENTS:}}
+- `/{{SKILL_NAME}}` — {{describe behavior with no argument; if not supported, say "abort and ask the user to supply X"}}
+- `/{{SKILL_NAME}} <{{ARG_NAME}}>` — {{describe what the argument means, valid forms, how it maps to the workflow step that consumes it}}
+
+{{IF_SKILL_TAKES_NO_ARGUMENTS: Remove this section entirely AND drop `argument-hint` from frontmatter.}}
+
 ## Workflow
 
 {{STEP_1_HEADING}}

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -51,9 +51,10 @@ Review the conversation history and identify candidate items. For each, note:
 - **Why**: context from the conversation
 - **Source**: what triggered it (review finding, user comment, edge case discovered, etc.)
 - **Category**: `enhancement` | `bug` | `tech-debt` | `infrastructure`
-- **Mode**: `AFK` | `HITL`
-  - **AFK** — clearly-specified implementation, no design decisions or external access required. An agent could pick this up and run end-to-end through `/execute` autonomously.
-  - **HITL** — needs human-in-the-loop: a design decision the user must own, manual verification, external access, or domain knowledge an agent can't get from the code. Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
+- **Mode**: `AFK` | `HITL` — see `/guardian`'s "How AFK/HITL composes across skills" section for authoritative definitions and how this label cascades into `/execute` runtime behavior and `/guardian` permission modes. For classification at this layer:
+  - **AFK** — clearly-specified implementation, no design decisions or external access required.
+  - **HITL** — needs a design decision, manual verification, external access, or domain knowledge an agent can't get from the code.
+  - Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
 
 ### Step 2: Deduplicate Against Existing Issues and Prior Rejections
 

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -51,15 +51,27 @@ Review the conversation history and identify candidate items. For each, note:
 - **Why**: context from the conversation
 - **Source**: what triggered it (review finding, user comment, edge case discovered, etc.)
 - **Category**: `enhancement` | `bug` | `tech-debt` | `infrastructure`
+- **Mode**: `AFK` | `HITL`
+  - **AFK** — clearly-specified implementation, no design decisions or external access required. An agent could pick this up and run end-to-end through `/execute` autonomously.
+  - **HITL** — needs human-in-the-loop: a design decision the user must own, manual verification, external access, or domain knowledge an agent can't get from the code. Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
 
-### Step 2: Deduplicate Against Existing Issues
+### Step 2: Deduplicate Against Existing Issues and Prior Rejections
 
-For each candidate, search existing issues:
+For each candidate:
+
+**2a. Search existing GitHub issues:**
 ```bash
 gh issue list --search "<keywords>" --limit 5
 ```
-
 Skip anything that's already tracked. If an existing issue is related but doesn't cover the new scope, note it as a cross-reference.
+
+**2b. Check `.out-of-scope/` for prior rejections.** If `.out-of-scope/` exists at the repo root, grep it for keyword matches against the candidate:
+```bash
+[ -d .out-of-scope ] && grep -rli "<keyword>" .out-of-scope/ 2>/dev/null
+```
+If a prior rejection covers the same idea, **skip the candidate silently** and note it in the report as `Skipped (out-of-scope: <slug>.md)`. Don't re-litigate decisions that were already made — that's the whole point of the knowledge base.
+
+If a prior rejection is *related but not the same scope*, surface it to the user: *"This is similar to a previous rejection (`.out-of-scope/<slug>.md`) but the new scope differs because X — proceed?"* The user decides whether the new scope warrants a new issue or whether to update the rejection record.
 
 ### Step 3: Present Candidates
 
@@ -101,6 +113,19 @@ EOF
 - `tech-debt` → `tech-debt`
 - `infrastructure` → `infrastructure`
 
+**Mode label** (additional, applied alongside category):
+- `AFK` → `afk` label
+- `HITL` → `hitl` label
+
+If the labels don't already exist on the repo, create them once. **Gate the create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
+
+```bash
+gh label list --json name -q '.[].name' | grep -qx afk \
+  || gh label create afk --color 0E8A16 --description "Agent can complete unattended"
+gh label list --json name -q '.[].name' | grep -qx hitl \
+  || gh label create hitl --color FBCA04 --description "Needs human in the loop"
+``` The labels let `/execute --multi issue:...` filter for AFK-only work safe to fan out across panes, and let `/babysit-pr` flag HITL items that need user attention.
+
 ### Step 5: Report
 
 Output a summary:
@@ -113,11 +138,37 @@ Created N issues:
 Skipped M items (already tracked or too small).
 ```
 
+## Recording rejections to `.out-of-scope/`
+
+When the user says *"don't create that"*, *"we considered this and rejected it"*, or closes an enhancement as `wontfix`, **write a rejection record** to `.out-of-scope/<kebab-slug>.md`. Future `/sweep-issues` runs (and `/plan --grill`, `/improve-architecture`) read this directory to avoid re-suggesting the same thing.
+
+Format:
+
+```markdown
+---
+slug: <kebab-slug>
+rejected: YYYY-MM-DD
+related-issues: [#NN, #MM]   # optional — issues that triggered the rejection
+---
+
+# <Short title>
+
+**The proposal:** {1-2 sentences describing what was suggested.}
+
+**Why we rejected it:** {The load-bearing reason. This is the most important field — it must be specific enough that a future explorer reading this 6 months later understands why and doesn't re-suggest.}
+
+**What would change our minds:** {A concrete trigger that should reopen this. Examples: "if we ever add multi-tenancy", "if a customer asks for it more than 3 times", "if we hit N% error rate on the alternative". If nothing would change our minds, write "nothing — this is a permanent no" and explain why.}
+```
+
+Skip ephemeral reasons ("not worth it right now") — those become stale fast. Only record rejections with **durable** reasons, the kind that would still apply in 6 months.
+
 ## Important Rules
 
-- **Never create duplicate issues.** Always search first.
+- **Never create duplicate issues.** Always search GitHub *and* `.out-of-scope/` first.
 - **Never include secrets, credentials, API keys, or tokens in issue bodies.** Redact any sensitive data from conversation context before creating issues.
 - **Keep issues small and focused.** One issue per concern. Don't bundle unrelated items.
 - **Include enough context** that someone reading the issue 3 months from now understands what and why.
 - **Don't over-specify requirements.** 3-5 checklist items is ideal. The implementer will spec the details.
 - **Link related issues** when they exist (use `Related: #NNN` in the body).
+- **Tag mode (AFK / HITL).** Every created issue must carry exactly one of the `afk` or `hitl` labels.
+- **Record rejections, don't lose them.** When the user vetoes a candidate or closes an enhancement as `wontfix`, write `.out-of-scope/<slug>.md` so the rejection survives across sessions.

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -89,10 +89,13 @@ If `--dry-run`, stop here.
 
 ### Step 4: Create Issues
 
-For each item, create a GitHub issue:
+For each item, create a GitHub issue with **both labels** — one category label (from the mapping below) and one mode label (`afk` or `hitl`):
 
 ```bash
-gh issue create --title "<title>" --label "<label>" --body "$(cat <<'EOF'
+gh issue create --title "<title>" \
+  --label "<category-label>" \
+  --label "<mode-label>" \
+  --body "$(cat <<'EOF'
 ## Summary
 {1-2 sentence description}
 
@@ -107,6 +110,8 @@ gh issue create --title "<title>" --label "<label>" --body "$(cat <<'EOF'
 EOF
 )"
 ```
+
+`<category-label>` is one of `enhancement` / `bug` / `tech-debt` / `infrastructure`. `<mode-label>` is one of `afk` / `hitl`. Both labels are required — never omit the mode label.
 
 **Label mapping:**
 - `enhancement` → `enhancement`
@@ -149,7 +154,7 @@ Format:
 ---
 slug: <kebab-slug>
 rejected: YYYY-MM-DD
-related-issues: [#NN, #MM]   # optional — issues that triggered the rejection
+related-issues: ["#NN", "#MM"]   # optional — quote each ID; bare # starts a YAML comment
 ---
 
 # <Short title>

--- a/skills/zoom-out/SKILL.md
+++ b/skills/zoom-out/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: zoom-out
+version: 1.0.0
+description: |
+  zoom out, give me a map, broader context, higher-level perspective, what's the big picture,
+  how does this fit, walk me through this area, I don't know this code, unfamiliar code,
+  give me the lay of the land, sketch the architecture here.
+  Single-purpose: agent goes up a layer of abstraction and produces a callers-and-collaborators
+  map for an unfamiliar area of code, using the project's domain vocabulary if CONTEXT.md exists.
+user-invocable: true
+argument-hint: "[path-or-symbol]"
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Agent
+---
+
+# /zoom-out
+
+You are unfamiliar with this area of code. Go **up** one layer of abstraction and produce a map.
+
+## Process
+
+1. **Resolve the target.** If `$ARGUMENTS` is a path, start there. If it's a symbol, grep for the definition. If empty, infer from the recent conversation (last file read, last function discussed) and confirm with the user before proceeding.
+
+2. **Read CONTEXT.md if it exists.** Check the repo root and any closer `CONTEXT.md` (multi-context repos use a `CONTEXT-MAP.md` at root pointing to per-module files). If found, **use its vocabulary exactly** — don't drift to synonyms. If absent, just describe the code in its own terms.
+
+3. **Build the map.** Use Grep / Glob to enumerate:
+   - **Callers** — who imports / invokes this module?
+   - **Collaborators** — what does it import / depend on?
+   - **Siblings** — peer modules in the same directory or layer.
+   - **Entry points** — what user-facing surface (route, CLI command, hook event, job) ultimately reaches it?
+
+   For larger areas, dispatch an `Explore` agent rather than walking the tree yourself.
+
+4. **Output.** A short hierarchical map plus 3-5 sentences of orientation. Format:
+
+   ```
+   <Target> sits inside <broader concept from CONTEXT.md or filesystem>.
+
+   Reached from:
+     - <entry point> → <intermediate> → <target>
+     - <entry point> → <target>
+
+   Calls into:
+     - <collaborator> — <what for>
+     - <collaborator> — <what for>
+
+   Peers (sibling modules):
+     - <peer> — <one-line role>
+     - <peer> — <one-line role>
+
+   Tests:
+     - <test file> — covers <surface>
+
+   Notes
+     - <one or two non-obvious facts: invariant, recent refactor, ADR reference>
+   ```
+
+5. **Stop.** Don't propose changes, don't fix things, don't grill. The goal is orientation only — the user takes it from there.
+
+## Gotchas
+
+- **Don't dump file contents** — the user already knows how to read. The job is shape and relationships, not source code.
+- **Don't speculate about what code "should" do.** Map what's there. If something is confusing, list it under Notes as a question, not a recommendation.
+- **Use CONTEXT.md vocabulary verbatim.** If the glossary calls it an "Order intake module," don't rewrite as "the order service." Drift defeats the point of having a glossary.
+- **Stay one layer up, not three.** Zooming too far loses signal. If the target is a function, map its module. If the target is a module, map its package. One step.

--- a/skills/zoom-out/SKILL.md
+++ b/skills/zoom-out/SKILL.md
@@ -20,6 +20,16 @@ allowed-tools:
 
 You are unfamiliar with this area of code. Go **up** one layer of abstraction and produce a map.
 
+## Arguments
+
+- `/zoom-out` — no argument; infer the target from the recent conversation (last file read, last function discussed) and confirm with the user before mapping.
+- `/zoom-out <path-or-symbol>` — explicit target. The argument is matched against `argument-hint: "[path-or-symbol]"` in the frontmatter:
+  - **Path** (e.g. `src/billing/charges.ts`) — start there; map its module / package as the broader scope.
+  - **Symbol** (e.g. `applyDiscount`) — grep for the definition first, then proceed.
+  - Empty or ambiguous — fall through to the inference path above.
+
+The argument resolves at **Step 1: Resolve the target** in the Process below. Tools available are read-only (`Read`, `Grep`, `Glob`, `Agent` per the frontmatter) — the skill cannot modify files.
+
 ## Process
 
 1. **Resolve the target.** If `$ARGUMENTS` is a path, start there. If it's a symbol, grep for the definition. If empty, infer from the recent conversation (last file read, last function discussed) and confirm with the user before proceeding.
@@ -36,7 +46,7 @@ You are unfamiliar with this area of code. Go **up** one layer of abstraction an
 
 4. **Output.** A short hierarchical map plus 3-5 sentences of orientation. Format:
 
-   ```
+   ```text
    <Target> sits inside <broader concept from CONTEXT.md or filesystem>.
 
    Reached from:

--- a/templates/CONTEXT.md
+++ b/templates/CONTEXT.md
@@ -1,0 +1,65 @@
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**{Term}**:
+{One-sentence definition. What it IS, not what it does.}
+_Avoid_: {alias 1}, {alias 2}
+
+**{Term}**:
+{One-sentence definition.}
+_Avoid_: {alias 1}, {alias 2}
+
+## Relationships
+
+- A **{Term A}** {verb} one or more **{Term B}**
+- A **{Term B}** belongs to exactly one **{Term C}**
+
+## Example dialogue
+
+> **Dev:** "When a **Customer** places an **Order**, do we create the **Invoice** immediately?"
+> **Domain expert:** "No — an **Invoice** is only generated once a **Fulfillment** is confirmed."
+
+## Flagged ambiguities
+
+- "{ambiguous term}" was used to mean both **{Term A}** and **{Term B}** — resolved: these are distinct concepts.
+
+---
+
+## How to maintain this file
+
+`CONTEXT.md` is the project's domain glossary. Two groups of skills interact with it:
+
+**Read-only (use the vocabulary, don't edit):** `/zoom-out`, `/review`, `/debug` — these read CONTEXT.md to use its vocabulary verbatim in their output, but never modify it.
+
+**Read-and-update (write inline as terms resolve):** `/plan` (especially `/plan --grill`), `/execute`, `/improve-architecture` — these read CONTEXT.md and update it inline when a new term is resolved or a fuzzy term is sharpened during the work.
+
+**Rules**:
+
+- **Be opinionated.** When multiple words exist for the same concept, pick one and list the rest as aliases under `_Avoid_`.
+- **Flag conflicts explicitly.** If a term is used ambiguously, call it out in "Flagged ambiguities" with a clear resolution.
+- **Keep definitions tight.** One sentence max. Define what it IS, not what it does.
+- **Show relationships.** Bold term names; express cardinality where obvious.
+- **Domain only, not infrastructure.** General programming concepts (timeouts, retries, error types, utility patterns) don't belong even if the project uses them. Only terms unique to this project's *domain*.
+- **Group under subheadings** when natural clusters emerge. If everything fits in one cohesive area, a flat list is fine.
+- **Write an example dialogue.** A short conversation between a dev and a domain expert that uses the terms naturally and demonstrates the boundaries between related concepts.
+
+**Lazy creation:** create this file only when the first term is actually resolved. Don't scaffold it empty.
+
+**Multi-context repos** keep a `CONTEXT-MAP.md` at the root that points to each context's `CONTEXT.md`. Format:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+
+## Relationships
+
+- **Ordering → Billing**: Ordering emits `OrderPlaced`; Billing consumes it to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```

--- a/templates/adr/0000-template.md
+++ b/templates/adr/0000-template.md
@@ -1,0 +1,48 @@
+# ADR-{NNNN}: {Short imperative title — verb-led}
+
+**Status:** {Proposed | Accepted | Superseded by ADR-NNNN | Deprecated}
+**Date:** YYYY-MM-DD
+
+## Context
+
+{What's the situation that forces a decision? What constraints, requirements, or pre-existing facts shape the choice? 2-5 sentences.}
+
+## Decision
+
+{What did we decide. State it clearly and unambiguously in 1-3 sentences.}
+
+## Consequences
+
+**Positive:**
+- {What gets easier or possible}
+
+**Negative:**
+- {What gets harder or impossible}
+
+**Neutral:**
+- {Tradeoffs that aren't strictly good or bad — facts the future reader needs}
+
+## Alternatives considered
+
+- **{Alternative 1}** — rejected because {specific reason}
+- **{Alternative 2}** — rejected because {specific reason}
+
+---
+
+## When to write an ADR
+
+Only when **all three** are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful (data migrations, breaking API changes, retraining the team).
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **Result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons.
+
+If any of the three is missing, skip the ADR. Most decisions don't need one — over-stuffed ADR directories become noise. The skills (`/plan`, `/plan --grill`, `/execute`, `/improve-architecture`) offer to write an ADR only when the conversation surfaces a decision that meets all three criteria.
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-title.md` — zero-padded sequential, lowercase. Examples: `0001-event-sourced-orders.md`, `0014-postgres-for-write-model.md`.
+- **Title:** verb-led ("use Postgres for writes", "split sessions by tenant"), not noun-led ("Postgres choice").
+- **Immutable once accepted.** When a decision changes, write a new ADR that supersedes the old one (`Status: Superseded by ADR-NNNN`). Don't rewrite history.
+- **Single-context repos** keep ADRs at `docs/adr/`.
+- **Multi-context repos** keep system-wide ADRs at `docs/adr/` and per-context ADRs at `<context>/docs/adr/`.


### PR DESCRIPTION
## Summary

- New skills: **`/zoom-out`** (orientation micro-skill) and **`/improve-architecture`** (periodic codebase-health review with the deletion test, vocabulary discipline in `LANGUAGE.md`).
- New `/plan --grill` modifier — relentless one-question-at-a-time decision-tree walk; always lead with the recommended answer; challenge user terms against `CONTEXT.md` inline; propose ADRs only for hard-to-reverse + surprising + real-tradeoff decisions.
- Vocabulary infrastructure: `templates/CONTEXT.md` (domain glossary) and `templates/adr/0000-template.md` (ADR template). Distributed skills (`/plan`, `/improve-architecture`, `/learn`) carry the format inline so they're self-contained — no calsuite-path references in target repos.
- Domain-awareness wired into `/plan`, `/execute`, `/review`, `/debug`, `/learn` — every relevant skill now reads `CONTEXT.md` and `docs/adr/` and uses the glossary vocabulary verbatim.
- AFK / HITL labelling adopted across `/guardian`, `/sweep-issues`, `/execute`. AFK = agent runs end-to-end; HITL = needs human-in-the-loop. `/sweep-issues` auto-creates the labels (idempotent gate) and tags every issue.
- `.out-of-scope/<slug>.md` rejection knowledge base in `/sweep-issues` — durable record of why we said no, with a "What would change our minds" trigger. `/plan --grill` and `/improve-architecture` read this directory so prior rejections aren't re-litigated.
- `/debug` Phase 1 reframed: **the feedback loop IS the skill**. 10-tactic ladder (failing test → curl → CLI → headless browser → trace replay → throwaway harness → fuzz → bisect → differential → HITL script). Iterate-the-loop discipline. Don't proceed to Phase 2 without a loop you believe in.
- `/skill-builder` gains a 10-item review checklist (Step 6) before confirmation: triggers in description, body length, no time-sensitive info, references one level deep, etc.
- `README.md` Skills overview bucketed by usage frequency (Daily code work / Daily workflow / Occasional / Calsuite-internal).
- Version bump 2.22 → 2.23.

## How It Works

```mermaid
flowchart TD
  CTX["`CONTEXT.md
  domain glossary`"]
  ADR["`docs/adr/
  locked decisions`"]
  OOS["`.out-of-scope/
  rejection records`"]

  PLAN["/plan --grill"]
  IMPRV["/improve-architecture"]
  EXEC["/execute"]
  REV["/review"]
  DBG["/debug"]
  ZO["/zoom-out"]
  LRN["/learn"]
  SWP["/sweep-issues"]

  PLAN -->|read + write| CTX
  PLAN -->|propose| ADR
  PLAN -->|read| OOS
  IMPRV -->|read + write| CTX
  IMPRV -->|propose| ADR
  IMPRV -->|read| OOS
  EXEC -->|read + write| CTX
  EXEC -->|respect| ADR
  REV -->|read| CTX
  REV -->|respect| ADR
  DBG -->|read| CTX
  DBG -->|respect| ADR
  ZO -->|read| CTX
  LRN -->|triage to| CTX
  LRN -->|triage to| ADR
  SWP -->|write| OOS
```

## Important Files

| File | Change |
|------|--------|
| `skills/improve-architecture/SKILL.md` + `LANGUAGE.md` | New — periodic codebase-health skill with deletion test and fixed architectural vocabulary |
| `skills/zoom-out/SKILL.md` | New — orientation micro-skill, one layer up |
| `skills/plan/SKILL.md` | `--grill` modifier + inline `CONTEXT.md` / ADR format guidance |
| `skills/sweep-issues/SKILL.md` | AFK/HITL labels with idempotent label create + `.out-of-scope/` rejection records |
| `skills/debug/SKILL.md` | Phase 1 reframed as Build a feedback loop with 10-tactic ladder |
| `skills/skill-builder/SKILL.md` | 10-item review checklist (Step 6) |
| `skills/execute/SKILL.md` | AFK/HITL routing + CONTEXT.md/ADR awareness |
| `skills/guardian/SKILL.md` | AFK/HITL aliases for autonomous/supervised |
| `skills/learn/SKILL.md` | Learning vs CONTEXT.md term vs ADR triage table |
| `skills/review/SKILL.md` | Domain awareness — vocabulary verbatim in findings |
| `templates/CONTEXT.md` + `adr/0000-template.md` | Calsuite-internal authoring references |
| `config/profiles.json`, `README.md`, `CLAUDE.md`, `CHANGELOG.md` | Skill registration, bucketed README, version bump |

## Test Results

No tests run — markdown / config / skill changes only; no test runner for skill markdown. Validated via:

| Check | Result |
|-------|--------|
| `python3 -m json.tool config/profiles.json` | ✅ valid |
| YAML frontmatter parse on all modified `SKILL.md` files | ✅ valid |
| Distributed-skill calsuite leakage (`grep CALSUITE_DIR \| <calsuite>`) | ✅ none in distributed skills |
| Stale `/triage` references | ✅ none |
| ADR three-condition gate consistency across `/plan`, `/learn`, `/improve-architecture` | ✅ aligned |
| `zoom-out` + `improve-architecture` registered in `base` and `monorepo-root` | ✅ both |

## Pre-Landing Review

`/review` ran in this session — 11 issues found (6 critical, 5 informational), all 6 critical resolved inline before commit:

1. `<calsuite>` placeholder in distributed skills → replaced with inline format guidance (no calsuite-path references in target repos).
2. `/triage` referenced in `/guardian` but doesn't exist → dropped.
3. ADR three-condition gate drift between `/plan`, `/learn`, `/improve-architecture` → standardized.
4. `templates/CONTEXT.md` claimed `/zoom-out`, `/review`, `/debug` update CONTEXT.md inline (they're read-only) → split into reader vs writer groups.
5. `/sweep-issues` claimed `/plan --grill` and `/improve-architecture` read `.out-of-scope/` (they didn't) → added the reading directive to both.
6. `gh label create` would error on existing labels → gated with `gh label list ... | grep -qx <name> ||`.

5 informational findings: `/customise` README bucket fixed, unused `Bash` dropped from `/zoom-out` allowed-tools, `/debug` description / gotcha vocabulary aligned with reframe, `/improve-architecture` avoid-list completeness fixed.

Deferred (non-blocking): HITL definition layering across guardian / sweep-issues / execute can be sharpened in a follow-up; `--grill` × REVIEW question-format interaction is workable.

## Doc Completeness

- [x] CHANGELOG.md updated (2.23 entry)
- [x] CLAUDE.md updated (version bump)
- [x] README.md updated (Skills overview bucketed)
- [n/a] tasks.md — no spec for this work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added zoom-out and improve-architecture skills.
  * Added --grill planning modifier.
  * Introduced AFK/HITL mode semantics across execute, guardian, sweep-issues, and related flows.
  * Reworked debug into a deterministic feedback-loop workflow.
  * Added mandatory skill-builder review checklist.

* **Documentation**
  * New domain glossary and ADR templates.
  * README now includes a Skills overview and guidance on context/ADR usage.
  * Enhanced skill docs to require domain-context priming and vocabulary reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->