### PR TITLE
chore(skills): add /humanize skill and ambient prose ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Current version: **2.24**
 ### Added
 
 - **`skills/humanize/SKILL.md`** — on-demand prose audit skill condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). Use for blog posts, external docs, READMEs, long-form PR bodies. Resolves input from a file path, `above`/`last` (most recent assistant message), inline text, or asks. Embeds the full compact ruleset: workflow, medium routing, safety rails, 10 core rules, required checks, watchlist. Explicitly forbids fake-human moves (invented typos, programmed sentence-length wobble, staged messiness) — calibrates stance to genre instead.
-- **`~/Projects/.claude/CLAUDE.md`** — always-on "Writing prose" section using Anbeeld's mini ruleset (~155 words). Applies to all projects under `~/Projects/`. Scoped to commit messages, PR bodies, READMEs, docs, external copy; explicitly skips terse status updates and one-line comments. Points to `/humanize` for the long-form audit pass.
+- **`skills/humanize/ambient.md`** — drop-in mini ruleset (~155 words) for global `CLAUDE.md` / `AGENTS.md`. Always-on prose guidance scoped to commit messages, PR bodies, READMEs, docs, external copy; explicitly skips terse status updates and one-line comments. Points to `/humanize` for the long-form audit pass.
 
 ### Why
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this repository.
 
-Current version: **2.23**
+Current version: **2.24**
+
+## [2.24] — 2026-04-30
+
+### Added
+
+- **`skills/humanize/SKILL.md`** — on-demand prose audit skill condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). Use for blog posts, external docs, READMEs, long-form PR bodies. Resolves input from a file path, `above`/`last` (most recent assistant message), inline text, or asks. Embeds the full compact ruleset: workflow, medium routing, safety rails, 10 core rules, required checks, watchlist. Explicitly forbids fake-human moves (invented typos, programmed sentence-length wobble, staged messiness) — calibrates stance to genre instead.
+- **`~/Projects/.claude/CLAUDE.md`** — always-on "Writing prose" section using Anbeeld's mini ruleset (~155 words). Applies to all projects under `~/Projects/`. Scoped to commit messages, PR bodies, READMEs, docs, external copy; explicitly skips terse status updates and one-line comments. Points to `/humanize` for the long-form audit pass.
+
+### Why
+
+Reviewed two AI-writing rulesets the user surfaced: Anbeeld's principled WRITING.md and a checklist-style "Humanizer" skill. Anbeeld won on the always-on layer (no fake-voice injection, calibrated to genre, refuses to break grammar to dodge detection). Split deployment: mini-ruleset embedded as ambient guidance, full audit gated behind an explicit `/humanize` invocation so it doesn't bleed into routine work output.
 
 ## [2.23] — 2026-04-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.23** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.24** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,14 @@ When the user's intent matches, read the pointed file *before* doing anything el
 
 ## Codify on repeat
 
-If the user asks for the same *shape* of thing a second time, propose a skill. The third time is too late. Skill files live at `skills/<name>/SKILL.md` and are auto-registered via the installer.
+If the user asks for the same *shape* of thing a second time, propose a skill. The third time is too late. Skill files live at `skills/<name>/SKILL.md`.
+
+**Adding a new skill is two edits, not one:**
+
+1. Create `skills/<name>/SKILL.md` (and any supporting files).
+2. Add `<name>` to `config/profiles.json` — at minimum the `base.skills` array, plus any other profile that declares its own `skills` (currently `monorepo-root`). The installer treats the profile array as an **allowlist**, not autodiscover. A skill that exists on disk but not in any profile silently fails to distribute to targets, and `--sync` will report `0 new` while looking like it succeeded.
+
+If the skill is calsuite-internal (lives in calsuite, not distributed — e.g. `sync`, `reconcile`, `customise`, `skill-builder`), skip step 2.
 
 Record durable learnings (patterns, pitfalls, preferences) via `/learn save` — they persist across sessions in `.context/learnings/`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.23**
+**Version: 2.24**
 
 ## Getting started
 

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture"],
+      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture"],
+      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -11,6 +11,13 @@ Apply [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) ruleset to a
 
 This is for content writing. If invoked on terse work output (a status note, a commit message, a one-line PR comment), confirm the user actually wants this — short utilitarian text shouldn't perform voice.
 
+## Arguments
+
+- `<path>` — read prose from a file path.
+- `above` / `last` — target the most recent assistant message in this conversation.
+- `<inline text>` — treat the argument itself as the prose to humanize.
+- omitted — ask the user what to humanize.
+
 ## Resolving input
 
 In order:

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: humanize
+description: Audit and rewrite prose to remove AI tells. Use for blog posts, external docs, READMEs, long-form PR bodies, public-facing copy. Not for code, terse status updates, or routine commit messages — sterile is correct there.
+user-invocable: true
+arguments: Optional path to a file, "above" for the most recent assistant output, or paste text inline. Defaults to asking what to humanize.
+---
+
+# /humanize
+
+Apply [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) ruleset to a piece of prose. Audit, then revise. For long pieces, run the audit-revise loop twice.
+
+This is for content writing. If invoked on terse work output (a status note, a commit message, a one-line PR comment), confirm the user actually wants this — short utilitarian text shouldn't perform voice.
+
+## Resolving input
+
+In order:
+1. If `$ARGUMENTS` is a file path, read the file.
+2. If `$ARGUMENTS` is `above` or `last`, target the most recent assistant message in this conversation.
+3. If `$ARGUMENTS` is text, treat it as the input.
+4. Otherwise ask the user to paste the text or give a path.
+
+## Ruleset
+
+Precedence: truth/safety/accessibility > user instructions > genre norms > core rules > watchlists.
+
+### Workflow
+
+1. Identify medium, audience, reader need, job of the text.
+2. If task-oriented: identify the answer or next action that belongs first.
+3. If long-form: decide the through-line and one concrete example that can carry weight.
+4. Draft to fit that context, not an abstract idea of good writing.
+5. Run the required checks.
+6. Cut what sounds generic, ceremonial, over-engineered, or too cleanly modular.
+
+### Medium routing
+
+- Chat, comments, DMs: prose by default. Lists only when naturally list-like. No decorative formatting. Straight quotes in plain text.
+- Email: prose first; lists for discrete items.
+- Documents, specs, tech writing: structure expected.
+- Web, help, UI text: answer early. Preserve scannability.
+- Long-form: structure on purpose. Pick an angle, not a timeline.
+
+### Safety rails
+
+Em dashes, semicolons, `however`, competent punctuation, and the right word are not AI tells. Do not invent typos, break grammar, inject fake uncertainty, or program sentence-length wobble. In casual prose, repeated em dashes are a social AI cue — use where they belong, not as default. Do not strip needed headings, lists, citations, or next steps to sound less AI-written.
+
+### Core rules
+
+1. **Anchor to context before drafting.** A reply paste-able into any thread on the topic reads generic. Keep register stable.
+2. **Fit format to medium.** Over-structuring casual writing makes it templated. Under-structuring technical writing makes it unusable.
+3. **Concrete specificity over polished generality.** Each substantial paragraph needs a concrete anchor: proper noun, specific number, direct quote, named decision, or checkable detail. `many`, `various`, `meaningful`, `essentially`, `fundamentally`, `ultimately`, bare milestone names — do not count. Earn specificity. Do not invent milestones, synthetic quotes, or suspiciously exact claims. Cannot verify? Attribute, soften, or cut. Where causation is unconfirmed, use `coincided with` or `was followed by`, not `caused` or `drove`.
+4. **Plain words, verbs, reference.** Do not chase synonyms for `problem`, `change`, `system`, `work`, `people`. Prefer `we changed it` to `the implementation of the change`. Cohere through pronouns, not `Furthermore` / `Moreover` / `Additionally` / `Importantly`.
+5. **Do not perform.** No keynote cadence, mission phrasing, ceremonial wrap-ups. No `Great question`, `I hope this helps`, `Feel free to reach out` unless the situation clearly calls for it. Start where the answer starts. Stop where it stops.
+6. **Calibrate stance to genre.** Confident where evidence is strong, explicit where it is weak. Visible writer where the genre expects one; neutral where it expects it. Don't sand to uniform mildness or manufacture views.
+7. **Show concrete before generalizing.** Usually: what happened → where the pattern appeared → what constraint mattered → what failed or changed → what that seems to mean.
+8. **Watch regularity.** The most visible LLM tell is its own regularity: parallel enumeration, three-part cadence, sentences doing hidden list work, concession-plus-positive rhythm (`not X, but Y`), paragraph-closing type definitions (`the kind of X where Y`), identical paragraph arcs, same punctuation move every paragraph, thesis-like openings, stacked mini-sentences. Three-item lists count. Fix by breaking the dominant pattern, not by random variation.
+9. **Develop thought; choose structure.** Longer pieces should not feel pre-solved. Include a concrete example, noticed detail, or brief doubling-back. For retrospectives, criticism, feature writing: avoid chronological march, topic buckets, catalog prose. If each paragraph reduces to a single label (`background`, `mechanism`, `impact`, `verdict`), it's system-tour prose — restructure. Alternatives: thematic, reverse-chronological, perspective-led, counterfactual, opinion-first, single-example-led.
+10. **Revise by cutting.** Re-read as a first-time reader. Cut auditioning, announcements, restating paragraphs, the most generic clause. Most edits should shorten.
+
+### Required checks
+
+Short pieces (≤ ~150 words): run 1–3 and 5. Longer: run all.
+
+1. **Register fit.** Format, punctuation, structure match medium and request? Accessibility preserved?
+2. **Concrete anchor.** One per substantial paragraph; if none, add or cut. If citing a source, confirm it supports the exact claim.
+3. **Regularity tripwire.** Name the most repeated pattern. Appears 3+ times or dominates two consecutive paragraphs? Rewrite one.
+4. **Stance and shape.** Genre expects a writer? State the view in one sentence; if you can't, add stance. Long piece? State organizing principle in five words; if it's just the genre default, restructure.
+5. **Over-correction.** Added fake-human moves to break a pattern?
+
+Tripwires, not goals. Don't output the audit unless asked.
+
+### Watchlist
+
+Scrutinize when defaulting to: `delve`, `tapestry`, `leverage`, `realm`, `robust`, `seamless`, `holistic`, `underscore`; `it's important to note`, `when it comes to`, `in conclusion`, `the kind of X where Y`; vague authority (`experts say` unnamed); unsupported causality (`X drove Y` without evidence); smart quotes in plain text; decorative emoji in prose. Repeated fallback is the problem, not any single item.
+
+## Output
+
+1. Revised text.
+2. If the input was already tight, say so and return it unchanged rather than performing edits.
+3. If the user asks, list the dominant patterns you broke (one line each).
+
+Don't narrate the revision process by default. Show the result.
+
+## Source
+
+Ruleset condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). The mini version is embedded in `~/Projects/.claude/CLAUDE.md` as always-on prose guidance; this skill is the on-demand audit pass for long-form work. Re-sync if upstream rules change materially.

--- a/skills/humanize/SKILL.md
+++ b/skills/humanize/SKILL.md
@@ -83,4 +83,4 @@ Don't narrate the revision process by default. Show the result.
 
 ## Source
 
-Ruleset condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). The mini version is embedded in `~/Projects/.claude/CLAUDE.md` as always-on prose guidance; this skill is the on-demand audit pass for long-form work. Re-sync if upstream rules change materially.
+Ruleset condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). For always-on prose guidance, paste [ambient.md](./ambient.md) (~155 words) into your global `CLAUDE.md` or `AGENTS.md`. This skill is the on-demand audit pass for long-form work. Re-sync if upstream rules change materially.

--- a/skills/humanize/ambient.md
+++ b/skills/humanize/ambient.md
@@ -1,0 +1,24 @@
+# Ambient prose ruleset
+
+Mini version of [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). Paste the section below verbatim into your global `CLAUDE.md` or `AGENTS.md` for always-on prose guidance. The full audit pass lives in [SKILL.md](./SKILL.md) and runs on demand via `/humanize`.
+
+---
+
+## Writing prose
+
+Applies to commit messages, PR bodies, READMEs, docs, blog posts, external copy. Not code. Skip for terse status updates and one-line comments — sterile is correct there.
+
+When rules conflict: truth > user > genre > rules.
+
+- Casual: prose. Technical: structure. Long-form: angle, not timeline. Straight quotes in plain text.
+- Each paragraph: one concrete anchor (proper noun, number, quote, detail). `many` / `various` / `essentially` don't count. Don't invent milestones, narrate hidden mechanisms, or launder vague authority — attribute, soften, or cut what you can't verify.
+- Plain words and verbs. Repeat ordinary words. Link with pronouns, not `furthermore` / `moreover`.
+- No `keynote`, `Great question`, `I hope this helps`. Start and stop at the answer. Stance: visible where expected, neutral where expected. Don't sand mild, don't manufacture a view.
+- Avoid repeated patterns: parallel lists (three items still count), concession rhythm (`not X, but Y`), X-is-that wrappers, `called` before nouns, identical paragraph arcs. Break where they dominate.
+- Long-form: pick a through-line (thematic, perspective-led, single-example-led), not chronology or catalog. Include an example, pause, or double back; don't rush to conclusion.
+- Cut, don't add. No fake humanity, no programmed sentence-length variation, no invented typos. Don't strip structure for style.
+- Check: register, anchors, regularity, stance, over-correction. Scrutinize (fallback, not bans): `delve` / `leverage` / `seamless`, `it's important to note`, unnamed `experts`, unsupported causality.
+
+For one-shot polish on long-form work, run `/humanize`.
+
+Source: [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT).


### PR DESCRIPTION
## Summary

- New `skills/humanize/SKILL.md` — on-demand prose audit skill condensed from [Anbeeld's WRITING.md](https://github.com/Anbeeld/WRITING.md) (MIT). For blog posts, external docs, READMEs, long-form PR bodies. Resolves input from a file path, `above`/`last` (most recent assistant message), inline text, or asks.
- Embeds the full compact ruleset: workflow, medium routing, safety rails, 10 core rules, required checks, watchlist. Explicitly forbids fake-human moves (invented typos, programmed sentence-length wobble, staged messiness) — calibrates stance to genre instead.
- Companion `skills/humanize/ambient.md` — drop-in mini ruleset (~155 words) intended to be pasted into a global `CLAUDE.md` or `AGENTS.md` for always-on prose guidance.
- Version bump 2.23 → 2.24.

## Why

Reviewed two AI-writing rulesets surfaced as candidates: Anbeeld's principled WRITING.md and a checklist-style "Humanizer" skill that recommended faking voice (invented opinions, programmed rhythm variation, "let some mess in"). Anbeeld won on the always-on layer — calibrated to genre, refuses to break grammar to dodge detection. Split deployment: the mini ruleset (`ambient.md`) for ambient guidance on routine prose (commits, PR bodies, READMEs), full audit gated behind explicit `/humanize` invocation so the heavier ruleset doesn't bleed into terse work output where sterile is correct.

## Important Files

| File | Change |
|------|--------|
| `skills/humanize/SKILL.md` | New skill. Compact ruleset + audit workflow. |
| `skills/humanize/ambient.md` | Drop-in mini ruleset for global `CLAUDE.md` / `AGENTS.md`. |
| `CLAUDE.md` | Version bump to 2.24. |
| `README.md` | Version bump to 2.24. |
| `CHANGELOG.md` | 2.24 entry with rationale. |

## Doc Completeness

- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md and README.md
- [ ] CLAUDE.md conventions section — no changes (skill follows existing layman/zoom-out pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New user-invocable "humanize" prose-audit skill for refining text (accepts inline or recent content, applies structured rewrite rules, reports changes on request).
  * Ambient prose guidance that runs continuously to nudge clearer, context-fit wording while deferring deep audits to the humanize skill.

* **Documentation**
  * Clarified installation/registration steps for adding new skills to profiles; noted internal-skill exception.

* **Chores**
  * Version bumped to 2.24; profiles updated to include the humanize skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->