### PR TITLE
fix(installer): skip _origin rewrite when content unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.24**
+Current version: **2.25**
+
+## [2.25] — 2026-04-30
+
+### Fixed
+
+- **`scripts/lib/origin-protocol.cjs` + `scripts/configure-claude.js`** — `--sync` no longer rewrites the `_origin: calsuite@<sha>` marker on files whose content is byte-identical to the calsuite source. Closes [#77](https://github.com/ckallum/calsuite/issues/77). Adds a new `'no-op'` action to `decideFileAction`'s return enum, fired when dest content matches both the install-sha content (calsuite-managed) and current calsuite HEAD (no rewrite needed). Sync logs now surface the count as `N unchanged` alongside `written` / `skipped`.
+
+### Why
+
+Every calsuite content change was creating a wave of zero-content drift PRs in target repos: 16 in verity, 23 in timeline, 23 in museli after [#75](https://github.com/ckallum/calsuite/issues/75) merged, all of them single-line `_origin` SHA bumps with no actual content delta. The marker's purpose (knowing which calsuite revision distributed each file, for divergence detection) is preserved — a stale marker still uniquely identifies a real calsuite revision, and the next *real* content change will refresh it.
 
 ## [2.24] — 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Current version: **2.25**
 
 ### Fixed
 
-- **`scripts/lib/origin-protocol.cjs` + `scripts/configure-claude.js`** — `--sync` no longer rewrites the `_origin: calsuite@<sha>` marker on files whose content is byte-identical to the calsuite source. Closes [#77](https://github.com/ckallum/calsuite/issues/77). Adds a new `'no-op'` action to `decideFileAction`'s return enum, fired when dest content matches both the install-sha content (calsuite-managed) and current calsuite HEAD (no rewrite needed). Sync logs now surface the count as `N unchanged` alongside `written` / `skipped`.
+- **`scripts/lib/origin-protocol.cjs` + `scripts/configure-claude.js`** — `--sync` no longer rewrites the `_origin: calsuite@<sha>` marker when the destination matches the calsuite source under `normalizeForCompare` (LF-normalized, with the `_origin:` line stripped from both sides). Closes [#77](https://github.com/ckallum/calsuite/issues/77). Adds a new `'no-op'` action to `decideFileAction`'s return enum, fired when dest content matches both the install-sha content (calsuite-managed) and current calsuite HEAD (no rewrite needed) under that normalized comparison. Sync logs now surface the count as `N unchanged` alongside `written` / `skipped`.
 
 ### Why
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.24** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.25** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.24**
+**Version: 2.25**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -113,6 +113,7 @@ function makeInstallStats() {
     'write-new': 0,
     'write-update': 0,
     'migrate': 0,
+    'no-op': 0,
     'skip-diverged': 0,
     'skip-unknown': 0,
     'skip-claimed': 0,
@@ -120,10 +121,11 @@ function makeInstallStats() {
   };
 }
 
-// Aggregate a stats object into the three numbers used in log lines.
+// Aggregate a stats object into the four numbers used in log lines.
 function summarizeInstallStats(stats) {
   return {
     written: stats['write-new'] + stats['write-update'] + stats['migrate'],
+    noOp: stats['no-op'],
     skipped: stats['skip-diverged'] + stats['skip-unknown'],
     preserved: stats['skip-claimed'] + stats['skip-exists'],
   };
@@ -166,6 +168,9 @@ function installProtectedFile({ srcFile, destFile, calsuiteDir, currentSha, stat
     fs.writeFileSync(destFile, stamped);
     return;
   }
+
+  // 'no-op': dest content already matches calsuite current; rewriting just to
+  // refresh the _origin marker would create zero-content drift PRs in targets.
 
   if (BLOCKING_SKIP_ACTIONS.has(decision.action)) {
     divergences.push({ destPath: destFile, action: decision.action, reason: decision.reason });
@@ -598,7 +603,8 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   const preservedBreakdown = [];
   if (skillStats['skip-claimed']) preservedBreakdown.push(`${skillStats['skip-claimed']} user-claimed`);
   if (skillStats['skip-exists']) preservedBreakdown.push(`${skillStats['skip-exists']} non-md kept`);
-  console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated), ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
+  const skillNoOp = skillSummary.noOp ? `, ${skillSummary.noOp} unchanged` : '';
+  console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated)${skillNoOp}, ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
 
   // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
@@ -611,7 +617,8 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
       installProtectedFile({ srcFile: srcAgent, destFile: destAgent, calsuiteDir, currentSha, stats: agentStats, divergences });
     }
     const agentSummary = summarizeInstallStats(agentStats);
-    console.log(`  ✓ Agents: ${agentSummary.written} written, ${agentSummary.skipped} skipped${agentStats['skip-claimed'] ? `, ${agentStats['skip-claimed']} user-claimed` : ''}`);
+    const agentNoOp = agentSummary.noOp ? `, ${agentSummary.noOp} unchanged` : '';
+    console.log(`  ✓ Agents: ${agentSummary.written} written${agentNoOp}, ${agentSummary.skipped} skipped${agentStats['skip-claimed'] ? `, ${agentStats['skip-claimed']} user-claimed` : ''}`);
   }
 
   // 5. Copy templates (never overwrite existing)
@@ -790,7 +797,8 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
       }
     }
     const summary = summarizeInstallStats(stats);
-    console.log(`  → ${count} skill(s): ${summary.written} files written, ${summary.skipped} skipped, ${summary.preserved} preserved`);
+    const noOp = summary.noOp ? `, ${summary.noOp} unchanged` : '';
+    console.log(`  → ${count} skill(s): ${summary.written} files written${noOp}, ${summary.skipped} skipped, ${summary.preserved} preserved`);
   }
 
   // Install specified agents through the same protocol.
@@ -811,7 +819,8 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
       }
     }
     const summary = summarizeInstallStats(stats);
-    console.log(`  → ${count} agent(s): ${summary.written} written, ${summary.skipped} skipped`);
+    const noOp = summary.noOp ? `, ${summary.noOp} unchanged` : '';
+    console.log(`  → ${count} agent(s): ${summary.written} written${noOp}, ${summary.skipped} skipped`);
   }
 
   // Also install into workspaces if monorepo, unless the target opted out

--- a/scripts/lib/origin-protocol.cjs
+++ b/scripts/lib/origin-protocol.cjs
@@ -144,6 +144,9 @@ function currentCalsuiteSha(calsuiteDir) {
  * Returns one of:
  *   'write-new'     dest missing — fresh write + stamp
  *   'write-update'  dest calsuite-managed and unchanged since install — safe overwrite
+ *   'no-op'         dest calsuite-managed and content already matches calsuite current —
+ *                   nothing to write; refreshing the _origin marker alone would create
+ *                   spurious drift in target repos (see issue #77).
  *   'migrate'       dest has no _origin but content matches calsuite current — stamp in place
  *   'skip-diverged' dest calsuite-managed but user edited — skip, flag
  *   'skip-unknown'  dest has no _origin and content differs — pre-protocol edit or stale, skip, flag
@@ -169,6 +172,10 @@ function decideFileAction(destPath, calsuiteRelPath, calsuiteDir) {
       return { action: 'skip-unknown', reason: `origin sha ${installSha} has no record of ${calsuiteRelPath}` };
     }
     if (normalizeForCompare(destContent) === normalizeForCompare(atSha)) {
+      if (calsuiteCurrent !== null &&
+          normalizeForCompare(destContent) === normalizeForCompare(calsuiteCurrent)) {
+        return { action: 'no-op' };
+      }
       return { action: 'write-update' };
     }
     return { action: 'skip-diverged', reason: `user-modified since ${installSha}` };


### PR DESCRIPTION
## Summary

Closes [#77](https://github.com/ckallum/calsuite/issues/77).

`configure-claude.js --sync` was rewriting the `_origin: calsuite@<sha>` frontmatter on every distributed file every time calsuite HEAD moved, even when the file's body matched the source under `normalizeForCompare` (LF-normalized, with the `_origin:` line stripped from both sides). That created zero-content drift PRs in every target repo (16 in verity, 23 in timeline, 23 in museli) for every calsuite content change.

## What changed

- **`scripts/lib/origin-protocol.cjs`** — `decideFileAction` returns a new `'no-op'` action when dest content matches BOTH `contentAtSha(installSha)` AND current calsuite source. Previously this branch always returned `'write-update'`.
- **`scripts/configure-claude.js`** — adds `'no-op': 0` to install stats, surfaces the count as `N unchanged` in the Skills / Agents log lines (and the `--only` paths). The new action is silent — not in `WRITE_ACTIONS`, not in `BLOCKING_SKIP_ACTIONS`.

## Why this is safe

The `_origin` marker's purpose is to track *which calsuite revision distributed each file* for divergence detection. A stale marker still uniquely identifies a real calsuite revision, and the next *real* content change naturally refreshes it. The only thing we lose is "what's the latest calsuite version this target has been synced against?" as a global answer — but that question is better answered by `git log` in calsuite itself.

`'migrate'` is **not** affected — pre-protocol files still get stamped on first sync.

## Verification

Before:

```
$ node scripts/configure-claude.js --sync
  ✓ Skills: 21 written (0 new / 21 updated / 0 migrated), ...
$ cd ~/Projects/verity && git status --short | wc -l
16
```

After:

```
$ node scripts/configure-claude.js --sync
  ✓ Skills: 0 written (0 new / 0 updated / 0 migrated), 16 unchanged, 3 skipped, ...
  ✓ Skills: 0 written (0 new / 0 updated / 0 migrated), 24 unchanged, 7 skipped, ...
$ cd ~/Projects/verity && git status --short | wc -l
0
$ cd ~/Projects/timeline && git status --short | wc -l
0
```

## Files

| File | Change |
|------|--------|
| `scripts/lib/origin-protocol.cjs` | Add `'no-op'` action when dest matches calsuite current. |
| `scripts/configure-claude.js` | New stat counter + log surfacing as `N unchanged`. |
| `CLAUDE.md` | Version bump to 2.25. |
| `README.md` | Version bump to 2.25. |
| `CHANGELOG.md` | 2.25 entry. |

## Doc Completeness

- [x] CHANGELOG.md updated
- [x] Version bumped in CLAUDE.md and README.md
- [x] decideFileAction JSDoc updated with new action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary file rewrites when normalized content is unchanged (avoids PRs caused solely by origin-marker bumps); installer now counts these as "unchanged".
* **Documentation**
  * Updated CHANGELOG, README, and CLAUDE version references for 2.25 with notes about the no-op behavior.
* **Chores**
  * Bumped release version to 2.25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->