### PR TITLE
chore(skills): guard /sweep-issues against deferring PR-introduced bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable changes to this repository.
 
-Current version: **2.25**
+Current version: **2.26**
+
+## [2.26] — 2026-05-01
+
+### Changed
+
+- **`skills/sweep-issues/SKILL.md`** — new Step 2c "Flag PR-introduced bugs". For every candidate categorized as `bug`, the skill now diffs against `origin/main`, matches the candidate against changed files and added/modified symbols, and uses AskUserQuestion to force a fix-inline / pre-existing / dismiss decision before the issue gets created. Added `AskUserQuestion` to allowed-tools. Added the rule to "What NOT to Capture".
+- **`skills/ship/SKILL.md` Step 7.2** — triage is now grounded in an explicit `CHANGED_FILES` list captured from `git diff origin/main --name-only`. The "fix now" column gains a top row "Anything touching a file in `CHANGED_FILES` (default)", and the "create issue" column gains a matching "Pre-existing bug in a file this PR doesn't touch" row. New hard rule: bugs whose file is in `CHANGED_FILES` are never deferrable.
+- **`skills/ship/SKILL.md` PR-only mode** — new Step 2.5 between Commit and Push runs the same `CHANGED_FILES`-grounded triage. PR-only mode previously skipped Step 7.2 entirely, so any bug introduced by a docs/config/skill PR sailed straight into a deferred issue.
+
+### Why
+
+`/sweep-issues` was creating GitHub issues for bugs the PR itself had introduced — the post-PR safety-net call (`/ship` Step 9 and pr-only Step 4) had no awareness of the diff and would defer anything tagged "bug" without checking whether it lived in code the branch was changing. Step 7.2's existing inline-fix triage was the right idea but relied on the LLM "knowing" which files were touched without anchoring to the actual diff. The fix puts the diff-file-list in front of every triage decision, makes file-in-diff bugs un-deferrable by rule, and adds the same guard inside `/sweep-issues` itself so the rule holds whether the skill is invoked from `/ship`, from pr-only mode, or standalone.
 
 ## [2.25] — 2026-04-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.25** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.26** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.25**
+**Version: 2.26**
 
 ## Getting started
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -59,6 +59,22 @@ EOF
 
 Use `docs:` for documentation, `chore:` for config/skills, `style:` for formatting. If there are already commits on the branch and no uncommitted changes, skip this step.
 
+### Step 2.5: Sweep and fix PR-introduced bugs inline
+
+Even in pr-only mode, scan the conversation for **bugs in code this branch is changing**. PR-only mode skips tests, review, and simplification — but it must NOT skip the rule that bugs introduced by the PR get fixed in the PR.
+
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Review the conversation for any minor bugs, TODOs, edge cases, or rough edges that surfaced during the work. For each candidate, check whether it touches `CHANGED_FILES`:
+
+- **If yes and it's a bug:** fix it now, stage, commit (`git commit -m "fix: <what>"`). No exceptions.
+- **If yes and it's an enhancement/cleanup:** default to fixing inline unless it would meaningfully grow the PR.
+- **If no:** defer to Step 4 (the post-PR `/sweep-issues` call will create the issue).
+
+Skip this step silently if no candidates surfaced.
+
 ### Step 3: Push, run Pre-PR Gates, create PR
 
 ```bash
@@ -257,23 +273,34 @@ git push -u origin $(git branch --show-current)
 
 **Before** running Pre-PR Gates, scan the conversation for deferred items, fast-follows, minor bugs, enhancements, and tech debt — the same categories `/sweep-issues` looks for. Fix anything coherent with the current PR; defer the rest to Step 9.
 
-### 7.2a: Gather candidates
+### 7.2a: Gather candidates and capture the diff file list
 
-Review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description and its source (conversation turn, review finding, etc.).
+First, capture the canonical list of files this branch touches — every later triage decision is grounded against it:
+
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Then review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description, its source (conversation turn, review finding, etc.), and **the file(s) it relates to** if known.
 
 ### 7.2b: Triage — fix now vs. create issue
+
+For each candidate, first check whether it touches `CHANGED_FILES`. **If it does, default to "fix now"** — the reviewer is going to see those files anyway, and any bug, TODO, or rough edge in them belongs in the same PR. Only override the default if the user explicitly confirms the issue is pre-existing and out of scope.
 
 Classify each candidate:
 
 | Fix now (inline) | Create issue (later) |
 |---|---|
-| Minor bug in code touched by this PR | Feature request unrelated to this PR |
-| Missing edge case in a function this PR added/modified | Large refactor spanning multiple files not in this diff |
-| TODO/FIXME left in files changed by this PR | Work that requires design discussion |
-| Small enhancement coherent with the PR's purpose | Performance optimization with unclear scope |
-| Cleanup in files already being modified | Anything that would change the PR's scope significantly |
+| **Anything touching a file in `CHANGED_FILES`** (default) | Feature request unrelated to this PR |
+| Minor bug in code touched by this PR | Large refactor spanning multiple files not in this diff |
+| Missing edge case in a function this PR added/modified | Work that requires design discussion |
+| TODO/FIXME left in files changed by this PR | Performance optimization with unclear scope |
+| Small enhancement coherent with the PR's purpose | Anything that would change the PR's scope significantly |
+| Cleanup in files already being modified | Pre-existing bug in a file this PR doesn't touch |
 
-**The test:** "Would a reviewer expect this to be part of this PR?" If yes → fix now. If no → create issue.
+**The test:** "Would a reviewer expect this to be part of this PR?" If the candidate's file is in `CHANGED_FILES`, the answer is almost always yes — fix now. If no → create issue.
+
+**Bugs introduced by this PR are never deferrable.** If a candidate is a bug AND its file is in `CHANGED_FILES`, fix it inline. Do not move it to the "create issue" column even if the user requested deferring something else.
 
 ### 7.2c: Apply inline fixes
 

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Read
   - Grep
   - Glob
+  - AskUserQuestion
 ---
 
 # Sweep Issues: Auto-Create GitHub Issues from Session Work
@@ -41,6 +42,7 @@ Scan the conversation for ANY of these patterns:
 - Items completed in this session
 - Items that are trivially small (single-line fixes you could do right now)
 - Vague wishes without actionable scope
+- **Bugs in code this branch is currently touching** — these belong inline in the PR, not deferred. Step 2c detects and surfaces these explicitly.
 
 ## Process
 
@@ -56,7 +58,7 @@ Review the conversation history and identify candidate items. For each, note:
   - **HITL** — needs a design decision, manual verification, external access, or domain knowledge an agent can't get from the code.
   - Prefer AFK whenever possible — only mark HITL when there's a real reason an agent can't finish unattended.
 
-### Step 2: Deduplicate Against Existing Issues and Prior Rejections
+### Step 2: Filter — dedup, prior rejections, and PR-introduced bugs
 
 For each candidate:
 
@@ -73,6 +75,41 @@ Skip anything that's already tracked. If an existing issue is related but doesn'
 If a prior rejection covers the same idea, **skip the candidate silently** and note it in the report as `Skipped (out-of-scope: <slug>.md)`. Don't re-litigate decisions that were already made — that's the whole point of the knowledge base.
 
 If a prior rejection is *related but not the same scope*, surface it to the user: *"This is similar to a previous rejection (`.out-of-scope/<slug>.md`) but the new scope differs because X — proceed?"* The user decides whether the new scope warrants a new issue or whether to update the rejection record.
+
+**2c. Flag PR-introduced bugs.** A bug in code this branch is already changing belongs inline in the PR, not in a deferred issue. Skip this check on `main` or when no diff exists — otherwise it produces noise.
+
+```bash
+# Skip the check entirely if not on a feature branch with real divergence
+branch=$(git branch --show-current 2>/dev/null)
+if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
+  changed_files=$(git diff origin/main --name-only 2>/dev/null)
+fi
+```
+
+If `$changed_files` is non-empty, for every candidate categorized as `bug`:
+
+1. Match the candidate against the diff. A candidate is **PR-touched** if any of:
+   - Its description references a file path in `$changed_files` (literal or basename match)
+   - Its description references a symbol (function, type, constant) that appears in `git diff origin/main` as an added or modified line
+2. If PR-touched, use AskUserQuestion individually:
+   ```
+   This bug looks like it lives in code this PR is changing:
+     <one-line bug description>
+     Matched: <file path or symbol>
+
+   PR-introduced bugs should be fixed in this PR, not deferred.
+
+   A) Fix inline — skip this candidate. You'll fix it before the PR is published
+      (or as a follow-up commit if the PR is already up).
+   B) Defer to issue — confirmed pre-existing, not introduced by this branch.
+   C) Dismiss — not a real bug.
+   ```
+3. Apply the answer:
+   - **A:** drop from the create-list. Add to the final report as `Skipped (fix inline): <description>`. After Step 5, surface a clear callout reminding the user to fix before publishing.
+   - **B:** keep the candidate. Add a `**Pre-existing:** confirmed not introduced by branch <name>` line to the issue body so the next reader knows the triage already happened.
+   - **C:** drop silently.
+
+This guard runs on every `/sweep-issues` invocation, including the safety-net call at the end of `/ship`. It's the last line of defense against PR-introduced bugs slipping into deferred issues.
 
 ### Step 3: Present Candidates
 

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -92,7 +92,7 @@ If `$changed_files` is non-empty, for every candidate categorized as `bug`:
    - Its description references a file path in `$changed_files` (literal or basename match)
    - Its description references a symbol (function, type, constant) that appears in `git diff origin/main` as an added or modified line
 2. If PR-touched, use AskUserQuestion individually:
-   ```
+   ```text
    This bug looks like it lives in code this PR is changing:
      <one-line bug description>
      Matched: <file path or symbol>


### PR DESCRIPTION
## Summary
- New Step 2c inside `/sweep-issues`: every `bug` candidate is matched against `git diff origin/main` (changed files + added/modified symbols). On a hit, `AskUserQuestion` forces a fix-inline / pre-existing-defer / dismiss decision before the issue is created.
- `/ship` Step 7.2 grounds its triage in `CHANGED_FILES` captured from `git diff origin/main --name-only`. Top row of the "fix now" column is now "Anything touching a file in `CHANGED_FILES` (default)". Bugs whose file is in `CHANGED_FILES` are explicitly un-deferrable.
- New Step 2.5 in `/ship pr` mode runs the same `CHANGED_FILES`-grounded triage before push. PR-only mode previously had no inline-fix triage at all.
- Bumps to **2.26**.

## Why
`/sweep-issues` was creating GitHub issues for bugs the PR itself had introduced. The post-PR safety-net call (Step 9 in full ship, Step 4 in pr-only) had no diff awareness — it would defer anything labeled `bug` without checking whether the bug lived in code the branch was changing. Step 7.2's existing inline-fix triage was the right idea but relied on the model knowing which files were touched without anchoring to the actual diff. The fix puts the diff file list in front of every triage decision, makes file-in-diff bugs un-deferrable by rule, and adds the same guard inside `/sweep-issues` itself so the rule holds whether the skill is invoked from `/ship`, from pr-only mode, or standalone.

## Important Files
| File | Change |
|------|--------|
| [skills/sweep-issues/SKILL.md](skills/sweep-issues/SKILL.md) | New Step 2c PR-introduced-bug guard. AskUserQuestion added to allowed-tools. New "What NOT to Capture" rule. |
| [skills/ship/SKILL.md](skills/ship/SKILL.md) | Step 7.2 grounded in `CHANGED_FILES`. New Step 2.5 in PR-only mode. Hard rule: file-in-diff bugs are not deferrable. |
| [CHANGELOG.md](CHANGELOG.md) | 2.26 entry. |
| [CLAUDE.md](CLAUDE.md), [README.md](README.md) | Version bump. |

## Pre-Landing Review
No issues found — pr-only mode (skills/docs only, no executable code).

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md / README.md version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bug detection in pull requests with interactive decision prompts guiding users to fix, defer, or dismiss PR-affected candidates.
  * Improved workflow consistency with file change detection integrated across bug-sweep and shipping processes.
  * Stricter handling rules for PR-introduced bugs prevent automatic deferral to issue tracking.
  * Version updated to 2.26 with documentation refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->