### PR TITLE
docs(ship): correct '/ship pr skips ALL safety checks' Gotcha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this repository.
 
-Current version: **2.26**
+Current version: **2.27**
+
+## [2.27] — 2026-05-02
+
+### Fixed
+
+- **`skills/ship/SKILL.md` Gotchas** — the "/ship pr skips ALL safety checks" bullet contradicted Steps 2.5 (PR-introduced-bug sweep) and 3 (Pre-PR Gates from Step 7.4) added in 2.26. Reworded to reflect what pr-only mode actually does: skips the heavy checks (full test suite, simplification, Pre-Landing Review, CHANGELOG generation, commit splitting) but still runs the cheap ones (Step 2.5 sweep, Step 7.4 Pre-PR Gates, Step 8.5 claim-vs-diff grep).
 
 ## [2.26] — 2026-05-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.26** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.27** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.26**
+**Version: 2.27**
 
 ## Getting started
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -564,7 +564,7 @@ args: ""
 - **Simplify runs BEFORE review** so the review stamp covers the final code state. Don't reorder Steps 4 and 4.5.
 - **`git push` may fail if the branch was force-pushed elsewhere.** Never force push to recover — ask the user.
 - **CHANGELOG auto-generation reads all commits on the branch** — if prior commits have bad messages, the CHANGELOG entries will be vague.
-- **`/ship pr` skips ALL safety checks** (tests, review, simplification). Only use for genuinely low-risk changes. If in doubt, use `/ship`.
+- **`/ship pr` skips the heavy safety checks** (full test suite, simplification, Pre-Landing Review, CHANGELOG generation, commit splitting) but still runs the cheap ones: the Step 2.5 PR-introduced-bug sweep, the Pre-PR Gates from Step 7.4 (PR-size, test-presence, spec-contract), and the PR-claim-vs-diff grep (Step 8.5). Use for genuinely low-risk changes (docs, config, skills); if in doubt, use `/ship`.
 - **Pre-PR Gates (Step 7.4) warn but do not block** unless `.claude/ship-config.json` sets `strict: true`. They surface context about the diff shape — large PRs, no-test diffs, spec deviations — but the user always has the final word.
 - **`.claude/ship-config.json` is optional and per-repo.** Keys: `criticalPaths: [glob, ...]` for strict test-presence on sensitive files, `strict: true` to promote the strict warning into a block. Only the test-presence gate reads this file — size, spec-contract, and claim-grep gates run unconditionally.
 - **PR-claim-vs-diff grep (Step 8.5) uses literal string search.** A claim is missing if `grep -F` doesn't find it in the full diff. If the code renamed a symbol that the PR body still references, the grep correctly flags it.


### PR DESCRIPTION
## Summary
- Reworks the contradictory Gotcha bullet introduced when 2.26 added Step 2.5 (PR-introduced-bug sweep) and wired Step 3 to run Pre-PR Gates from Step 7.4. The old wording (\`/ship pr\` skips ALL safety checks) is no longer accurate.
- New wording distinguishes heavy checks still skipped (full test suite, simplification, Pre-Landing Review, CHANGELOG generation, commit splitting) from cheap checks still run (Step 2.5 sweep, Step 7.4 Pre-PR Gates, Step 8.5 claim-vs-diff grep).
- Bumps to **2.27**.

## Important Files
| File | Change |
|------|--------|
| [skills/ship/SKILL.md](skills/ship/SKILL.md) | Rewrites the contradictory Gotcha bullet. |
| [CHANGELOG.md](CHANGELOG.md) | 2.27 entry. |
| [CLAUDE.md](CLAUDE.md), [README.md](README.md) | Version bump. |

## Pre-Landing Review
No issues found — pr-only mode (single docs change, no executable code).

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md / README.md version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)