### PR TITLE
feat(installer): add per-target skills.exclude to config/targets.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.29**
+Current version: **2.30**
+
+## [2.30] — 2026-05-12
+
+### Added
+
+- **`scripts/configure-claude.js` `applyTargetSkillsFilter()` + `targets.json` `skills.exclude` knob** — closes [#82](https://github.com/ckallum/calsuite/issues/82). Per-target entries in `config/targets.json` may now carry `{ "skills": { "exclude": ["a", "b"] } }`; the named skills are dropped from the profile-resolved set before the install loop iterates. Plugins, agents, templates, and hooks are untouched. The install log appends `, N excluded by target config` to the `✓ Skills:` line when the filter fires; entries that don't match any profile-derived skill surface as a separate `⚠ targets.json skills.exclude entries with no matching profile-derived skill: …` warning so typos and profile-drift get caught the next sync. Plumbed through both single-target and `--sync` call sites. `--only` mode skips the filter — explicit skill lists always win.
+
+### Why
+
+The harness was binary: accept the full profile-resolved set or post-install `rm -rf .claude/skills/<name>` and remove the target from `config/targets.json` to stop `--sync` from resurrecting them. For small or single-purpose projects (the trigger here was a Tailwind landing page that only needs ~12 of the ~25 frontend-profile skills), neither option fit. `--only` exists but skips hooks/plugins/settings entirely, which is too restrictive when you still want the rest of the harness wired up. Adding a per-target exclude knob preserves the profile system as the source of truth (the auto-detection logic stays unchanged) and lets the target file express small curation deltas without forking profiles. Surfacing unmatched exclude entries as a warning matches the same drift-detection style used by `validateProfilesConfig()` for profile-vs-disk drift, so typos and skill renames don't silently fall through.
 
 ## [2.29] — 2026-05-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.29** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.30** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 
@@ -53,7 +53,7 @@ templates/   # spec / doc / changelog templates
 - `~/.mcp.json` — user-global MCP server configs (installer adds missing servers from manifest)
 - `<target>/.claude/settings.json` — **team-shared** (committed). Installer writes `enabledPlugins` and `permissions` here. Never hooks, never paths.
 - `<target>/.claude/settings.local.json` — **per-user** (gitignored by the installer). Installer writes calsuite hook wiring here with literal resolved `$CALSUITE_DIR` paths.
-- `config/targets.json` — repos that `--sync` installs to
+- `config/targets.json` — repos that `--sync` installs to. Each entry: `{ path, workspaces?, skills? }`. `workspaces: "skip"` restricts monorepo targets to root-only install. `skills: { exclude: ["a", "b"] }` drops the named skills from the profile-resolved install set; unmatched names surface as a ⚠ drift warning. See `config/targets.example.json`.
 - `.git/hooks/post-commit` — auto-syncs on commit when hooks/skills/agents/scripts/config change
 
 ## Gotchas

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.29**
+**Version: 2.30**
 
 ## Getting started
 

--- a/config/targets.example.json
+++ b/config/targets.example.json
@@ -1,8 +1,10 @@
 {
   "_comment": "Copy this file to config/targets.json and replace the paths with your own target repos. targets.json is gitignored — it stays local and is never committed. Paths may use '~' for your home directory; the installer expands it.",
   "_workspaces_comment": "For monorepo targets (backend/ + frontend/ subdirs), set `workspaces: \"skip\"` to install the harness only at the repo root. Default is `\"full\"` — every workspace gets its own mirrored .claude/ skills/agents/config/permissions. Use `\"skip\"` when only the root should be the Claude Code harness (recommended for most monorepos — avoids duplicated skill definitions and drift).",
+  "_skills_comment": "Set `skills: { exclude: [...] }` to drop specific skills from the profile-derived install set — useful for small or single-purpose targets where the full profile is more than you need. Names must match `skills/<name>/` dirs; entries that don't match any profile-derived skill surface as a ⚠ drift warning at install time.",
   "targets": [
     { "path": "~/Projects/my-first-repo" },
-    { "path": "~/Projects/my-monorepo", "workspaces": "skip" }
+    { "path": "~/Projects/my-monorepo", "workspaces": "skip" },
+    { "path": "~/Projects/my-landing-page", "skills": { "exclude": ["improve-architecture", "plan-ceo"] } }
   ]
 }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -500,6 +500,36 @@ function validateProfilesConfig(profilesConfig) {
   }
 }
 
+/**
+ * Apply a per-target `skills.exclude` filter to the profile-resolved skill
+ * list. The target's entry in `config/targets.json` may carry:
+ *   { "skills": { "exclude": ["skill-a", "skill-b"] } }
+ *
+ * Returns `{ filtered, excluded, missing }`:
+ *   - filtered: skill names that survive the filter (in original order)
+ *   - excluded: skill names that were both in `resolvedSkills` and in the
+ *     exclude list (i.e. genuinely removed)
+ *   - missing: skill names listed in exclude that did NOT appear in
+ *     `resolvedSkills` — typo or drift signal for the caller to surface
+ *
+ * Pure function: returns data, does not log. Callers decide how to render.
+ */
+function applyTargetSkillsFilter(resolvedSkills, targetSkillsConfig) {
+  const rawExclude = targetSkillsConfig?.exclude;
+  if (!Array.isArray(rawExclude) || rawExclude.length === 0) {
+    return { filtered: resolvedSkills, excluded: [], missing: [] };
+  }
+  // Drop non-string entries so a stray null/number in hand-edited targets.json
+  // doesn't silently land in `missing` as a phantom drift warning.
+  const exclude = rawExclude.filter(s => typeof s === 'string');
+  const excludeSet = new Set(exclude);
+  const resolvedSet = new Set(resolvedSkills);
+  const filtered = resolvedSkills.filter(s => !excludeSet.has(s));
+  const excluded = resolvedSkills.filter(s => excludeSet.has(s));
+  const missing = exclude.filter(s => !resolvedSet.has(s));
+  return { filtered, excluded, missing };
+}
+
 function findWorkspaces(targetDir) {
   const workspaces = [];
 
@@ -643,10 +673,15 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   //    Every markdown file under each profile-listed skill dir is copied
   //    with `_origin: calsuite@<sha>` stamped into its frontmatter.
   //    Existing files with local edits are detected and preserved.
+  //    Per-target `skills.exclude` from targets.json is applied here —
+  //    excluded names are dropped from the iteration, and entries that
+  //    don't match any profile-derived skill surface as a drift warning.
   const destSkills = path.join(claudeDir, 'skills');
   const skillStats = makeInstallStats();
   const divergences = opts.divergences || [];
-  for (const skillName of resolvedProfile.skills) {
+  const { filtered: filteredSkills, excluded: excludedSkills, missing: missingExcludes } =
+    applyTargetSkillsFilter(resolvedProfile.skills, opts.targetSkillsConfig);
+  for (const skillName of filteredSkills) {
     if (INTERNAL_SKILLS.has(skillName)) continue;
     const srcSkill = path.join(SKILLS_DIR, skillName);
     if (!fs.existsSync(srcSkill) || !fs.statSync(srcSkill).isDirectory()) continue;
@@ -661,7 +696,11 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   if (skillStats['skip-claimed']) preservedBreakdown.push(`${skillStats['skip-claimed']} user-claimed`);
   if (skillStats['skip-exists']) preservedBreakdown.push(`${skillStats['skip-exists']} non-md kept`);
   const skillNoOp = skillSummary.noOp ? `, ${skillSummary.noOp} unchanged` : '';
-  console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated)${skillNoOp}, ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}`);
+  const skillExcluded = excludedSkills.length ? `, ${excludedSkills.length} excluded by target config` : '';
+  console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated)${skillNoOp}, ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}${skillExcluded}`);
+  if (missingExcludes.length > 0) {
+    console.log(`  ⚠ targets.json skills.exclude entries with no matching profile-derived skill: ${missingExcludes.join(', ')}`);
+  }
 
   // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
@@ -940,6 +979,9 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
         console.log(`\n  Workspace "${ws.name}" profiles: ${wsProfiles.join(', ')}`);
       }
       const wsResolved = resolveProfile(wsProfiles, profilesConfig);
+      // `opts.targetSkillsConfig` carries across to workspaces by design — the
+      // targets.json entry describes the repo as a whole, so an `skills.exclude`
+      // applies to root and every workspace mirror within it.
       installForProfile(ws.path, wsResolved, `workspace: ${ws.name} [${wsProfiles.join(', ')}]`, opts);
 
       if (opts.copyWorkspaceDocs && rootResolved.templates.includes('specs')) {
@@ -1771,7 +1813,11 @@ function main() {
         continue;
       }
       const skipWorkspaces = target.workspaces === 'skip';
-      installTarget(targetPath, profilesConfig, { divergences, skipWorkspaces });
+      installTarget(targetPath, profilesConfig, {
+        divergences,
+        skipWorkspaces,
+        targetSkillsConfig: target.skills,
+      });
     }
 
     console.log('\nSync complete!\n');
@@ -1820,6 +1866,7 @@ function main() {
     copyWorkspaceDocs: true,
     divergences,
     skipWorkspaces,
+    targetSkillsConfig: matchingTarget?.skills,
   });
 
   // Global settings check

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -698,9 +698,11 @@ function installForProfile(targetDir, resolvedProfile, label, opts = {}) {
   const skillNoOp = skillSummary.noOp ? `, ${skillSummary.noOp} unchanged` : '';
   const skillExcluded = excludedSkills.length ? `, ${excludedSkills.length} excluded by target config` : '';
   console.log(`  ✓ Skills: ${skillSummary.written} written (${skillStats['write-new']} new / ${skillStats['write-update']} updated / ${skillStats['migrate']} migrated)${skillNoOp}, ${skillSummary.skipped} skipped${skillSummary.preserved ? `, ${preservedBreakdown.join(' / ')}` : ''}${skillExcluded}`);
-  if (missingExcludes.length > 0) {
-    console.log(`  ⚠ targets.json skills.exclude entries with no matching profile-derived skill: ${missingExcludes.join(', ')}`);
-  }
+  // The per-target drift warning for excludes that don't match any
+  // profile-derived skill is emitted once by installTarget() against the
+  // union of every profile in the target's scope (root + workspaces in
+  // monorepos). Emitting it here would fire spuriously for monorepo targets
+  // where an excluded skill appears in some profiles but not others.
 
   // 4. Install agents via the same protocol (agent files are single .md each)
   if (resolvedProfile.agents.length > 0) {
@@ -948,6 +950,17 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
   return missing;
 }
 
+// Emit a single `skills.exclude` drift warning for a target, scoped against the
+// union of every profile resolved during its install. In monorepo targets this
+// means root + every workspace — a skill that only lives in some of them is a
+// valid exclude, not drift.
+function emitTargetExcludeDriftWarning(unionedResolvedSkills, targetSkillsConfig) {
+  const { missing } = applyTargetSkillsFilter([...unionedResolvedSkills], targetSkillsConfig);
+  if (missing.length > 0) {
+    console.log(`  ⚠ targets.json skills.exclude entries with no matching profile-derived skill: ${missing.join(', ')}`);
+  }
+}
+
 function installTarget(targetDir, profilesConfig, opts = {}) {
   const detectedProfiles = detectProfiles(targetDir);
   if (opts.logProfiles) {
@@ -955,10 +968,14 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
   }
 
   const isMonorepo = detectedProfiles.includes('monorepo');
+  // Union of resolved skills across every profile in this target's scope.
+  // Drives the single per-target drift warning emitted at the end.
+  const unionedResolvedSkills = new Set();
 
   if (isMonorepo) {
     const rootProfileNames = detectedProfiles.filter(p => p !== 'monorepo').concat('monorepo-root');
     const rootResolved = resolveProfile(rootProfileNames, profilesConfig);
+    rootResolved.skills.forEach(s => unionedResolvedSkills.add(s));
     installForProfile(targetDir, rootResolved, `monorepo root [${rootProfileNames.join(', ')}]`, opts);
 
     // `workspaces: "skip"` in targets.json means this target treats only the
@@ -969,6 +986,7 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
       if (opts.logProfiles) {
         console.log(`\n  Skipping workspace harness install (targets.json: workspaces = "skip")`);
       }
+      emitTargetExcludeDriftWarning(unionedResolvedSkills, opts.targetSkillsConfig);
       return { detectedProfiles, isMonorepo, rootProfileNames };
     }
 
@@ -979,6 +997,7 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
         console.log(`\n  Workspace "${ws.name}" profiles: ${wsProfiles.join(', ')}`);
       }
       const wsResolved = resolveProfile(wsProfiles, profilesConfig);
+      wsResolved.skills.forEach(s => unionedResolvedSkills.add(s));
       // `opts.targetSkillsConfig` carries across to workspaces by design — the
       // targets.json entry describes the repo as a whole, so an `skills.exclude`
       // applies to root and every workspace mirror within it.
@@ -993,11 +1012,14 @@ function installTarget(targetDir, profilesConfig, opts = {}) {
       }
     }
 
+    emitTargetExcludeDriftWarning(unionedResolvedSkills, opts.targetSkillsConfig);
     return { detectedProfiles, isMonorepo, rootProfileNames };
   }
 
   const resolved = resolveProfile(detectedProfiles, profilesConfig);
+  resolved.skills.forEach(s => unionedResolvedSkills.add(s));
   installForProfile(targetDir, resolved, detectedProfiles.join(', '), opts);
+  emitTargetExcludeDriftWarning(unionedResolvedSkills, opts.targetSkillsConfig);
   return { detectedProfiles, isMonorepo };
 }
 


### PR DESCRIPTION
Closes #82.

Stacked on top of #85 (#83's cleanup). Picks 2.30 in the version files assuming #85 lands first. If #85 hasn't merged when this is ready, rebase will need to drop the 2.30 entry down to 2.29.

## Summary

- New per-target knob in `config/targets.json`: `{ "skills": { "exclude": ["a", "b"] } }`. Named skills get dropped from the profile-resolved install set before the install loop iterates. Plugins, agents, templates, and hooks are untouched.
- New helper `applyTargetSkillsFilter()` in `scripts/configure-claude.js` — pure function returning `{ filtered, excluded, missing }`. Drops non-string entries defensively.
- Install log appends `, N excluded by target config` to the `✓ Skills:` line when the filter fires. Unmatched entries surface as a separate `⚠ targets.json skills.exclude entries with no matching profile-derived skill: <names>` warning — same drift-detection style as the `validateProfilesConfig()` warning added in #81.
- Plumbed through both call sites (`--sync` loop and single-target invocation) → `installTarget` opts → `installForProfile` opts. Workspace mirrors inherit the same filter — target entries describe the repo as a whole.
- `config/targets.example.json` gains a `_skills_comment` and an example entry. `CLAUDE.md` Key file locations row rewritten to cover both `workspaces` and `skills.exclude`.
- `--only` mode is unaffected. Explicit skill lists always win.

## Why

The harness was binary: accept the full profile-resolved set, or post-install `rm -rf .claude/skills/<name>` and pull the target out of `config/targets.json` to stop `--sync` from resurrecting them. For small or single-purpose targets (this surfaced applying the harness to `verity-v2-landing`, a Tailwind landing page that only needs ~12 of the ~25 frontend-profile skills), neither was right. `--only` exists but skips hooks/plugins/settings entirely.

Adding a per-target exclude knob preserves the profile system as the source of truth (auto-detection stays unchanged) and lets the target file express small curation deltas without forking profiles. The drift warning catches typos and skill renames the next time sync runs — same shape as #81's profile-vs-disk drift check.

## Test plan

- [x] Unit (9 cases for `applyTargetSkillsFilter`): undefined config, empty config, empty exclude, normal exclude, multi exclude, typo / drift only, mixed match+typo, exclude all, non-array exclude — all pass.
- [x] Integration: temporary `{ path: '/tmp/test-82-target', skills: { exclude: ['plan', 'review', 'totally-nonexistent-skill'] } }` entry, ran installer. Output: `✓ Skills: 31 written … 2 excluded by target config` + `⚠ targets.json skills.exclude entries with no matching profile-derived skill: totally-nonexistent-skill`. Filesystem confirmed `plan/` and `review/` not written; `ship/` etc. were. targets.json restored from backup; /tmp cleaned up.
- [x] Re-validated on the rebased branch after #81 landed on main (skill count rose to 31 from #81's profile additions).
- [x] `node -c scripts/configure-claude.js` — syntax OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-target skill exclusion: specify skills to skip during installation; excluded skills are omitted, install summary shows how many were skipped, unmatched excludes surface drift warnings, `--only` mode bypasses the filter, and explicit skill lists override exclusions.

* **Documentation**
  * Bumped version to 2.30 and updated docs and examples to show per-target skill exclusion usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ckallum/calsuite/pull/86)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->