### PR TITLE
chore: re-sync .claude/skills to current source

### DIFF
--- a/.claude/skills/receiving-pr-feedback/SKILL.md
+++ b/.claude/skills/receiving-pr-feedback/SKILL.md
@@ -1,4 +1,5 @@
 ---
+_origin: calsuite@88c2320
 name: receiving-pr-feedback
 version: 1.0.0
 description: |
@@ -57,9 +58,6 @@ Watch progress in the tmux panes. This instance is done.
 If a PR number is in `$ARGUMENTS`, fetch ALL comment types:
 
 ```bash
-# Derive owner/repo for gh api calls:
-# gh repo view --json nameWithOwner --jq '.nameWithOwner'
-
 # Issue-level comments (general PR discussion, including /review bot comments)
 gh pr view <number> --comments --json comments,reviews,reviewDecision
 
@@ -165,7 +163,7 @@ gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment-id>/replies -f body
 
 ## Step 4.5: Update PR Description
 
-After fixes are applied and commits pushed, update the PR description to reflect the current state. Both `/ship` (Step 8) and this skill follow the same PR body structure defined in `skills/ship/pr-template.md`.
+After fixes are applied and commits pushed, update the PR description to reflect the current state. Both `/ship` (Step 8) and this skill follow the same PR body structure defined in `.claude/skills/ship/pr-template.md`.
 
 ### Compute summary data first
 
@@ -192,14 +190,14 @@ Split the body on `^## ` at line start (regex). This yields:
 
 Identify sections by header name. Known sections: Summary, How It Works, Important Files, Test Results, Pre-Landing Review, Development Flow, Doc Completeness, Revision History. Unknown sections are preserved in their original position.
 
-Reference implementation: `.claude/scripts/lib/pr-body-parser.cjs` (parsePrBody / assemblePrBody).
+Reference implementation: `.claude/scripts/lib/pr-body-parser.cjs` (parsePrBody / assemblePrBody). Path is relative to the target project's `.claude/` directory — the installer places calsuite's `scripts/lib/` there. In calsuite itself, the source file lives at `scripts/lib/pr-body-parser.cjs`.
 
 **c. Regenerate dynamic sections:**
 
 - **Summary**: Analyze all commits on the branch (`git log origin/main..HEAD --oneline`) and generate updated bullet points summarizing what shipped.
 - **Important Files**: Run `git diff origin/main --stat` and rebuild the file/change table matching the format in `pr-template.md`.
 - **Test Results**: Re-run the project's test suites and rebuild the results table. Omit suites that weren't run.
-- **Development Flow**: If `.claude/flow-trace-*.jsonl` exists, regenerate the Mermaid diagram. If no trace file exists, skip this section entirely.
+- **Development Flow**: If `.claude/flow-trace-${CLAUDE_SESSION_ID:-unknown}.jsonl` exists, regenerate the Mermaid diagram. If no trace file exists, skip this section entirely. The `:-unknown` fallback matches the default used by calsuite's session-scoped trackers when `CLAUDE_SESSION_ID` is unset.
 
 **d. Preserve static sections as-is (do not regenerate):**
 
@@ -221,21 +219,22 @@ If a `## Revision History` section exists, append to it. If not, create it after
 - Questions answered: Z comments
 ```
 
-Round number = count of existing `**Round N**` entries + 1. Date = today's date.
+Round number = count of lines in the Revision History section matching the anchored regex `^\*\*Round \d+\*\*` (line start, literal `**Round `, one or more digits, literal `**`), plus 1. This avoids false matches inside prose or HTML comments. Date = today's date.
 
 **f. Update the PR:**
 
-Reassemble the body from the parsed/modified sections, write to a temp file, and update:
+Reassemble the body from the parsed/modified sections, then write it to a temp file and update the PR. Use the `Write` tool to write the assembled body — this avoids heredoc sentinel collisions (a PR body can legitimately contain a line that is literally `EOF`, which would terminate a `<<'EOF'` heredoc early):
 
 ```bash
-tmp_body_file="$(mktemp)"
-trap 'rm -f "$tmp_body_file"' EXIT
-cat >"$tmp_body_file" <<'EOF'
-<reassembled body>
-EOF
-gh pr edit <number> --body-file "$tmp_body_file"
-trap - EXIT
-rm -f "$tmp_body_file"
+# 1. Create the temp file path
+tmp_body="$(mktemp)"
+trap 'rm -f "$tmp_body"' EXIT
+
+# 2. Write the reassembled body to $tmp_body using the Write tool
+#    (not a shell heredoc — sentinels can collide with body content)
+
+# 3. Update the PR from the file
+gh pr edit <number> --body-file "$tmp_body"
 ```
 
 ## Step 5: Summary

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,5 +1,5 @@
 ---
-_origin: calsuite@88c2320
+_origin: calsuite@fe64414
 name: ship
 version: 1.0.0
 description: |
@@ -84,7 +84,7 @@ git push -u origin $(git branch --show-current)
 
 Run the Pre-PR Gates from **Step 7.4** (PR-size, test-presence, spec-contract) before drafting the body. Even in pr-only mode, these gates surface useful warnings — the test-presence gate typically stays silent on docs/config changes because it only warns when `code_additions > 50`. Spec-contract still applies if the repo has active specs.
 
-Read the PR body template at `skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
+Read the PR body template at `.claude/skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
 
 Run **Step 8.5** (PR-claim-vs-diff grep) against the drafted body before calling `gh pr create`.
 
@@ -342,7 +342,7 @@ fi
 ```
 
 If `added > 400`, emit:
-```
+```text
 ⚠ PR size: <N> lines added. Large PRs get surface-level reviews.
   Top files:
     <N1> lines  <path1>
@@ -376,7 +376,7 @@ code_additions=$(git diff origin/main -- \
 ```
 
 If `code_additions > 50` AND `new_tests == 0`, emit:
-```
+```text
 ⚠ Test-presence: <N> lines of code added, zero new tests.
   Code-only files (no tests alongside):
     <list of non-test files with net-positive additions>
@@ -403,7 +403,7 @@ fi
 
 For each critical glob, check whether any diff file matches it (use the same glob-matching logic as `lint-gate.cjs`). If a critical path is touched AND `new_tests == 0`, emit a strong warning that cites the matching glob:
 
-```
+```text
 ⚠ Test-presence (STRICT): critical path touched without tests.
   Matched glob: <glob pattern>
   Files: <matching files from diff>
@@ -433,7 +433,7 @@ Flag two classes:
   - **EXTRA:** diff introduces behavior (new command handler, new event emitter, new persisted field) not described anywhere in `design.md`.
 
 For each deviation, use AskUserQuestion individually:
-```
+```text
 <Deviation description — what the spec says vs what the diff does>
 
 Recommendation: [A or B, lead with your pick and 1-sentence reason]
@@ -484,7 +484,7 @@ If the trace file is missing or empty, skip the `## Development Flow` section en
 
 ## Step 8: Draft PR body
 
-Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
+Read the PR body template at `.claude/skills/ship/pr-template.md` and follow its structure exactly.
 
 Populate each section:
 - **Summary** — bullet points from CHANGELOG entries (what shipped)
@@ -519,7 +519,7 @@ Before creating the PR, cross-check the drafted body against the actual diff. Th
    ```
 
 3. If any claims are missing from the diff, surface them above the PR body draft:
-   ```
+   ```text
    ⚠ PR body claims not found in diff:
      - `hydrated_from_storage`  — mentioned in Summary, not in any changed file
      - `session-hydrate-degraded` — mentioned in How It Works, not emitted anywhere

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,4 +1,5 @@
 ---
+_origin: calsuite@88c2320
 name: ship
 version: 1.0.0
 description: |
@@ -59,13 +60,33 @@ EOF
 
 Use `docs:` for documentation, `chore:` for config/skills, `style:` for formatting. If there are already commits on the branch and no uncommitted changes, skip this step.
 
-### Step 3: Push and create PR
+### Step 2.5: Sweep and fix PR-introduced bugs inline
+
+Even in pr-only mode, scan the conversation for **bugs in code this branch is changing**. PR-only mode skips tests, review, and simplification — but it must NOT skip the rule that bugs introduced by the PR get fixed in the PR.
+
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Review the conversation for any minor bugs, TODOs, edge cases, or rough edges that surfaced during the work. For each candidate, check whether it touches `CHANGED_FILES`:
+
+- **If yes and it's a bug:** fix it now, stage, commit (`git commit -m "fix: <what>"`). No exceptions.
+- **If yes and it's an enhancement/cleanup:** default to fixing inline unless it would meaningfully grow the PR.
+- **If no:** defer to Step 4 (the post-PR `/sweep-issues` call will create the issue).
+
+Skip this step silently if no candidates surfaced.
+
+### Step 3: Push, run Pre-PR Gates, create PR
 
 ```bash
 git push -u origin $(git branch --show-current)
 ```
 
-Read the PR body template at `skills/ship/pr-template.md`. Create the PR following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits).
+Run the Pre-PR Gates from **Step 7.4** (PR-size, test-presence, spec-contract) before drafting the body. Even in pr-only mode, these gates surface useful warnings — the test-presence gate typically stays silent on docs/config changes because it only warns when `code_additions > 50`. Spec-contract still applies if the repo has active specs.
+
+Read the PR body template at `skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
+
+Run **Step 8.5** (PR-claim-vs-diff grep) against the drafted body before calling `gh pr create`.
 
 **Output the PR URL.**
 
@@ -249,61 +270,207 @@ git push -u origin $(git branch --show-current)
 
 ---
 
-## Step 8: Sweep and Fix Inline
+## Step 7.2: Sweep and Fix Inline
 
-**Before** creating the PR, scan the conversation for deferred items, fast-follows, minor bugs, enhancements, and tech debt — the same categories `/sweep-issues` looks for.
+**Before** running Pre-PR Gates, scan the conversation for deferred items, fast-follows, minor bugs, enhancements, and tech debt — the same categories `/sweep-issues` looks for. Fix anything coherent with the current PR; defer the rest to Step 9.
 
-### 8a: Gather candidates
+### 7.2a: Gather candidates and capture the diff file list
 
-Review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description and its source.
+First, capture the canonical list of files this branch touches — every later triage decision is grounded against it:
 
-### 8b: Triage — fix now vs. create issue
+```bash
+git diff origin/main --name-only > /tmp/ship-changed-files.txt
+```
+
+Hold the contents as `CHANGED_FILES`. Then review the conversation for deferred work, TODOs, edge cases, minor bugs, and improvements. For each item, note a one-line description, its source (conversation turn, review finding, etc.), and **the file(s) it relates to** if known.
+
+### 7.2b: Triage — fix now vs. create issue
+
+For each candidate, first check whether it touches `CHANGED_FILES`. **If it does, default to "fix now"** — the reviewer is going to see those files anyway, and any bug, TODO, or rough edge in them belongs in the same PR. Only override the default if the user explicitly confirms the issue is pre-existing and out of scope.
 
 Classify each candidate:
 
 | Fix now (inline) | Create issue (later) |
 |---|---|
-| Minor bug in code touched by this PR | Feature request unrelated to this PR |
-| Missing edge case in a function this PR added/modified | Large refactor spanning multiple files not in this diff |
-| TODO/FIXME left in files changed by this PR | Work that requires design discussion |
-| Small enhancement coherent with the PR's purpose | Performance optimization with unclear scope |
-| Cleanup in files already being modified | Anything that would change the PR's scope significantly |
+| **Anything touching a file in `CHANGED_FILES`** (default) | Feature request unrelated to this PR |
+| Minor bug in code touched by this PR | Large refactor spanning multiple files not in this diff |
+| Missing edge case in a function this PR added/modified | Work that requires design discussion |
+| TODO/FIXME left in files changed by this PR | Performance optimization with unclear scope |
+| Small enhancement coherent with the PR's purpose | Anything that would change the PR's scope significantly |
+| Cleanup in files already being modified | Pre-existing bug in a file this PR doesn't touch |
 
-**The test:** "Would a reviewer expect this to be part of this PR?" If yes → fix now. If no → create issue.
+**The test:** "Would a reviewer expect this to be part of this PR?" If the candidate's file is in `CHANGED_FILES`, the answer is almost always yes — fix now. If no → create issue.
 
-### 8c: Apply inline fixes
+**Bugs introduced by this PR are never deferrable.** If a candidate is a bug AND its file is in `CHANGED_FILES`, fix it inline. Do not move it to the "create issue" column even if the user requested deferring something else.
+
+### 7.2c: Apply inline fixes
 
 For each "fix now" item:
 1. Make the fix
 2. Stage it: `git add <files>`
 3. Commit: `git commit -m "fix: <what was fixed>"`
 
-### 8d: Re-run tests if fixes were applied
+### 7.2d: Re-run tests if fixes were applied
 
 If any inline fixes were made, re-run the test suites from Step 3 to verify no regressions. If tests fail, fix the failure before proceeding.
 
-### 8e: Push inline fixes
+### 7.2e: Push inline fixes
 
 If new commits were created:
 ```bash
 git push
 ```
 
+### 7.2f: Hand off deferred items
+
+Record the "create issue" candidates from 7.2b as `DEFERRED_ITEMS` — Step 9 will turn them into GitHub issues. Do not create the issues now (the PR should be open first, so issues can cross-link it).
+
 ---
 
-## Step 9: Create PR
+## Step 7.4: Pre-PR Gates
 
-Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
+Before drafting the PR body, run three cheap grep/glob-based gates against the diff, then collect their output. These gates **warn but do not block** by default — surface context so the user can either proceed with intent or pause to address. Each gate runs independently; collect all outputs and show them together before Step 8.
 
-### Generate Development Flow diagram
-
-Before creating the PR, check if a flow trace file exists for this session and is non-empty:
+### Gate 1 — PR-size warning
 
 ```bash
-test -s "${CLAUDE_PROJECT_DIR:-.}/.claude/flow-trace-${CLAUDE_SESSION_ID}.jsonl"
+added=$(git diff origin/main --shortstat | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo 0)
+if [ "${added:-0}" -gt 400 ]; then
+  # Identify the top files dominating the diff
+  git diff origin/main --numstat | awk '{print $1 + $2, $3}' | sort -rn | head -5
+fi
 ```
 
-If the file exists and is non-empty, parse the JSONL entries and generate a Mermaid `flowchart TD` diagram following the same rules as the `/flow` skill:
+If `added > 400`, emit:
+```
+⚠ PR size: <N> lines added. Large PRs get surface-level reviews.
+  Top files:
+    <N1> lines  <path1>
+    <N2> lines  <path2>
+  Suggest: split on commit boundaries —
+    git log origin/main..HEAD --oneline
+  Each commit is already a logical split point. Consider shipping one per PR.
+```
+Do NOT block. The user decides.
+
+### Gate 2 — Test-presence gate
+
+**Universal heuristic (always runs):**
+```bash
+# Count new test functions across all languages in the diff
+diff=$(git diff origin/main)
+new_tests=$(echo "$diff" | grep -cE '^\+\s*(#\[(test|tokio::test|rstest)\]|\btest\(|\bit\(|def\s+test_|func\s+Test[A-Z]|it\s+[\x27"])' || true)
+
+# Count substantive code additions in non-test, non-docs, non-config files
+code_additions=$(git diff origin/main -- \
+  ':(exclude)**/*.test.*' \
+  ':(exclude)**/*.spec.*' \
+  ':(exclude)**/tests/**' \
+  ':(exclude)**/__tests__/**' \
+  ':(exclude)**/migrations/**' \
+  ':(exclude)docs/' \
+  ':(exclude).github/' \
+  ':(exclude)*.md' \
+  ':(exclude)*.json' \
+  | grep -cE '^\+[^+]' || true)
+```
+
+If `code_additions > 50` AND `new_tests == 0`, emit:
+```
+⚠ Test-presence: <N> lines of code added, zero new tests.
+  Code-only files (no tests alongside):
+    <list of non-test files with net-positive additions>
+  If this is intentional (refactor, config, docs), proceed. Otherwise consider
+  adding tests before shipping.
+```
+
+**Optional strict mode (per-repo):**
+```bash
+# Check for .claude/ship-config.json at the repo root
+if [ -f .claude/ship-config.json ]; then
+  critical_globs=$(node -e '
+    try {
+      const c = require(process.cwd() + "/.claude/ship-config.json");
+      if (Array.isArray(c.criticalPaths)) console.log(c.criticalPaths.join("\n"));
+    } catch {}
+  ')
+  strict=$(node -e '
+    try { console.log(!!require(process.cwd() + "/.claude/ship-config.json").strict); }
+    catch { console.log("false"); }
+  ')
+fi
+```
+
+For each critical glob, check whether any diff file matches it (use the same glob-matching logic as `lint-gate.cjs`). If a critical path is touched AND `new_tests == 0`, emit a strong warning that cites the matching glob:
+
+```
+⚠ Test-presence (STRICT): critical path touched without tests.
+  Matched glob: <glob pattern>
+  Files: <matching files from diff>
+  No new tests detected in this PR.
+```
+
+If `strict: true` in ship-config.json, this blocks. Otherwise surface and continue.
+
+### Gate 3 — Spec-contract deviation
+
+Detect the active spec the same way `/review` Agent I does:
+```bash
+branch=$(git branch --show-current)
+slug=$(echo "$branch" | sed -E 's#^(feat|fix|chore|refactor|feature)/##')
+SPEC_DIR=""
+[ -d ".claude/specs/$slug" ] && SPEC_DIR=".claude/specs/$slug"
+[ -z "$SPEC_DIR" ] && SPEC_DIR=$(find .claude/specs -mindepth 1 -maxdepth 2 -name design.md -exec dirname {} \; 2>/dev/null | head -1)
+```
+
+If `$SPEC_DIR` is non-empty:
+1. Read `$SPEC_DIR/design.md` and `$SPEC_DIR/tasks.md`.
+2. For each named symbol/field/event/task in these files, grep the diff.
+3. For each unchecked task in `tasks.md`, check whether the diff plausibly addresses it.
+
+Flag two classes:
+  - **MISSING:** spec promises a specific symbol/event/task, diff does not contain it.
+  - **EXTRA:** diff introduces behavior (new command handler, new event emitter, new persisted field) not described anywhere in `design.md`.
+
+For each deviation, use AskUserQuestion individually:
+```
+<Deviation description — what the spec says vs what the diff does>
+
+Recommendation: [A or B, lead with your pick and 1-sentence reason]
+
+A) Remediate: bring the diff back to the spec before shipping.
+B) Update spec: mark the outdated bullet in design.md/tasks.md with strikethrough
+   (~~old text~~) and append an **Addendum** under the same section describing
+   the current implementation path. Then ship.
+C) Dismiss: not a real deviation.
+```
+
+If the user picks B, apply the edit to `design.md` and/or `tasks.md` using the following pattern — preserve the original bullet (struck through) and add a dated addendum directly beneath it:
+
+```markdown
+- ~~Original task/bullet text~~
+  - **Addendum (YYYY-MM-DD):** <current implementation path — what was built
+    instead, and why (1-2 sentences)>.
+```
+
+Stage the spec edit alongside the PR commits. Skip this gate silently if `$SPEC_DIR` is empty.
+
+### Output collection
+
+Collect the output of Gates 1-3 as `PRE_PR_GATE_FINDINGS`. These will be surfaced in the PR body (below the Summary section, above How It Works) and in the user-facing console output before Step 8. If every gate passes cleanly, `PRE_PR_GATE_FINDINGS` is empty and nothing is added to the PR body.
+
+---
+
+## Step 7.5: Generate Development Flow diagram
+
+Before creating the PR, check if a flow trace file exists for this session and is non-empty. Use the `:-unknown` fallback so the path still resolves when `CLAUDE_SESSION_ID` is unset (matching the convention used by calsuite's other session-scoped trackers, e.g. `skill-usage-tracker.cjs`):
+
+```bash
+session_id="${CLAUDE_SESSION_ID:-unknown}"
+test -s ".claude/flow-trace-${session_id}.jsonl"
+```
+
+If the file exists and is non-empty, read and parse the JSONL entries and generate a Mermaid `flowchart TD` diagram following the same rules as the `/flow` skill:
 - Skill nodes: `S1(skill-name)`, Agent nodes: `A1{{agent-type: description}}`
 - Sequential entries get `-->` edges
 - Parallel detection: entries within 1s of each other from same predecessor = fan-out
@@ -313,32 +480,81 @@ This diagram will be inserted as a `## Development Flow` section in the PR body 
 
 If the trace file is missing or empty, skip the `## Development Flow` section entirely — no error, no placeholder.
 
-### Populate the PR body
+---
+
+## Step 8: Draft PR body
+
+Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
 
 Populate each section:
-- **Summary** — bullet points from CHANGELOG entries (what shipped). Include any inline fixes from Step 8 in the summary.
+- **Summary** — bullet points from CHANGELOG entries (what shipped)
+- **Pre-PR Gates** — findings from Step 7.4 (omit section entirely if no findings)
 - **How It Works** — Mermaid diagram for non-trivial PRs (skip for < 50 lines, config-only, docs-only)
 - **Development Flow** — Mermaid diagram from flow trace (insert after How It Works, before Important Files). Only include if trace data exists.
 - **Important Files** — table of key files with one-line descriptions
-- **Test Results** — table from Step 3 (or re-run from Step 8d)
+- **Test Results** — table from Step 3
 - **Pre-Landing Review** — findings from Step 4.5, or "No issues found."
 - **Doc Completeness** — checklist
 
-Create the PR using `gh pr create` with a HEREDOC body. **Output the PR URL.**
+Hold the drafted body as `PR_BODY_DRAFT` — do NOT call `gh pr create` yet. Step 8.5 verifies the body against the diff.
 
 ---
 
-## Step 10: Create Issues for Remaining Items
+## Step 8.5: PR-claim-vs-diff grep
 
-For any candidates from Step 8b that were triaged as "create issue", invoke `/sweep-issues` to create GitHub issues. Pass context so it doesn't re-scan — it should create issues only for the deferred items, not re-discover them.
+Before creating the PR, cross-check the drafted body against the actual diff. The goal is to catch "promised-but-not-delivered" claims — PR bodies that mention symbols, fields, or events that never appear in the changes.
+
+1. Extract claims from `PR_BODY_DRAFT`. A claim is any identifier wrapped in backticks that names code:
+   - Type/struct names (e.g. `` `SessionDetail` ``)
+   - Field/key names (e.g. `` `hydrated_from_storage` ``)
+   - Event names (e.g. `` `session-hydrate-degraded` ``)
+   - Function/method names (e.g. `` `open_session()` ``)
+   - Constants (e.g. `` `MAX_RETRY_COUNT` ``)
+
+   Skip claims that are obviously not symbols: English prose in backticks, file paths, shell commands, or package names.
+
+2. For each extracted claim, grep the diff:
+   ```bash
+   git diff origin/main | grep -F "<claim>" >/dev/null || echo "MISSING: <claim>"
+   ```
+
+3. If any claims are missing from the diff, surface them above the PR body draft:
+   ```
+   ⚠ PR body claims not found in diff:
+     - `hydrated_from_storage`  — mentioned in Summary, not in any changed file
+     - `session-hydrate-degraded` — mentioned in How It Works, not emitted anywhere
+
+   Options:
+     A) Edit PR body to remove the claim(s)
+     B) Edit the code to actually deliver the claim(s)
+     C) Dismiss — the claim is correct, grep missed it (explain why)
+   ```
+
+   Use AskUserQuestion for each missing claim individually.
+
+4. If no claims are missing, proceed silently.
+
+---
+
+## Step 8.6: Create PR
+
+Create the PR using `gh pr create` with `PR_BODY_DRAFT` passed via HEREDOC. **Output the PR URL.**
+
+---
+
+## Step 9: Create Issues for Deferred Items
+
+After the PR is created, turn the `DEFERRED_ITEMS` list from Step 7.2b into GitHub issues. The triage already happened — `/sweep-issues` only needs to create the issues.
 
 ```text
 skill: "sweep-issues"
 args: ""
 ```
 
-**If no deferred items remain:** Skip silently — the PR URL is the final output.
-**If items remain:** Create the issues and output the sweep summary. The PR URL remains the last line of output.
+`/sweep-issues` re-scans the conversation as a safety net in case new items emerged after Step 7.2 (e.g. from Step 4.5 review or the claim-grep in 8.5). It deduplicates against the `DEFERRED_ITEMS` list and against existing GitHub issues.
+
+**If nothing remains to defer:** Continue silently — the PR URL is the final output.
+**If items found:** Create the issues and output the sweep summary. The PR URL remains the last line of output.
 
 ---
 
@@ -349,7 +565,11 @@ args: ""
 - **Simplify runs BEFORE review** so the review stamp covers the final code state. Don't reorder Steps 4 and 4.5.
 - **`git push` may fail if the branch was force-pushed elsewhere.** Never force push to recover — ask the user.
 - **CHANGELOG auto-generation reads all commits on the branch** — if prior commits have bad messages, the CHANGELOG entries will be vague.
-- **`/ship pr` skips ALL safety checks** (tests, review, simplification). Only use for genuinely low-risk changes. If in doubt, use `/ship`.
+- **`/ship pr` skips the heavy safety checks** (full test suite, simplification, Pre-Landing Review, CHANGELOG generation, commit splitting) but still runs the cheap ones: the Step 2.5 PR-introduced-bug sweep, the Pre-PR Gates from Step 7.4 (PR-size, test-presence, spec-contract), and the PR-claim-vs-diff grep (Step 8.5). Use for genuinely low-risk changes (docs, config, skills); if in doubt, use `/ship`.
+- **Pre-PR Gates (Step 7.4) warn but do not block** unless `.claude/ship-config.json` sets `strict: true`. They surface context about the diff shape — large PRs, no-test diffs, spec deviations — but the user always has the final word.
+- **`.claude/ship-config.json` is optional and per-repo.** Keys: `criticalPaths: [glob, ...]` for strict test-presence on sensitive files, `strict: true` to promote the strict warning into a block. Only the test-presence gate reads this file — size, spec-contract, and claim-grep gates run unconditionally.
+- **PR-claim-vs-diff grep (Step 8.5) uses literal string search.** A claim is missing if `grep -F` doesn't find it in the full diff. If the code renamed a symbol that the PR body still references, the grep correctly flags it.
+- **Spec-contract deviation (Gate 3) mutates `design.md`/`tasks.md`** when the user picks option B (strikethrough + addendum). Those edits get staged with the shipping commits — review them before pushing.
 
 ## Important Rules
 

--- a/.claude/skills/ship/pr-template.md
+++ b/.claude/skills/ship/pr-template.md
@@ -1,15 +1,19 @@
+---
+_origin: calsuite@88c2320
+---
+
 # PR Body Template
 
-Shared template for PR creation across skills (`/ship`, `/receiving-pr-feedback`, parallel agents).
+Shared template for PR creation across skills (`/ship`, `/execute`, `/receiving-pr-feedback`, parallel agents).
 
 ## Usage
 
-This is the canonical PR body structure. Both `/ship` (Step 8) and `/receiving-pr-feedback` (Step 4.5) follow this format.
+This is the canonical PR body structure. Both `/ship` (Steps 8 draft + 8.6 create) and `/receiving-pr-feedback` (Step 4.5) follow this format.
 
 - **On initial PR creation** (`/ship`): all sections are generated fresh from the current branch state.
 - **After feedback rounds** (`/receiving-pr-feedback`): dynamic sections (Summary, Important Files, Test Results, Development Flow) are regenerated to reflect fixes. Static sections (How It Works, Pre-Landing Review, Doc Completeness) are preserved as-is. A Revision History section is appended with per-round summaries.
 
-Parser utility: `.claude/scripts/lib/pr-body-parser.cjs` provides `parsePrBody` / `assemblePrBody` for splitting and reassembling the body by `## ` headers.
+Parser utility: `.claude/scripts/lib/pr-body-parser.cjs` provides `parsePrBody` / `assemblePrBody` for splitting and reassembling the body by level-2 headers. The `.claude/` prefix is the runtime path inside target projects (where the installer places calsuite's `scripts/lib/`). In calsuite itself the source file lives at `scripts/lib/pr-body-parser.cjs`.
 
 ## Title Format
 
@@ -26,6 +30,11 @@ Parser utility: `.claude/scripts/lib/pr-body-parser.cjs` provides `parsePrBody` 
 ```markdown
 ## Summary
 <1-5 bullet points describing what shipped — derived from CHANGELOG or commit history>
+
+## Pre-PR Gates
+<Findings from Step 7.4 pre-PR gates: size warning, test-presence, spec-contract.
+Omit this section entirely when all gates pass cleanly. Only include when there
+is at least one non-silent finding.>
 
 ## How It Works
 <Mermaid diagram showing the key flow introduced or changed>
@@ -75,17 +84,25 @@ Omit suites that weren't run (e.g., no backend changes = no backend tests).
 - [ ] CLAUDE.md updated (if conventions/structure changed)
 - [ ] tasks.md updated (if working on a spec)
 
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Feedback-round additions
+
+The initial PR body created by `/ship` ends at the Doc Completeness section — **do not** include a Revision History heading on initial creation. An empty heading would survive `parsePrBody` and render as an empty section in the PR UI.
+
+`/receiving-pr-feedback` (Step 4.5) appends a Revision History section only after a feedback round has actually run. The format it uses:
+
+```markdown
 ## Revision History
-<!-- Omit this section on initial PR creation. Only appended by /receiving-pr-feedback. -->
-<!-- Example format (do not copy literally):
+
 **Round 1** (YYYY-MM-DD):
 - Accepted: X comments — brief list of key changes
 - Pushed back: Y comments
 - Questions answered: Z comments
--->
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
+
+Subsequent rounds append new `**Round N**` blocks to the existing `## Revision History` section (round number is the count of existing anchored `^\*\*Round \d+\*\*` matches + 1).
 
 ## gh pr create Example
 

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -83,7 +83,7 @@ git push -u origin $(git branch --show-current)
 
 Run the Pre-PR Gates from **Step 7.4** (PR-size, test-presence, spec-contract) before drafting the body. Even in pr-only mode, these gates surface useful warnings — the test-presence gate typically stays silent on docs/config changes because it only warns when `code_additions > 50`. Spec-contract still applies if the repo has active specs.
 
-Read the PR body template at `skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
+Read the PR body template at `.claude/skills/ship/pr-template.md`. Draft the PR body following the template structure, but omit Test Results and Pre-Landing Review sections (not applicable in pr-only mode). Skip diagrams for trivial changes (< 50 lines, single-file edits). If any Pre-PR Gate produced findings, include them below Summary as a `## Pre-PR Gates` section.
 
 Run **Step 8.5** (PR-claim-vs-diff grep) against the drafted body before calling `gh pr create`.
 
@@ -341,7 +341,7 @@ fi
 ```
 
 If `added > 400`, emit:
-```
+```text
 ⚠ PR size: <N> lines added. Large PRs get surface-level reviews.
   Top files:
     <N1> lines  <path1>
@@ -375,7 +375,7 @@ code_additions=$(git diff origin/main -- \
 ```
 
 If `code_additions > 50` AND `new_tests == 0`, emit:
-```
+```text
 ⚠ Test-presence: <N> lines of code added, zero new tests.
   Code-only files (no tests alongside):
     <list of non-test files with net-positive additions>
@@ -402,7 +402,7 @@ fi
 
 For each critical glob, check whether any diff file matches it (use the same glob-matching logic as `lint-gate.cjs`). If a critical path is touched AND `new_tests == 0`, emit a strong warning that cites the matching glob:
 
-```
+```text
 ⚠ Test-presence (STRICT): critical path touched without tests.
   Matched glob: <glob pattern>
   Files: <matching files from diff>
@@ -432,7 +432,7 @@ Flag two classes:
   - **EXTRA:** diff introduces behavior (new command handler, new event emitter, new persisted field) not described anywhere in `design.md`.
 
 For each deviation, use AskUserQuestion individually:
-```
+```text
 <Deviation description — what the spec says vs what the diff does>
 
 Recommendation: [A or B, lead with your pick and 1-sentence reason]
@@ -483,7 +483,7 @@ If the trace file is missing or empty, skip the `## Development Flow` section en
 
 ## Step 8: Draft PR body
 
-Read the PR body template at `skills/ship/pr-template.md` and follow its structure exactly.
+Read the PR body template at `.claude/skills/ship/pr-template.md` and follow its structure exactly.
 
 Populate each section:
 - **Summary** — bullet points from CHANGELOG entries (what shipped)
@@ -518,7 +518,7 @@ Before creating the PR, cross-check the drafted body against the actual diff. Th
    ```
 
 3. If any claims are missing from the diff, surface them above the PR body draft:
-   ```
+   ```text
    ⚠ PR body claims not found in diff:
      - `hydrated_from_storage`  — mentioned in Summary, not in any changed file
      - `session-hydrate-degraded` — mentioned in How It Works, not emitted anywhere


### PR DESCRIPTION
## Summary
- Re-syncs calsuite-self's installed skill copies (`ship`, `receiving-pr-feedback`, `ship/pr-template`) to match source `skills/` at HEAD
- Pure installer output — content matches modulo the `_origin: calsuite@88c2320` stamp; no manual edits
- Captures the state `node scripts/configure-claude.js .` produces, so cloning calsuite yields a calsuite-self install matching HEAD without re-running the installer

## Why
Calsuite is intentionally absent from `config/targets.json` (it is the source, not a downstream), so the post-commit auto-sync skips calsuite-self. The installed `.claude/skills/` copies drifted behind `skills/` after recent ship/receiving-pr-feedback updates landed; this commit catches them up.

## Test plan
- [ ] `diff <(git show HEAD:skills/ship/SKILL.md) <(grep -v '^_origin:' .claude/skills/ship/SKILL.md)` is empty
- [ ] Same check passes for `receiving-pr-feedback/SKILL.md` and `ship/pr-template.md`
- [ ] No unrelated files in the diff

## Revision History

**Round 1** (2026-05-22):
- Accepted: 2 comments — normalized `pr-template.md` references to `.claude/skills/ship/pr-template.md` (lines 86 + 486 of source), added `text` language label to five fenced sample-output blocks (PR-size, test-presence, test-presence STRICT, deviation prompt, PR-claim-vs-diff) for markdownlint MD040 compliance. Applied in both source `skills/` and installed `.claude/skills/` in lockstep via the installer ([0e177a4](https://github.com/ckallum/calsuite/commit/0e177a4)).
- Pushed back: 0 comments
- Questions answered: 0 comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline bug/TODO scanning and auto-fixing during shipping workflows
  * Introduced pre-PR validation gates including test presence checks and spec-contract deviation detection
  * Added development flow diagram generation for session tracing

* **Improvements**
  * Enhanced PR body structure with new Pre-PR Gates section and clearer revision history tracking
  * Strengthened PR body verification to ensure claimed features match actual code changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ckallum/calsuite/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
