### PR TITLE
fix(installer): stop prepending duplicate _origin on placeholder frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 All notable changes to this repository.
 
-Current version: **2.32**
+Current version: **2.33**
+
+## [2.33] — 2026-05-24
+
+### Fixed
+
+- **Installer no longer prepends a duplicate `_origin:` line when the source file ships with a placeholder frontmatter block** — closes [#93](https://github.com/ckallum/calsuite/issues/93). Two-part fix:
+  - **Installer guard** in `scripts/lib/origin-protocol.cjs`: tightened the regex used by `stampOrigin()` and `normalizeForCompare()` from `/^_origin:\s*(.+?)\s*$/m` to `/^_origin:\s*(.*?)\s*$/m`. The old `(.+?)` form required at least one character after `_origin:`, so the placeholder convention (`_origin:` with no value) didn't match, and `stampOrigin` fell through to the prepend branch — producing two `_origin:` keys in the destination instead of replacing the placeholder. The new `(.*?)` form matches the empty-value placeholder as well as fully-stamped lines.
+  - **Source cleanup**: removed the placeholder frontmatter block from `skills/improve-prompt/references/checklist.md` so it matches the convention of `skills/review/checklist.md` and `skills/ship/pr-template.md` (no source-side frontmatter; the installer's auto-prepend path adds the `_origin:` block on first install). Belt and braces — the installer fix alone covers this case, but a source file with no frontmatter at all is the simpler invariant.
+  - Verified with a `/tmp/test-project` install per CLAUDE.md `Testing configure-claude.js` guidance: all three auto-frontmatter target files (`improve-prompt/references/checklist.md`, `review/checklist.md`, `ship/pr-template.md`) now have exactly one `_origin:` line.
+
+### Why
+
+[#93](https://github.com/ckallum/calsuite/issues/93) was filed during the 2.32 downstream-sync sweep when four of five target repos came back with `---\n_origin: calsuite@<sha>\n_origin:\n---` in their freshly-installed `improve-prompt/references/checklist.md`. The duplicate is technically valid YAML — most parsers take last-key-wins, which means `_origin` reads as empty — but that's a silent footgun: `decideFileAction()` would route the file to `skip-unknown` on the next sync because `readOrigin()` returns `null` for the empty value, which is wrong (the file *is* calsuite-managed). The downstream PRs that landed yesterday (verityaml/verity#502, Verity-V2/landing#3) needed follow-up one-line dedup PRs (#503, #4) to fix the YAML before the next `--sync` would behave correctly.
+
+The regex fix is the load-bearing change — it makes the installer correct for any future source file that ships with a placeholder `_origin:`, not just `improve-prompt`. The source-side cleanup is belt-and-braces: removing the placeholder removes the failure case entirely, matching the convention already followed by `review/checklist.md` and `ship/pr-template.md` (which never had this bug because they have no source-side frontmatter at all).
+
+No new test harness — calsuite still relies on `/tmp/test-project` integration testing per CLAUDE.md, tracked separately in [#46](https://github.com/ckallum/calsuite/issues/46). The four `stampOrigin()` cases (placeholder source / re-stamp / frontmatter-without-origin / no-frontmatter) were verified inline before commit.
 
 ## [2.32] — 2026-05-22
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.32** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.33** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.32**
+**Version: 2.33**
 
 ## Getting started
 

--- a/scripts/lib/origin-protocol.cjs
+++ b/scripts/lib/origin-protocol.cjs
@@ -3,7 +3,12 @@ const path = require('path');
 const { execFileSync } = require('child_process');
 
 const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
-const ORIGIN_LINE_RE = /^_origin:\s*(.+?)\s*$/m;
+// `(.*?)` (not `(.+?)`) so the placeholder form `_origin:` with no value also
+// matches. Source files that ship with a placeholder frontmatter block — e.g.
+// `skills/improve-prompt/references/checklist.md` — used to fall through to the
+// prepend branch in stampOrigin and produce two _origin keys in the destination.
+// See calsuite#93.
+const ORIGIN_LINE_RE = /^_origin:\s*(.*?)\s*$/m;
 
 function parseFrontmatter(content) {
   const match = content.match(FRONTMATTER_RE);

--- a/skills/improve-prompt/references/checklist.md
+++ b/skills/improve-prompt/references/checklist.md
@@ -1,7 +1,3 @@
----
-_origin:
----
-
 # Audit checklist — fast pass
 
 A single-page checklist for triaging a prompt. Use when the user wants a quick pass rather than a full rewrite. Each item is a yes/no — if "no", note what to add or change.


### PR DESCRIPTION
## Summary

Closes [#93](https://github.com/ckallum/calsuite/issues/93). Two-part fix for the duplicate `_origin:` key the installer was leaving in destination files when the source ships with a placeholder `_origin:` frontmatter block.

- **`scripts/lib/origin-protocol.cjs`** — `ORIGIN_LINE_RE` was `/^_origin:\s*(.+?)\s*$/m`. The `(.+?)` required at least one char after `_origin:`, so the placeholder form (`_origin:` with no value) didn't match. `stampOrigin()` fell through to the prepend branch and produced two `_origin:` keys. Changed to `(.*?)` so the empty-value placeholder matches and gets replaced.
- **`skills/improve-prompt/references/checklist.md`** — removed the placeholder frontmatter block from the source. Now matches `skills/review/checklist.md` / `skills/ship/pr-template.md` (no source-side frontmatter; installer auto-prepends on first install).

## How It Works

```mermaid
flowchart TD
    A[Source file: skills/improve-prompt/references/checklist.md] --> B{parseFrontmatter}
    B -->|has frontmatter| C{ORIGIN_LINE_RE.test}
    C -->|matches placeholder _origin:| D[replace with _origin: calsuite@sha]
    C -->|no match before fix| E[prepend new line → DUPLICATE]
    D --> F[Destination: single _origin line ✓]
    E --> G[Destination: two _origin lines ✗]

    style E stroke:#f55,stroke-width:2px
    style G stroke:#f55,stroke-width:2px
    style D stroke:#0a0,stroke-width:2px
    style F stroke:#0a0,stroke-width:2px
```

## Important Files
| File | Change |
|------|--------|
| `scripts/lib/origin-protocol.cjs` | `ORIGIN_LINE_RE`: `(.+?)` → `(.*?)`; comment explains why |
| `skills/improve-prompt/references/checklist.md` | Drop placeholder frontmatter (5-line removal) |
| `CHANGELOG.md` | v2.33 entry with detailed reasoning |
| `CLAUDE.md`, `README.md` | Version bump 2.32 → 2.33 |

## Test Results

| Suite | Result |
|-------|--------|
| `stampOrigin()` inline cases (placeholder / re-stamp / fm-no-origin / no-fm) | ✅ 4/4 pass, single `_origin:` line in each |
| `/tmp/test-project` install | ✅ All three auto-frontmatter target files (`improve-prompt/references/checklist.md`, `review/checklist.md`, `ship/pr-template.md`) have exactly one `_origin:` line |

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md / README.md version bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved installer issue creating duplicate placeholder entries in generated file headers

* **New Features**
  * Added a new audit checklist for prompt verification and quality assurance

* **Documentation**
  * Updated version references across documentation to 2.33

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ckallum/calsuite/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->