### PR TITLE
fix(installer): honor per-target overrides when installing into a worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this repository.
 
-Current version: **2.36**
+Current version: **2.37**
+
+## [2.37] — 2026-05-31
+
+### Fixed
+
+- **Installing into a git worktree now honors per-target `targets.json` overrides.** Single-path invocation (`node scripts/configure-claude.js <dir>`) matched a target's config by exact path equality, so a worktree of a registered target — whose working-tree path differs from the registered one — matched nothing and silently dropped `workspaces: "skip"` and `skills.exclude`. A worktree of the monorepo target `verity` would reinstall the full workspace harness into `frontend/` and `backend/` instead of staying root-only. Added `findMatchingTarget()`, which falls back from path equality to git repo identity (`git rev-parse --git-common-dir`, shared across all worktrees of a repo) so overrides follow the repo rather than the path. Threaded through all three matching callsites: single-path `main()`, `installOnly()` (`--only`), and `handlePruneStale()`.
+- **`scripts/sync-preview.cjs` no longer crashes when an installed file is already current.** The preview's bucket map was missing the `no-op` action that `decideFileAction` returns for up-to-date files, so any clean target threw `Cannot read properties of undefined (reading 'push')` — the common case, which made the dry run effectively unusable.
+
+### Why
+
+Surfaced while syncing calsuite `2.36` out to its five downstream targets via per-target worktree PRs. Building the sync branch in a throwaway worktree off `origin/main` keeps the target's checked-out branch untouched, which is the natural way to turn a mechanical sync into reviewable PRs — but it tripped the path-equality assumption baked into target matching. The git-identity fallback makes the worktree workflow correct by construction instead of relying on the caller to hand-stage around the over-install.
 
 ## [2.36] — 2026-05-29
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.36** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.37** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.36**
+**Version: 2.37**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -147,6 +147,48 @@ function ensureTargetsArray(targetsJson) {
   }
 }
 
+/**
+ * Resolve a directory's git "common dir" — the shared .git directory every
+ * worktree of a repo points at. Two worktrees of the same repo return the same
+ * value, while their working-tree paths (--show-toplevel) differ. Returns null
+ * if `dir` isn't a git tree or git isn't on PATH.
+ */
+function gitCommonDir(dir) {
+  try {
+    const { execFileSync } = require('node:child_process');
+    return execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find the config/targets.json entry that corresponds to `targetDir`.
+ *
+ * Matches on path equality first (the common case), then falls back to git repo
+ * identity so installing into a *worktree* of a registered target still picks
+ * up that target's per-repo overrides (`workspaces: "skip"`, `skills.exclude`).
+ * Without the identity fallback a worktree's path never equals the registered
+ * path, so overrides silently vanish — e.g. a monorepo target with
+ * `workspaces: "skip"` would get its workspace harness reinstalled.
+ */
+function findMatchingTarget(targets, targetDir) {
+  if (!Array.isArray(targets)) return undefined;
+  const exact = targets.find(
+    t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === targetDir
+  );
+  if (exact) return exact;
+  const targetCommon = gitCommonDir(targetDir);
+  if (!targetCommon) return undefined;
+  return targets.find(
+    t => gitCommonDir(path.resolve(t.path.replace(/^~/, HOME_DIR))) === targetCommon
+  );
+}
+
 // Actions that should result in (re)writing the destination file.
 const WRITE_ACTIONS = new Set(['write-new', 'write-update', 'migrate']);
 // Actions that indicate a file was skipped and needs user reconciliation.
@@ -974,9 +1016,7 @@ function installOnly(targetDir, onlySkills, onlyAgents, outerDivergences = null)
   if (detectedProfiles.includes('monorepo')) {
     const targetsConfig = readJsonSync(TARGETS_JSON);
     ensureTargetsArray(targetsConfig);
-    const matchingTarget = targetsConfig?.targets?.find(
-      t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === targetDir
-    );
+    const matchingTarget = findMatchingTarget(targetsConfig?.targets, targetDir);
     const skipWorkspaces = matchingTarget?.workspaces === 'skip';
     if (!skipWorkspaces) {
       const workspaces = findWorkspaces(targetDir);
@@ -1412,9 +1452,7 @@ function handlePruneStale(targetPath, { assumeYes = false } = {}) {
       console.error(`  ✗ ${resolved} does not exist`);
       process.exit(1);
     }
-    const matching = targetsJson?.targets?.find(
-      t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === resolved
-    );
+    const matching = findMatchingTarget(targetsJson?.targets, resolved);
     targets = [{ path: resolved, label: path.basename(resolved), workspaces: matching?.workspaces }];
   } else {
     if (!targetsJson) {
@@ -1955,9 +1993,7 @@ function main() {
   // workspace harness even though the user configured the target otherwise.
   const targetsConfig = readJsonSync(TARGETS_JSON);
   ensureTargetsArray(targetsConfig);
-  const matchingTarget = targetsConfig?.targets?.find(
-    t => path.resolve(t.path.replace(/^~/, HOME_DIR)) === targetDir
-  );
+  const matchingTarget = findMatchingTarget(targetsConfig?.targets, targetDir);
   const skipWorkspaces = matchingTarget?.workspaces === 'skip';
 
   const { isMonorepo } = installTarget(targetDir, profilesConfig, {

--- a/scripts/sync-preview.cjs
+++ b/scripts/sync-preview.cjs
@@ -80,6 +80,7 @@ function previewTarget(targetPath) {
     'write-new': [],
     'write-update': [],
     'migrate': [],
+    'no-op': [],
     'skip-diverged': [],
     'skip-unknown': [],
     'skip-claimed': [],


### PR DESCRIPTION
## Summary
Single-path install (`node scripts/configure-claude.js <dir>`) matched a `targets.json` entry by **exact path equality**. A git worktree of a registered target has a different working-tree path, so it matched nothing and silently dropped that target's overrides (`workspaces: "skip"`, `skills.exclude`). A worktree of a monorepo target reinstalled its full workspace harness into every workspace instead of staying root-only.

- Add `findMatchingTarget()` — path equality first, then fall back to **git repo identity** (`git rev-parse --git-common-dir`, shared across all worktrees of a repo). Overrides now follow the repo, not the path.
- Thread it through all three matching callsites: single-path `main()`, `installOnly()` (`--only`), and `handlePruneStale()`.
- Fix a crash in `scripts/sync-preview.cjs`: its bucket map was missing the `no-op` action `decideFileAction` returns for already-current files, so any clean target threw `Cannot read properties of undefined (reading 'push')` — the common case.

## Why
Surfaced while syncing calsuite `2.36` to its five downstream targets via per-target worktree PRs. Building the sync branch in a throwaway worktree off `origin/main` keeps the target's checked-out branch untouched — the natural way to turn a mechanical sync into reviewable PRs — but it tripped the path-equality assumption. The git-identity fallback makes that workflow correct by construction.

## Test plan
- [x] `node -c` syntax check passes.
- [x] Install into a fresh `verity` worktree → stays monorepo-root only; `backend/.claude` and `frontend/.claude` untouched (previously over-installed).
- [x] `sync-preview.cjs` runs to completion across all targets (previously crashed).
- [x] Exact-path match short-circuits before any `git` call (no behavior change for normal installs); null/non-git inputs return `undefined` gracefully.

Version 2.36 → 2.37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)