### PR TITLE
chore(review): add Cross-cutting patterns framing to /review checklist (v2.38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.37**
+Current version: **2.38**
+
+## [2.38] — 2026-05-31
+
+### Added
+
+- **`/review` checklist gains a "Cross-cutting patterns" framing section.** Three abstract shapes that most Pass 1/Pass 2 bullets instantiate: **A — State surface sync** (any logical state with two or more surfaces must have every transition touch all of them), **B — Defensive-default trap** (substituting an empty/default/`Ok(None)` for an error signal turns "something broke" into "nothing happened"), and **C — Stale-reference class** (after a structural change, every reference to the old shape must grep to zero). It sits at the top of Review Categories so a reviewer carries the principle into the scan and flags new instances the concrete bullets don't yet list.
+
+### Why
+
+Surfaced while syncing calsuite out to its five downstream targets. museli's installed checklist carried this section but calsuite's source didn't, so a mechanical force-adopt would have deleted the richer downstream content. Ported the framing up to source instead — with its concrete "instances of this" cross-references rewritten to match calsuite's current checklist taxonomy (e.g. *Stale in-memory state after DB write*, *Aggregation Source Consistency*, *Error Handling*) rather than museli's older bullet names — so the next sync resolves the divergence everywhere instead of clobbering it.
 
 ## [2.37] — 2026-05-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.37** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.38** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.37**
+**Version: 2.38**
 
 ## Getting started
 

--- a/skills/review/checklist.md
+++ b/skills/review/checklist.md
@@ -30,6 +30,16 @@ Be terse. For each issue: one line describing the problem, one line with the fix
 
 ## Review Categories
 
+### Cross-cutting patterns
+
+Most of the citation-rich Pass 1 and Pass 2 bullets below are instances of three abstract shapes. Carry the principle into the scan so you can flag new instances the checklist doesn't yet list.
+
+- **A — State surface sync.** Any logical state with two or more surfaces (in-memory + DB, source doc + parsed store, prop + live store, event payload + frontend listener, write path + read path) must have every transition touch all surfaces. A one-sided change ships green. Instances below: *Stale in-memory state after DB write* (Race Conditions), *Conditional Side Effects* (status set on one branch only), *Aggregation Source Consistency* (totals derived from different sources with different filtering), *Derive-during-render must also sync state* (React 19 State Patterns), and the *Serialize/deserialize symmetry* check in the versioned-struct pass.
+- **B — Defensive-default trap.** Substituting an empty / default / `Ok(None)` for an error signal turns "something went wrong" into "nothing happened" — indistinguishable to callers, and the next write destroys the evidence. Instances below: the swallowed-error, catch-all-without-context, and empty-`catch {}` bullets under *Error Handling*; *Error state vs empty state* and *Feature flags inferred from API failure* under *React Async Patterns*; and the sentinel-value bullet under *Aggregation Source Consistency*.
+- **C — Stale-reference class.** After a structural change (renamed type, new enum variant, dropped param, changed contract, deleted column), every reference to the old shape must grep to zero — including comments, specs, tests, and blame-anchored claims. Instances below: the stale-comment and "all X converted" bullets under *Dead Code & Consistency*, the error-string-as-query-filter bullet under *Magic Numbers & String Coupling*, *Sibling Helper Drift*, and *Test Mock Staleness*.
+
+Not unified here: the ordering / atomicity family (TOCTOU re-reads under *SQL & Data Safety*, atomic conditional updates under *Race Conditions & Concurrency*) is a sibling concern. Same goal as A — consistency across surfaces — but the mechanism is sequencing and rollback, not symmetric writes. Treat the concrete bullets as load-bearing rather than rolling them up.
+
 ### Pass 1 — CRITICAL
 
 #### SQL & Data Safety


### PR DESCRIPTION
## Summary
- Adds a `### Cross-cutting patterns` section to `skills/review/checklist.md` — the A/B/C abstract shapes (state-surface-sync, defensive-default-trap, stale-reference-class) that most Pass 1/Pass 2 bullets instantiate.
- Bumps to **v2.38** (CLAUDE.md, README.md, CHANGELOG.md).

## Provenance
Ported up from museli's installed checklist, which carried this section while calsuite source didn't — a mechanical force-adopt during the downstream sync would have deleted it. The concrete "instances of this" cross-references were rewritten from museli's older bullet names to calsuite's current taxonomy; all 13 verified to resolve.

## Test plan
- [ ] `node scripts/configure-claude.js /tmp/test-project` installs the updated checklist cleanly
- [ ] Cross-references in the new section all point at real checklist bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)