### PR TITLE
fix(installer): git-identity _origin naming for --claim/--reconcile (v2.40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Current version: **2.40**
 ### Fixed
 
 - **`--claim` and `--reconcile` now stamp the registered target name when run against a worktree.** Both derived the `_origin` value from the directory basename (`deriveTargetName`), so claiming a file inside a *worktree* of a registered target — e.g. `/tmp/cs-wt-museli/.claude/skills/review/checklist.md` — stamped `_origin: cs-wt-museli` instead of `_origin: museli`. A later `--sync` of the real checkout then computed the basename as `museli`, saw a foreign owner, and skipped the file for the wrong reason. A new `resolveTargetName()` resolves the target through git-repo identity (the same `findMatchingTarget` path #113 added for `--sync`), falling back to the basename only for files outside any registered target (one-off claims, fresh clones with no `targets.json`).
+- **`/verify` guards the `evidenceDir` fallback when `jq` is absent or the config is malformed.** The `jq -r '.evidenceDir // ".context/verify"'` default only covers a missing key in *valid* JSON; if `jq` isn't installed or `verify-config.json` is unparseable, the command substitution returns empty and `VERIFY_DIR` would root at `/`. Added an explicit `EVIDENCE_BASE=${EVIDENCE_BASE:-.context/verify}` guard. Narrow trigger and it fails loudly, hence non-blocking — found independently by all three PR-review agents.
 
 ### Why
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.39**
+Current version: **2.40**
+
+## [2.40] — 2026-06-02
+
+### Fixed
+
+- **`--claim` and `--reconcile` now stamp the registered target name when run against a worktree.** Both derived the `_origin` value from the directory basename (`deriveTargetName`), so claiming a file inside a *worktree* of a registered target — e.g. `/tmp/cs-wt-museli/.claude/skills/review/checklist.md` — stamped `_origin: cs-wt-museli` instead of `_origin: museli`. A later `--sync` of the real checkout then computed the basename as `museli`, saw a foreign owner, and skipped the file for the wrong reason. A new `resolveTargetName()` resolves the target through git-repo identity (the same `findMatchingTarget` path #113 added for `--sync`), falling back to the basename only for files outside any registered target (one-off claims, fresh clones with no `targets.json`).
+
+### Why
+
+Surfaced while reconciling the `/review` checklist across the downstream targets via worktrees: a `--claim` against a museli worktree stamped `_origin: cs-wt-museli` and had to be hand-corrected before commit. #113 moved `--sync`/install/prune-stale to git-identity matching but left `--claim`/`--reconcile` on the naive basename, so the worktree footgun persisted in exactly the reconcile workflow that most often runs against worktrees.
 
 ## [2.39] — 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,22 @@
 
 All notable changes to this repository.
 
-Current version: **2.38**
+Current version: **2.39**
+
+## [2.39] — 2026-06-02
+
+### Fixed
+
+- **`/review` Agent I dispatch prose now matches the exact-match `SPEC_DIR` code.** The gating logic was tightened to require an exact spec-directory match (no fallback to "first spec under `.claude/specs/`"), but the Agent I dispatch paragraph still described the old fallback. An issue-driven branch like `claude/<task>` would read as "a spec exists, dispatch the agent" when the code had already (correctly) decided to skip.
+- **`/sweep-issues` PR-introduced-bug guard works on non-`main` default branches.** The guard diffed against a hardcoded `origin/main`, so a repo whose default branch is `master` (the guard already special-cased that name) diffed against a nonexistent ref, got an empty file list, and silently never fired. Now resolves the default branch via `git rev-parse --abbrev-ref origin/HEAD`.
+- **`/sweep-issues` bootstraps the custom category labels.** Only `afk`/`hitl` were gate-created; `gh issue create --label tech-debt` fails outright if the label is missing, dropping the issue. Added gated creates for `tech-debt` and `infrastructure` (`enhancement`/`bug` are GitHub defaults).
+- **`/verify` honors the documented `evidenceDir` config.** `config-schema.md` advertised an `evidenceDir` knob, but the main loop hardcoded `.context/verify/<ts>`. The script now reads `evidenceDir` from `.claude/verify-config.json` (via the same `jq` pattern used for teardown) and falls back to the default.
+- **`/verify` frontend error check no longer inverts its own intent.** The console-error grep printed matches but never failed the run, despite the comment promising "hard errors fail the verify." Rewritten as `grep -qi … && exit 1` so a match (errors present) actually fails.
+- **`config-schema.md` no longer claims `/ship` auto-links verify evidence.** It said `/ship` "knows to link" the evidence dir; `verify/SKILL.md` says the opposite in three places. Corrected to match — `/ship` does not yet pick it up.
+
+### Why
+
+PR-review feedback (adversarial pass) on the `/verify`, `/review`, and `/sweep-issues` skills. Each finding was verified against current source before fixing — the markdownlint MD040 finding was dropped (calsuite runs no markdownlint, so a full fence-retag is scope creep; only the one cited ASCII-diagram fence was tagged `text`). The rest were real: stale prose drifting from tightened code, default-branch assumptions that break the distributable "works on any clone" contract, and documented config knobs the code ignored.
 
 ## [2.38] — 2026-05-31
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.38** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.39** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.39** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.40** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.39**
+**Version: 2.40**
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.38**
+**Version: 2.39**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -189,6 +189,30 @@ function findMatchingTarget(targets, targetDir) {
   );
 }
 
+/**
+ * Resolve the `_origin` target name to stamp on a claimed/reconciled file.
+ *
+ * Prefers the registered target's basename via git-repo identity, so claiming a
+ * file inside a *worktree* of a registered target stamps the real target name
+ * (e.g. `museli`) rather than the throwaway worktree directory (`cs-wt-museli`).
+ * A worktree-derived name makes later --sync of the real checkout treat the file
+ * as owned by a different target and skip it for the wrong reason. Falls back to
+ * the path-derived basename for files outside any registered target (a one-off
+ * claim in an unlisted repo, or a fresh clone with no targets.json).
+ */
+function resolveTargetName(destPath) {
+  const marker = path.sep + '.claude' + path.sep;
+  const idx = destPath.lastIndexOf(marker);
+  if (idx !== -1) {
+    const targetDir = destPath.slice(0, idx);
+    const targetsConfig = readJsonSync(TARGETS_JSON);
+    ensureTargetsArray(targetsConfig);
+    const match = findMatchingTarget(targetsConfig?.targets, targetDir);
+    if (match) return path.basename(path.resolve(match.path.replace(/^~/, HOME_DIR)));
+  }
+  return deriveTargetName(destPath);
+}
+
 // Actions that should result in (re)writing the destination file.
 const WRITE_ACTIONS = new Set(['write-new', 'write-update', 'migrate']);
 // Actions that indicate a file was skipped and needs user reconciliation.
@@ -1173,7 +1197,7 @@ function handleClaim(targetPath) {
     console.error(`    got: ${destPath}`);
     process.exit(1);
   }
-  const targetName = deriveTargetName(destPath);
+  const targetName = resolveTargetName(destPath);
   const content = fs.readFileSync(destPath, 'utf8');
   const stamped = originProtocol.stampOrigin(content, targetName);
   fs.writeFileSync(destPath, stamped);
@@ -1257,8 +1281,9 @@ function handleReconcile(targetPath) {
     process.exit(1);
   }
 
+  const targetName = resolveTargetName(destPath);
   console.log('Resolution options:');
-  console.log(`  [k] Keep target's version (stamp _origin: ${deriveTargetName(destPath)})`);
+  console.log(`  [k] Keep target's version (stamp _origin: ${targetName})`);
   console.log(`  [a] Adopt calsuite's current version (overwrite)`);
   console.log(`  [m] Three-way merge in $EDITOR`);
   console.log(`  [s] Skip (leave file flagged)`);
@@ -1275,7 +1300,6 @@ function handleReconcile(targetPath) {
   const choice = buf.slice(0, bytesRead).toString('utf8').trim().toLowerCase();
 
   if (choice === 'k' || choice === 'keep') {
-    const targetName = deriveTargetName(destPath);
     const stamped = originProtocol.stampOrigin(destContent, targetName);
     fs.writeFileSync(destPath, stamped);
     console.log(`  ✓ Kept target's version. Stamped ${destPath} → _origin: ${targetName}`);

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -609,7 +609,7 @@ description: "Cross-module format consistency"
 
 **Agent I — Spec-contract deviation (signal-gated: `$SPEC_DIR` non-empty):**
 
-Only dispatch if `$SPEC_DIR` is non-empty (branch slug matches a directory under `.claude/specs/` OR a spec with both `design.md` and `tasks.md` is found). If `$SPEC_DIR` is empty, skip this agent.
+Only dispatch if `$SPEC_DIR` is non-empty — i.e. the branch name, with standard feature-branch prefixes (`feat/`, `fix/`, `chore/`, `refactor/`, `feature/`) stripped, matches a spec directory under `.claude/specs/` **exactly**. There is no fallback to "first spec under `.claude/specs/`"; for issue-driven branches (e.g. `claude/<task>`) that would grab an unrelated spec and review against the wrong contract. If there's no exact match, `$SPEC_DIR` stays empty and this agent is skipped.
 
 ```text
 prompt: "Check the diff for deviations from the spec contract.

--- a/skills/sweep-issues/SKILL.md
+++ b/skills/sweep-issues/SKILL.md
@@ -82,7 +82,11 @@ If a prior rejection is *related but not the same scope*, surface it to the user
 # Skip the check entirely if not on a feature branch with real divergence
 branch=$(git branch --show-current 2>/dev/null)
 if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "master" ]; then
-  changed_files=$(git diff origin/main --name-only 2>/dev/null)
+  # Resolve the repo's default branch instead of assuming origin/main — repos
+  # whose default is master (or anything else) would otherwise diff against a
+  # nonexistent ref and silently no-op this guard.
+  base=$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null || echo origin/main)
+  changed_files=$(git diff "$base" --name-only 2>/dev/null)
 fi
 ```
 
@@ -90,7 +94,7 @@ If `$changed_files` is non-empty, for every candidate categorized as `bug`:
 
 1. Match the candidate against the diff. A candidate is **PR-touched** if any of:
    - Its description references a file path in `$changed_files` (literal or basename match)
-   - Its description references a symbol (function, type, constant) that appears in `git diff origin/main` as an added or modified line
+   - Its description references a symbol (function, type, constant) that appears in `git diff "$base"` (the default-branch diff resolved above) as an added or modified line
 2. If PR-touched, use AskUserQuestion individually:
    ```text
    This bug looks like it lives in code this PR is changing:
@@ -160,13 +164,17 @@ EOF
 - `AFK` → `afk` label
 - `HITL` → `hitl` label
 
-If the labels don't already exist on the repo, create them once. **Gate the create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
+If the labels don't already exist on the repo, create them once. This covers **both** the mode labels (`afk`/`hitl`) and the custom category labels (`tech-debt`/`infrastructure`) — `gh issue create --label tech-debt` fails outright if the label is missing, which would silently drop the issue. (`enhancement` and `bug` ship as defaults on every GitHub repo, so they don't need bootstrapping.) **Gate each create call** — `gh label create` errors on existing labels without `--force`, and `--force` would overwrite color/description on every run. Use:
 
 ```bash
 gh label list --json name -q '.[].name' | grep -qx afk \
   || gh label create afk --color 0E8A16 --description "Agent can complete unattended"
 gh label list --json name -q '.[].name' | grep -qx hitl \
   || gh label create hitl --color FBCA04 --description "Needs human in the loop"
+gh label list --json name -q '.[].name' | grep -qx tech-debt \
+  || gh label create tech-debt --color D4C5F9 --description "Technical debt"
+gh label list --json name -q '.[].name' | grep -qx infrastructure \
+  || gh label create infrastructure --color C5DEF5 --description "Infrastructure / tooling"
 ``` The labels let `/execute --multi issue:...` filter for AFK-only work safe to fan out across panes, and let `/babysit-pr` flag HITL items that need user attention.
 
 ### Step 5: Report

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -130,6 +130,10 @@ EVIDENCE_BASE=.context/verify
 if [ -f .claude/verify-config.json ]; then
   EVIDENCE_BASE=$(jq -r '.evidenceDir // ".context/verify"' .claude/verify-config.json 2>/dev/null)
 fi
+# jq's `// default` only fires for a missing key in valid JSON; if jq is absent
+# or the config is malformed the command substitution is empty, which would root
+# VERIFY_DIR at `/`. Guard the empty case explicitly.
+EVIDENCE_BASE=${EVIDENCE_BASE:-.context/verify}
 VERIFY_DIR=${EVIDENCE_BASE%/}/${VERIFY_TS}
 mkdir -p "${VERIFY_DIR}/screenshots" "${VERIFY_DIR}/responses"
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -31,7 +31,7 @@ Unit tests prove the function returns the right value for an input. Verify prove
 
 The flow:
 
-```
+```text
 write code → run the app → drive the changed path → did it work?
                               ↓ no                      ↓ yes
                            read logs                capture evidence
@@ -125,7 +125,12 @@ fi
 
 VERIFY_TS=$(date +%Y-%m-%d-%H%M%S)
 VERIFY_LOG=/tmp/verify-server-${VERIFY_TS}.log
-VERIFY_DIR=.context/verify/${VERIFY_TS}
+# Honor evidenceDir from .claude/verify-config.json if declared, else default.
+EVIDENCE_BASE=.context/verify
+if [ -f .claude/verify-config.json ]; then
+  EVIDENCE_BASE=$(jq -r '.evidenceDir // ".context/verify"' .claude/verify-config.json 2>/dev/null)
+fi
+VERIFY_DIR=${EVIDENCE_BASE%/}/${VERIFY_TS}
 mkdir -p "${VERIFY_DIR}/screenshots" "${VERIFY_DIR}/responses"
 
 # Scope docker compose to this run so the teardown doesn't tear down the user's other compose work.

--- a/skills/verify/references/config-schema.md
+++ b/skills/verify/references/config-schema.md
@@ -158,7 +158,7 @@ If the project has fixtures already loaded by `docker compose`, omit this.
 
 ### `evidenceDir`
 
-Where to save screenshots, log excerpts, DB query results. Defaults to `.context/verify/` (which `/ship` knows to link from PR bodies).
+Where to save screenshots, log excerpts, DB query results. Defaults to `.context/verify/`. `/ship` does not yet auto-pick-up this evidence — until that integration lands you paste the `summary.md` path into the PR body yourself (see `verify/SKILL.md`).
 
 ## Examples
 

--- a/skills/verify/references/frontend-recipes.md
+++ b/skills/verify/references/frontend-recipes.md
@@ -57,7 +57,10 @@ agent-browser --session verify screenshot "${VERIFY_DIR}/screenshots/after-signu
 
 # 7. Look for errors — hard errors fail the verify; warnings are surfaced but non-blocking
 #    (see "Console error handling" below for why warnings alone don't fail).
-agent-browser --session verify snapshot | grep -i -E '(error|exception|failed)'
+#    A grep MATCH means errors are present, so it must FAIL the run — invert with -q + exit.
+if agent-browser --session verify snapshot | grep -qi -E '(error|exception|failed)'; then
+  echo "✗ console errors detected — verify failed"; exit 1
+fi
 agent-browser --session verify snapshot | grep -i 'warning' || true
 ```
 


### PR DESCRIPTION
## Summary
- **`--claim`/`--reconcile` now stamp the registered target name when run against a worktree.** Both derived `_origin` from the directory basename (`deriveTargetName`), so claiming a file inside a *worktree* of a registered target stamped the worktree dir (e.g. `cs-wt-museli`) instead of the real target (`museli`). A later `--sync` of the real checkout then saw a foreign owner and skipped the file for the wrong reason.
- Adds `resolveTargetName()` routing through the existing `findMatchingTarget` (git-common-dir identity, from #113), falling back to `deriveTargetName` only for files outside any registered target (one-off claims, fresh clones with no `targets.json`). Wired into `handleClaim` and both reconcile keep-branch sites.

## Note on scope
This branch also carries the already-committed **v2.39** commit (`b196ace`, `/verify` `/review` `/sweep-issues` PR-review fixes) that was sitting unpushed on local `main`. The v2.40 CHANGELOG entry stacks on v2.39's, so they can't be cleanly separated — both land together here.

## Verification
- Worktree of a registered target → stamps real basename (`museli`). ✓
- Unregistered `/tmp` repo → falls back to dir basename. ✓
- `node -c` parses; `path-helpers.cjs` self-test passes.
- Independent `@code-reviewer` returned a genuine PASS on this exact diff (fresh-clone null path, `~`-expansion parity, reconcile keep-branch scoping all verified).

## Test plan
- [ ] `node scripts/configure-claude.js --claim <worktree>/.claude/skills/<x>/SKILL.md --yes` stamps the target basename, not the worktree dir.
- [ ] `--claim` in a repo not listed in `targets.json` still stamps the dir basename.
- [ ] `--reconcile` `[k]` keep option shows and applies the resolved target name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – Version 2.40

* **New Features**
  * Added support for optional evidence directory configuration in verification.

* **Bug Fixes**
  * Fixed worktree claims to use registered target names instead of directory paths.
  * Tightened spec-based review dispatch to require exact directory matches.
  * Fixed PR bug detection to work with any default branch, not just `main`.
  * Added missing labels for issue tracking.
  * Fixed verification frontend error detection to fail runs on console errors.
  * Corrected documentation: verification evidence must be manually linked to PRs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->