### PR TITLE
chore(skills): extract shared CONTEXT.md + ADR templates to one canonical file (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this repository.
 
-Current version: **2.50**
+Current version: **2.51**
+
+## [2.51] — 2026-06-05
+
+### Changed
+
+- **`/learn` and `/improve-architecture` now defer to the canonical `skills/plan/references/context-and-adr-formats.md` for the CONTEXT.md and ADR templates instead of carrying their own copies.** `/improve-architecture` still inlined the full CONTEXT.md glossary block and ADR template; `/learn` claimed both skills "carry the format inline," which stopped being true once `/plan` extracted its copy into the shared reference (#127). Both now link to the single canonical file, so the formats can't drift apart. Closes the remaining duplication from #100 — the bulk of the consolidation already landed via the `/plan` split. (#100)
 
 ## [2.50] — 2026-06-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.50** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.51** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.50**
+**Version: 2.51**
 
 ## Getting started
 

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -124,44 +124,14 @@ Once the user picks a candidate, drop into a `/plan --grill`-style conversation.
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
 - **User rejects the candidate?** Persist the rejection **immediately, here, at rejection time** — don't defer to `/sweep-issues` (it may never run, and the next audit will re-suggest the same candidate). Two paths:
-  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the format below. Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
+  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the [canonical ADR format](../plan/references/context-and-adr-formats.md). Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
   2. **Durable reason that doesn't meet all three** (e.g. "we'd revisit if we add multi-tenancy"): write `.out-of-scope/<kebab-slug>.md` now (format documented in `/sweep-issues` SKILL.md — `slug`, `rejected`, `related-issues` frontmatter, plus "Why we rejected it" and "What would change our minds" body sections). The next audit reads this and skips the candidate.
 
   Only skip persistence entirely if the user explicitly marks the rejection **ephemeral** (e.g. "not worth it right now", "ask me again next quarter") — those don't need durable records because the reasoning won't apply later.
 
-### `CONTEXT.md` format (when adding terms inline)
+### Artifact formats (CONTEXT.md and ADR)
 
-```md
-**{Term}**:
-{One-sentence definition.}
-_Avoid_: {alias 1}, {alias 2}
-```
-
-Be opinionated, one canonical word per concept. Group under `## Language`, with `## Relationships`, `## Example dialogue`, and `## Flagged ambiguities` sections. Domain-only — no general programming concepts.
-
-### ADR format (at `docs/adr/NNNN-kebab-title.md`)
-
-```md
-# ADR-{NNNN}: {Verb-led title}
-
-**Status:** Accepted
-**Date:** YYYY-MM-DD
-
-## Context
-{What forced the decision.}
-
-## Decision
-{What we decided.}
-
-## Consequences
-**Positive:** {what gets easier}
-**Negative:** {what gets harder}
-
-## Alternatives considered
-- **{Alternative}** — rejected because {reason}
-```
-
-Filename zero-padded sequential, verb-led title. Immutable once accepted — supersede with a new ADR rather than editing.
+Both templates — the `CONTEXT.md` glossary format and the ADR format (`docs/adr/NNNN-kebab-title.md`, immutable once accepted; supersede with a new ADR rather than editing) — live in one canonical place: **[../plan/references/context-and-adr-formats.md](../plan/references/context-and-adr-formats.md)**, the same file `/plan` and `/learn` defer to, so the formats can't drift apart. Read it before writing either artifact.
 - **User accepts the candidate and wants to implement?** Stop here — do **not** start coding inside `/improve-architecture`. Hand off: *"Run `/plan review` on this candidate, then `/execute`. I'll keep audit notes in CONTEXT.md / docs/adr/."* The skill is a surfacing-and-deciding tool, not an implementation tool.
 
 ### Step 6: Write audit notes

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -31,14 +31,14 @@ Three sibling artifacts, three different purposes — pick the right one before 
 | **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
 | **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
 
-If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning. The CONTEXT.md format lives in the canonical [context-and-adr-formats.md](../plan/references/context-and-adr-formats.md), which `/plan` and `/improve-architecture` also defer to. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
 
 If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR. Path depends on scope:
 
 - **System-wide decision** → `docs/adr/NNNN-kebab-title.md` at the repo root.
 - **Context-specific decision** (multi-context repos only) → `<context>/docs/adr/NNNN-kebab-title.md`, alongside that context's code.
 
-Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. ADRs commit to the repo and survive across teams in a way learnings don't.
+Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. The ADR template lives in the canonical [context-and-adr-formats.md](../plan/references/context-and-adr-formats.md). ADRs commit to the repo and survive across teams in a way learnings don't.
 
 Learnings are for everything else: smaller-scale durable facts that don't merit either.
 


### PR DESCRIPTION
Closes #100

## Summary

The CONTEXT.md and ADR format templates lived in three places — `/plan`, `/learn`, and `/improve-architecture` each carried its own copy, and the copies had already drifted. `/plan` held the full CONTEXT.md template with `## Relationships`, `## Example dialogue`, and `## Flagged ambiguities`; `/improve-architecture` had a stripped two-line version; `/learn` described the formats without showing them.

This hoists both templates into one canonical file, `skills/plan/references/artifact-formats.md`, and points the three skills at it. Tightening one copy no longer leaves the others stale. Control-flow text — when to write each artifact, the grill-mode side-effects, the rejection-persistence paths — stays inline in each skill; only the reference templates moved.

## Distribution

The file rides along with the `plan` skill, which every profile already installs, so it reaches targets with no `config/profiles.json` change and no orphan-skill warning. The cross-skill links use `../plan/references/artifact-formats.md`, a relative path that is identical in the calsuite source tree and in each target's `.claude/skills/` layout. `scripts/configure-claude.js` picks up the new reference path; version bumped to 2.42 across `CLAUDE.md`, `README.md`, and `CHANGELOG.md`.

## Review

Verdict: **pass**. Review feedback was addressed in 73b216c (the 2.41 version was already taken by a shipped `/grok` change, so this bumps to 2.42).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release 2.51

* **Documentation**
  * Consolidated CONTEXT and ADR format references into a single canonical source for improved consistency across guidance materials.
  * Refined rejection handling procedures with clearer requirements for durable outcome documentation.

* **Chores**
  * Version updated to 2.51.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->