### PR TITLE
chore(skills): add when-to-use triggers to 8 flagged skills; exempt non-invocable from guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this repository.
 
-Current version: **2.42**
+Current version: **2.43**
+
+## [2.43] — 2026-06-07
+
+### Changed
+
+- **Eight skill descriptions now signal *when* to use them, not just what they do.** `flow`, `guardian`, `layman`, `lint-rule-gen`, `new-spec`, `session-start`, and `update-docs` gained a leading trigger-phrase list plus a "Use when …" clause; each keeps its original what-it-does sentence. This clears the `validateSkillTriggers()` guard (added in 2.42), which had flagged all eight. Closes #123.
+- **The trigger guard now exempts `user-invocable: false` skills.** `strategic-compact` is hook-driven — it fires from a PreToolUse hook and is never selected by its description — so a "Use when" clause would be a trigger the user can't act on. The guard skips the trigger check for non-invocable skills; `strategic-compact`'s description was rewritten to lead with the mechanism and state it fires automatically. `skills/skill-builder/references/best-practices.md` §1 documents the exemption.
+
+### Why
+
+Wave 2 of the skill-audit follow-up (#123), surfaced by the guard shipped in 2.42. Pre-landing review caught that bolting a "Use when" clause onto a non-invocable hook skill is misleading — the fix was to make the guard's standard match reality (description-matching only applies to skills the model can actually pick) rather than force every skill into a user-facing shape.
 
 ## [2.42] — 2026-06-05
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.42** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.43** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.42**
+**Version: 2.43**
 
 ## Getting started
 

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -691,8 +691,13 @@ function validateSkillTriggers() {
     const parsed = originProtocol.parseFrontmatter(content);
     if (!parsed.hasFrontmatter) continue;
 
+    // Hook-driven skills (`user-invocable: false`) are never selected by their
+    // description, so the trigger-phrase standard doesn't apply — exempt them
+    // from the trigger check rather than forcing a meaningless "Use when" clause.
+    const userInvocable = parsed.frontmatter['user-invocable'] !== 'false';
+
     const desc = extractSkillDescription(parsed.rawBody);
-    if (!descriptionHasTriggerSignal(desc)) noTrigger.push(dirent.name);
+    if (userInvocable && !descriptionHasTriggerSignal(desc)) noTrigger.push(dirent.name);
     if (ARGS_USE_RE.test(parsed.body) && !bodyDefinesArguments(parsed.body)) bareArgs.push(dirent.name);
   }
 

--- a/skills/flow/SKILL.md
+++ b/skills/flow/SKILL.md
@@ -2,6 +2,9 @@
 name: flow
 version: 1.0.0
 description: |
+  show me the session flow, visualize the workflow, what skills ran this session,
+  diagram this session, flow diagram, which agents ran and in what order, map the session.
+  Use when you want to see what ran during the current session and how it connected.
   Generate a Mermaid flowchart diagram of the current session's development
   workflow — which skills and agents ran, in what order, with parallel edges
   and collapsed repeated dispatches.

--- a/skills/guardian/SKILL.md
+++ b/skills/guardian/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: guardian
-description: "Configure Guardian autonomous mode, switch modes, view audit log, and manage rules"
+description: |
+  guardian, switch to autonomous/supervised/lockdown mode, go AFK, view audit log,
+  manage deny/warn rules, change permission posture.
+  Configure Guardian's autonomous mode, switch modes, view the audit log, and manage rules.
+  Use when changing permission posture or before running unattended work.
 user-invocable: true
 argument-hint: "[mode|log|rules] [args]"
 allowed-tools: Bash(node *), Bash(cat *), Bash(tail *), Bash(jq *), Read, Glob, Edit

--- a/skills/layman/SKILL.md
+++ b/skills/layman/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: layman
-description: Summarise a code change in plain, non-technical language with real-life analogies and a clear flow
+description: |
+  explain this in plain English, layman's terms, explain to a non-technical stakeholder,
+  what does this PR do for a PM, ELI5 this change, non-technical summary.
+  Use when you need to explain a code change to someone non-technical.
+  Summarise a code change in plain, non-technical language with real-life analogies and a clear flow.
 user-invocable: true
 arguments: Optional PR number (#123), commit hash, branch, or file path. Defaults to current branch's PR, then staged/unstaged changes, then most recent commit.
 ---

--- a/skills/lint-rule-gen/SKILL.md
+++ b/skills/lint-rule-gen/SKILL.md
@@ -2,6 +2,9 @@
 name: lint-rule-gen
 version: 1.0.0
 description: |
+  generate a lint rule, make a lint rule, ban console.log in src, encode this review nit as a rule,
+  catch this pattern automatically, enforce a convention, turn recurring review feedback into a rule.
+  Use when a review keeps catching the same pattern and you want it enforced automatically.
   Generate lint rules from review feedback patterns.
   Aliases: /lint-rule-gen, /generate-lint-rule
 argument-hint: "[description of pattern to catch]"

--- a/skills/new-spec/SKILL.md
+++ b/skills/new-spec/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: new-spec
 description: |
+  new spec, scaffold a spec, start a spec, create a spec for this feature,
+  plan a new feature, set up requirements/design/tasks, kick off a spec.
+  Use when starting a new feature or planning work that needs requirements and design.
   Scaffold a new spec directory with requirements.md, design.md, and tasks.md
   templates. Adds a row to SPECLOG.md.
 argument-hint: <slug>

--- a/skills/session-start/SKILL.md
+++ b/skills/session-start/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: session-start
-description: Load full project context — reads all .md files, specs, changelog, and git history to produce a prioritized project briefing
+description: |
+  start session, get me up to speed, project briefing, onboard me on this repo,
+  what's the state of this project, load full context, catch me up before planning.
+  Use when starting a session or picking up unfamiliar work and you need orientation.
+  Load full project context — reads all .md files, specs, changelog, and git history
+  to produce a prioritized project briefing.
 user-invocable: true
 arguments: Optional workspace name to scope context loading e.g. "backend"
 ---

--- a/skills/skill-builder/references/best-practices.md
+++ b/skills/skill-builder/references/best-practices.md
@@ -31,7 +31,7 @@ Include 5-8 trigger phrases. Include the category name (e.g., "deployment", "cod
 1. A **trigger-phrase list** — the natural-language ways a user asks for this (`deploy code, push to production, ship deployment, roll out changes`), or
 2. An explicit **"Use when …" clause** — `Use when asked to verify a PR, confirm a fix works, or test a change manually`.
 
-This is enforced, not just advised: the installer (`configure-claude.js`) runs a `validateSkillTriggers()` guard on every sync and lists any skill whose description carries neither signal under `⚠ skill description validation`. A new skill that fails it surfaces the moment it lands.
+This is enforced, not just advised: the installer (`configure-claude.js`) runs a `validateSkillTriggers()` guard on every sync and lists any skill whose description carries neither signal under `⚠ skill description validation`. A new skill that fails it surfaces the moment it lands. Skills marked `user-invocable: false` (hook-driven, never selected by their description) are exempt — describe the mechanism instead, and don't bolt on a "Use when" clause the user can't act on.
 
 ## 2. Do Not State the Obvious
 

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: strategic-compact
-description: Hook-driven strategic compaction system. Tracks tool call count and suggests /compact at logical intervals (50 calls, then every 25) to preserve context through phase transitions.
+description: |
+  Hook-driven strategic compaction: tracks tool-call count and suggests /compact at
+  logical intervals (50 calls, then every 25) to preserve context through phase transitions.
+  Fires automatically via PreToolUse hook — not user-invocable.
 user-invocable: false
 ---
 

--- a/skills/update-docs/SKILL.md
+++ b/skills/update-docs/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: update-docs
-description: Update project documentation, specs, and changelog based on recent changes
+description: |
+  update the docs, update documentation, sync the docs after a change, update the changelog,
+  refresh the specs, keep docs current, document what changed.
+  Use after implementing features or fixing bugs to keep docs in sync with the code.
+  Update project documentation, specs, and changelog based on recent changes.
 user-invocable: true
 arguments: Optional spec name to focus on e.g. "auth-system"
 ---


### PR DESCRIPTION
## Summary

Wave 2 of the skill-audit follow-up. Clears the `validateSkillTriggers()` guard (shipped in 2.42) on all skills it flagged.

- Rewrote the `description` of **flow, guardian, layman, lint-rule-gen, new-spec, session-start, update-docs** to lead with a trigger-phrase list + a "Use when …" clause, keeping each original what-it-does sentence.
- **strategic-compact** is `user-invocable: false` (hook-driven — fires from a PreToolUse hook, never selected by its description). Rather than bolt on a "Use when" clause the user can't act on, the guard now **exempts non-invocable skills** from the trigger check, and its description was rewritten to lead with the mechanism. Documented in `skill-builder/references/best-practices.md` §1.

Closes #123.

## Pre-PR Gates

- Size ok (55 insertions). Test-presence: the one non-doc change is a 4-line guard refinement in `configure-claude.js`; verified by running the installer (guard now reports **0** flagged skills). Spec-contract: no active spec.

## How It Works

```mermaid
flowchart TD
    A[validateSkillTriggers: each SKILL.md] --> B{user-invocable: false?}
    B -- yes --> C[skip trigger check<br/>hook skills aren't picked by description]
    B -- no --> D{description has<br/>trigger signal?}
    D -- yes --> E[pass]
    D -- no --> F[⚠ flag]
```

## Important Files

| File | Change |
|------|--------|
| `skills/{flow,guardian,layman,lint-rule-gen,new-spec,session-start,update-docs}/SKILL.md` | Description gains trigger phrases + "Use when" clause |
| `skills/strategic-compact/SKILL.md` | Description rewritten to lead with mechanism (non-invocable) |
| `scripts/configure-claude.js` | Guard exempts `user-invocable: false` skills from the trigger check |
| `skills/skill-builder/references/best-practices.md` | §1 documents the non-invocable exemption |
| `CHANGELOG.md` / `CLAUDE.md` / `README.md` | v2.43 |

## Pre-Landing Review

`@code-reviewer`: reviewed all 8; **BLOCKED** on strategic-compact — a "Use when" opener on a `user-invocable: false` hook skill is misleading. Resolved by exempting non-invocable skills in the guard and rewriting that description to the honest mechanism form (the reviewer's own suggestion). Other 7 passed (triggers verified accurate against each skill's body, no information loss, frontmatter valid). Post-fix guard run: 0 flagged.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md updated (version)
- [ ] tasks.md (no spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)