### PR TITLE
chore(skills): remove maintainer-path leaks from configure-claude + worktrees bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 All notable changes to this repository.
 
-Current version: **2.43**
+Current version: **2.44**
+
+## [2.44] — 2026-06-07
+
+### Fixed
+
+- **`configure-claude` skill body no longer hardcodes the maintainer's checkout path.** Three `/Users/callumke/Projects/calsuite` references became `$CALSUITE_DIR`-relative, and the "am I in the calsuite repo?" check now keys off marker files (`config/profiles.json` + `scripts/configure-claude.js`) instead of matching that literal path. Also corrected a stale `${CLAUDE_CONFIG_DIR}` placeholder to `${CALSUITE_DIR}` (the only name the installer and `hooks/hooks.json` actually use). Closes #124.
+- **`worktrees` Step 2 dropped a stale, unsupported convention lookup.** It told the agent to "look in CLAUDE.md for a `worktree-dir` convention" that no repo defines. Since `worktrees` is a *distributed* skill (installed into target repos), Step 2 now leads with `git worktree list` detection and a `.claude/worktrees/` convention — no dependency on calsuite-internal files like `config/targets.json`.
+- **`CLAUDE.md` resolution-order note corrected.** It described the middle fallback as `~/Projects/calsuite`, but `resolveCalsuiteDir()` uses `git rev-parse --git-common-dir` (the hardcoded home-dir fallback was removed in #95). The note now matches the code and the Fresh-clone test guidance.
+
+### Why
+
+Wave 1 of the skill-audit follow-up (#124) — the fresh-clone test: a non-maintainer cloning calsuite should get working skills with no maintainer-only paths. The hardcoded paths and stale `~/Projects/calsuite` doc were exactly the assumptions that test exists to catch. Markdown-only.
 
 ## [2.43] — 2026-06-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.43** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.44** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 
@@ -146,7 +146,7 @@ templates/   # spec / doc / changelog templates
 - Hook scripts are **not** copied or symlinked into target repos. Hook commands in `settings.local.json` reference `$CALSUITE_DIR/scripts/hooks/*.cjs` directly. `$CALSUITE_DIR` is resolved **at install time** into an absolute path — Claude Code's hook runner does NOT shell-expand hook commands at runtime.
 - `hooks/hooks.json` template uses `${CALSUITE_DIR}` placeholder. Installer substitutes via `substituteCalsuiteDir()` in `scripts/configure-claude.js`.
 - Hook command entries use **exec form**: `"command": "node", "args": ["${CALSUITE_DIR}/scripts/hooks/x.cjs"]` — not a shell string. Each `args[]` element is passed to the spawned process as-is (no shell interpretation, no quoting needed for paths with spaces). `substituteCalsuiteDir()` resolves `${CALSUITE_DIR}` in both `command` and `args` because it operates on the JSON-stringified form. Inline scripts use `"command": "node", "args": ["-e", "<script>"]`. Sibling fields (`async`, `timeout`) sit alongside `command`/`args` on the same object.
-- Calsuite location resolves in this order: `$CALSUITE_DIR` env var → `~/Projects/calsuite` default → installer's own parent dir.
+- Calsuite location resolves in this order (`resolveCalsuiteDir()`): `$CALSUITE_DIR` env var → `git rev-parse --git-common-dir` (canonical checkout, resolves from any worktree) → installer's own parent dir (`__dirname/..`). No hardcoded `~/Projects/calsuite` fallback — that was removed (see Fresh-clone test).
 - Skills and agents use the `_origin` safe-overwrite protocol — frontmatter marker `_origin: calsuite@<short-sha>`. Decision matrix lives in `scripts/lib/origin-protocol.cjs` (`decideFileAction`). Migration for pre-protocol files happens automatically per-file (byte-identical → auto-stamp, differs → skip + log).
 - Content comparison is LF-normalized and strips the `_origin` line from both sides. Source files never carry `_origin`; target files always do once stamped. Comparing raw bytes would false-positive every time.
 - `_origin` protocol applies **only to markdown** under `skills/` and `agents/`. Non-markdown files (rare; e.g. `skills/strategic-compact/scripts/suggest-compact.cjs`) are copy-no-overwrite. JSON configs stay on copy-no-overwrite (can't host frontmatter).

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.43**
+**Version: 2.44**
 
 ## Getting started
 

--- a/skills/configure-claude/SKILL.md
+++ b/skills/configure-claude/SKILL.md
@@ -10,7 +10,7 @@ Install all Claude Code configs from this repository into a project's `.claude/`
 ## What it does
 
 1. Copies `scripts/hooks/` and `scripts/lib/` into the target project's `.claude/scripts/`
-2. Reads `hooks/hooks.json`, resolves `${CLAUDE_CONFIG_DIR}` paths, and merges the `hooks` key into the target's `.claude/settings.json` (preserving existing keys)
+2. Reads `hooks/hooks.json`, resolves `${CALSUITE_DIR}` paths, and merges the `hooks` key into the target's `.claude/settings.json` (preserving existing keys)
 3. Enables all manifest plugins in the project's `.claude/settings.json`
 4. Checks global settings against `config/global-settings.json` and warns about missing marketplaces, plugins, MCP servers, or statusLine config
 
@@ -18,16 +18,16 @@ Install all Claude Code configs from this repository into a project's `.claude/`
 
 When this skill is invoked:
 
-1. Determine the target project directory. If the current working directory is this config repo (`/Users/callumke/Projects/calsuite`), ask the user which project to configure. Otherwise, use the current working directory.
+1. Determine the target project directory. If the current working directory is the calsuite repo itself (it contains `config/profiles.json` and `scripts/configure-claude.js`), ask the user which project to configure. Otherwise, use the current working directory.
 
-2. Run the installer script:
+2. Run the installer script. `$CALSUITE_DIR` is calsuite's checkout location — set the env var, or run from the calsuite repo root and drop the `$CALSUITE_DIR/` prefix:
    ```bash
-   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js <target-directory>
+   node "$CALSUITE_DIR/scripts/configure-claude.js" <target-directory>
    ```
 
 3. Review the output and report what was installed to the user, including any global settings warnings.
 
 4. If ccstatusline config is missing or outdated, offer to install it:
    ```bash
-   node /Users/callumke/Projects/calsuite/scripts/configure-claude.js --install-ccstatusline
+   node "$CALSUITE_DIR/scripts/configure-claude.js" --install-ccstatusline
    ```

--- a/skills/worktrees/SKILL.md
+++ b/skills/worktrees/SKILL.md
@@ -24,10 +24,10 @@ If `$ARGUMENTS` has a branch name, use it. Otherwise, use AskUserQuestion:
 
 ## Step 2: Choose worktree directory
 
-Check these locations in order:
+Check these locations in order — the goal is to match whatever convention the repo already uses, not to impose one:
 
-1. **CLAUDE.md** — look for a `worktree-dir` or similar convention.
-2. **Existing worktrees** — run `git worktree list` to see where previous worktrees live. Use the same parent directory.
+1. **Existing worktrees** — run `git worktree list`. If the repo already has worktrees, create the new one under the same parent directory.
+2. **`.claude/worktrees/` convention** — if that directory exists (or is listed in `.gitignore`), use `.claude/worktrees/<branch-name>`.
 3. **Default** — `../worktrees/<branch-name>` (sibling to the repo root).
 
 If none of the above resolve clearly, ask via AskUserQuestion:


### PR DESCRIPTION
## Summary

Wave 1 of the skill-audit follow-up — the fresh-clone test (CLAUDE.md): a non-maintainer cloning calsuite should get working skills with no maintainer-only paths baked in.

- **`configure-claude/SKILL.md`** — three hardcoded `/Users/callumke/Projects/calsuite` paths → `$CALSUITE_DIR`-relative; the "am I in the calsuite repo?" check now keys off marker files (`config/profiles.json` + `scripts/configure-claude.js`); stale `${CLAUDE_CONFIG_DIR}` → `${CALSUITE_DIR}` (the only name the installer + `hooks/hooks.json` use).
- **`worktrees/SKILL.md`** — Step 2 dropped the unsupported "look in CLAUDE.md for a `worktree-dir` convention" lookup. Since `worktrees` is a *distributed* skill, it now leads with `git worktree list` detection + a `.claude/worktrees/` convention — no calsuite-internal refs (notably not `config/targets.json`, which wouldn't exist in a target repo).
- **`CLAUDE.md`** resolution-order note corrected: the middle fallback is `git rev-parse --git-common-dir`, not the long-removed `~/Projects/calsuite` (the exact anti-pattern this issue is about; it also contradicted line 91).

Closes #124.

## Pre-PR Gates

- Markdown-only (5 files) — size/test-presence gates N/A. Spec-contract: no active spec. Deterministic compliance: `grep -rn '/Users/callumke' skills/` → 0; trigger guard → 0 flagged (no regression).

## Important Files

| File | Change |
|------|--------|
| `skills/configure-claude/SKILL.md` | `$CALSUITE_DIR`-relative installer paths; marker-file cwd detection; `${CALSUITE_DIR}` placeholder fix |
| `skills/worktrees/SKILL.md` | Step 2 uses `git worktree list` + `.claude/worktrees/` detection |
| `CLAUDE.md` | Resolution-order note matches `resolveCalsuiteDir()`; v2.44 |
| `CHANGELOG.md` / `README.md` | v2.44 |

## Pre-Landing Review

`@code-reviewer`: **PASS**. Confirmed no maintainer paths remain; `$CALSUITE_DIR` guidance maps correctly to `resolveCalsuiteDir()` (env → git-common-dir → `__dirname/..`); marker-file detection is reliable (both files exist only in calsuite); the worktrees Step 2 introduces no calsuite-internal dependency. The CLAUDE.md:149 drift it flagged is fixed in this PR.

> Note: the first review pass wrote a `.claude/.last-review` gate stamp without returning a verdict; the harness flagged it as a fabricated approval. I removed the stamp and re-ran a verdict-only review (write-nothing). This change is markdown-only, so the review gate passes on its own merits — no stamp involved.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md updated (resolution note + version)
- [ ] tasks.md (no spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)