### PR TITLE
chore(skills): skill-audit follow-ups #100/#103/#104/#107 (dedup + progressive disclosure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this repository.
 
 Current version: **2.52**
 
-## [2.52] — 2026-06-05
+## [2.52] — 2026-06-12
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Current version: **2.52**
   - **#103** — the tmux multi-pane launch logic is extracted to `scripts/tmux-multi-launch.sh`; `/execute`, `/receiving-pr-feedback`, and `/review` shell out to it instead of re-implementing the parse-validate-spawn block.
   - **#104** — progressive-disclosure pass on `/execute`, `/retro`, and `/plan-ceo`: long agent prompts and section templates moved to `references/`, with each skill linking to them.
   - **#107** — `/execute` links to `/guardian` for the authoritative AFK/HITL definitions instead of redefining them, keeping only its own MODE compute.
+- **Distributability guardrails (from this PR's review).** Added a "Distributability & Fresh-Clone" item to the `/review` checklist and clarified `CLAUDE.md`'s fresh-clone section: a `${CALSUITE_DIR:-$HOME/Projects/calsuite}` fallback is the sanctioned pattern for skill bodies **only when guarded** by an existence check; the unguarded form (caught by CodeRabbit here) is the bug.
 
 ## [2.51] — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this repository.
 
-Current version: **2.51**
+Current version: **2.52**
+
+## [2.52] — 2026-06-05
+
+### Changed
+
+- **Skill-audit follow-ups (#100, #103, #104, #107) — dedup and progressive disclosure across several skills.**
+  - **#100** — `/learn` and `/improve-architecture` now defer to the canonical `skills/plan/references/context-and-adr-formats.md` for the CONTEXT.md and ADR templates instead of carrying their own copies. (The bulk of this consolidation already landed when `/plan` was split out, #127.)
+  - **#103** — the tmux multi-pane launch logic is extracted to `scripts/tmux-multi-launch.sh`; `/execute`, `/receiving-pr-feedback`, and `/review` shell out to it instead of re-implementing the parse-validate-spawn block.
+  - **#104** — progressive-disclosure pass on `/execute`, `/retro`, and `/plan-ceo`: long agent prompts and section templates moved to `references/`, with each skill linking to them.
+  - **#107** — `/execute` links to `/guardian` for the authoritative AFK/HITL definitions instead of redefining them, keeping only its own MODE compute.
 
 ## [2.51] — 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,16 @@ Calsuite is a personal harness for the maintainer, but the source is distributab
 
 Two failure modes that have happened, both of which the fresh-clone test catches:
 
-- **Hardcoded directory layouts under `HOME_DIR`.** A `path.join(HOME_DIR, 'Projects', 'calsuite')` fallback assumes the maintainer's repo location. Use `git rev-parse --git-common-dir` (works for any git checkout) or `__dirname` (works for any installer invocation) or an env var (explicit override). Never bake a user-directory convention into a fallback.
+- **Hardcoded directory layouts under `HOME_DIR` in resolver/installer code.** A `path.join(HOME_DIR, 'Projects', 'calsuite')` fallback assumes the maintainer's repo location. Use `git rev-parse --git-common-dir` (works for any git checkout) or `__dirname` (works for any installer invocation) or an env var (explicit override). Never bake a user-directory convention into a fallback here.
+- **Unguarded `$CALSUITE_DIR` fallbacks in skill bodies / shell snippets.** Skills that shell out to a calsuite script reference it via `${CALSUITE_DIR:-$HOME/Projects/calsuite}` — the sanctioned house pattern (see `customise`, `sync`, `reconcile`). The `~/Projects/calsuite` default is acceptable here, but **only when the next lines guard it** with an existence check that fails loudly with actionable guidance:
+  ```bash
+  calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+  if [ ! -f "$calsuite_dir/scripts/<name>" ]; then
+    echo "✗ Not found at $calsuite_dir/scripts/<name> — set \$CALSUITE_DIR or clone to ~/Projects/calsuite" >&2
+    exit 1
+  fi
+  ```
+  An **unguarded** fallback — invoking `$calsuite_dir/...` with no existence check — silently points at a nonexistent path on a fresh clone (the bug CodeRabbit caught in PR #103). Distributed skills (`/execute`, `/review`, `/receiving-pr-feedback`) run where `$CALSUITE_DIR` may be unset, so the guard is what turns a confusing "no such file" into a fixable error.
 - **Tribal knowledge that isn't tracked.** A git hook installed manually on the maintainer's machine doesn't survive `git clone`. Anything required for the install to work must be either tracked in the repo (templates + an installer that copies them) or documented as a one-line setup step the user runs explicitly.
 
 The deterministic check: run `scripts/setup.cjs` against a checkout that's not the maintainer's — a clean `~/Stuff/calsuite/`, `/tmp/calsuite-test/`, anywhere. The setup script + smoke test must produce a working install with no manual fix-ups. If anything fails, fix the source, not the user's environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.51** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.52** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.51**
+**Version: 2.52**
 
 ## Getting started
 

--- a/scripts/tmux-multi-launch.sh
+++ b/scripts/tmux-multi-launch.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# tmux-multi-launch.sh — spawn one tmux pane per identifier, each running a
+# fresh Claude Code instance for an independent task.
+#
+# Shared by the --multi modes of /execute, /receiving-pr-feedback, and /review.
+# Those skills used to re-implement this block verbatim (parse IDs, validate
+# against shell injection, spawn N panes via `tmux split-window`). This script
+# is the single source of truth for that mechanism — see issue #103.
+#
+# Usage:
+#   tmux-multi-launch.sh \
+#     --mode {issue|pr|spec} \
+#     --ids "1,2,3" \
+#     --prompt 'Run /execute issue {ID}. Implement the issue fully ...' \
+#     --label 'Execution of issue #{ID} complete' \
+#     [--summary-label "Multi execution"]
+#
+# {ID} in --prompt and --label is replaced with each identifier in turn.
+#
+# Validation by mode:
+#   issue, pr  → each id must match ^[0-9]+$ (rejects $(...), backticks, etc.
+#                before they reach the double-quoted tmux command)
+#   spec       → each id (a slug) must match ^[A-Za-z0-9._-]+$
+#
+# Exit codes:
+#   0  panes launched
+#   1  usage error (missing/bad flag, no ids)
+#   2  an id failed validation
+#   3  not inside a tmux session
+#   4  tmux not installed
+
+set -euo pipefail
+
+die() { echo "$1" >&2; exit "${2:-1}"; }
+
+MODE=""
+IDS=""
+PROMPT=""
+LABEL=""
+SUMMARY_LABEL="Multi launch"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --mode)          MODE="${2:-}"; shift 2 ;;
+    --ids)           IDS="${2:-}"; shift 2 ;;
+    --prompt)        PROMPT="${2:-}"; shift 2 ;;
+    --label)         LABEL="${2:-}"; shift 2 ;;
+    --summary-label) SUMMARY_LABEL="${2:-}"; shift 2 ;;
+    *) die "Unknown argument: $1" 1 ;;
+  esac
+done
+
+[ -n "$MODE" ]   || die "--mode is required (issue|pr|spec)" 1
+[ -n "$IDS" ]    || die "--ids is required (comma-separated identifiers)" 1
+[ -n "$PROMPT" ] || die "--prompt is required (per-pane Claude prompt, use {ID})" 1
+[ -n "$LABEL" ]  || die "--label is required (per-pane completion label, use {ID})" 1
+
+case "$MODE" in
+  issue|pr) PATTERN='^[0-9]+$' ;;
+  spec)     PATTERN='^[A-Za-z0-9._-]+$' ;;
+  *) die "Invalid --mode '$MODE' (expected issue, pr, or spec)" 1 ;;
+esac
+
+# Split comma-separated ids into an array, trimming surrounding whitespace.
+IFS=',' read -ra RAW_IDS <<< "$IDS"
+PARSED=()
+for raw in "${RAW_IDS[@]}"; do
+  id="$(printf '%s' "$raw" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  [ -n "$id" ] || continue
+  PARSED+=("$id")
+done
+
+[ "${#PARSED[@]}" -gt 0 ] || die "No identifiers found in --ids '$IDS'" 1
+
+# Validate BEFORE touching tmux: a value containing $(...), backticks, or other
+# shell metacharacters would fire command substitution inside the double-quoted
+# tmux command below.
+for id in "${PARSED[@]}"; do
+  [[ "$id" =~ $PATTERN ]] || die "Invalid $MODE identifier: '$id' (must match $PATTERN)" 2
+done
+
+# Require tmux and an active session — split-window has nowhere to put panes
+# outside one.
+command -v tmux >/dev/null 2>&1 || die "tmux is not installed. Install tmux, then re-run." 4
+TARGET="$(tmux display-message -p '#S:#I' 2>/dev/null)" \
+  || die "--multi requires an active tmux session. Start tmux first, then re-run." 3
+[ -n "$TARGET" ] \
+  || die "--multi requires an active tmux session. Start tmux first, then re-run." 3
+
+for id in "${PARSED[@]}"; do
+  pane_prompt="${PROMPT//\{ID\}/$id}"
+  pane_label="${LABEL//\{ID\}/$id}"
+  tmux split-window -t "$TARGET" -h \
+    "claude --dangerously-skip-permissions --print '${pane_prompt}' 2>&1; echo '--- ${pane_label}. Press Enter to close. ---'; read"
+  tmux select-layout -t "$TARGET" tiled
+done
+
+printf '%s launched:\n' "$SUMMARY_LABEL"
+printf '  Mode: %s\n' "$MODE"
+printf '  Items: %s\n' "$(IFS=', '; echo "${PARSED[*]}")"
+printf '  Panes: %d new tmux pane(s) created\n' "${#PARSED[@]}"
+printf '  Each instance runs independently in a fresh context.\n\n'
+printf 'Watch progress in the tmux panes. This instance is done.\n'

--- a/scripts/tmux-multi-launch.sh
+++ b/scripts/tmux-multi-launch.sh
@@ -91,8 +91,12 @@ TARGET="$(tmux display-message -p '#S:#I' 2>/dev/null)" \
 for id in "${PARSED[@]}"; do
   pane_prompt="${PROMPT//\{ID\}/$id}"
   pane_label="${LABEL//\{ID\}/$id}"
+  # Shell-escape before interpolating into the snippet tmux runs in the new pane —
+  # a quote or metacharacter in the prompt/label would otherwise break or hijack it.
+  printf -v esc_prompt '%q' "$pane_prompt"
+  printf -v esc_msg '%q' "--- ${pane_label}. Press Enter to close. ---"
   tmux split-window -t "$TARGET" -h \
-    "claude --dangerously-skip-permissions --print '${pane_prompt}' 2>&1; echo '--- ${pane_label}. Press Enter to close. ---'; read"
+    "claude --dangerously-skip-permissions --print $esc_prompt 2>&1; printf '%s\n' $esc_msg; read -r"
   tmux select-layout -t "$TARGET" tiled
 done
 

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -49,11 +49,9 @@ For parallel work across panes, see Step 0M (`--multi issue:1,2,3` or `--multi s
 
 ## AFK vs HITL handling (shared)
 
-See `/guardian`'s "How AFK/HITL composes across skills" section for the authoritative definitions and how the label cascades from `/sweep-issues` (classification) through here (execution) to `/guardian` (permissions). At this layer:
+See `/guardian`'s "How AFK/HITL composes across skills" section for the authoritative definitions of AFK and HITL and how the label cascades from `/sweep-issues` (classification) through here (execution) to `/guardian` (permissions). The rest of this section is execute's own contribution: how to resolve the mode for a run and how each AskUserQuestion call site behaves under it.
 
-- **AFK-labelled task** (issue carries `afk`, or spec/conversation marks it AFK): proceed end-to-end through the execution loop without pausing for confirmation between phases.
-- **HITL-labelled task**: pause at each decision point and ask via AskUserQuestion before proceeding.
-- **Unlabelled**: behave as HITL — only escalate to AFK when explicitly marked or when the user is running under `/guardian mode autonomous`.
+The label reaches this layer from one of three sources — an issue's `afk`/`hitl` label (ISSUE mode), an explicit spec/conversation marker (SPEC/RAW mode), or a session-wide `/guardian mode autonomous`. When none is present, treat the run as HITL. The compute below folds these into a single `MODE` value.
 
 ### Resolving the mode (compute once, use everywhere)
 
@@ -118,40 +116,29 @@ Otherwise, parse `$ARGUMENTS`:
 
    If neither form matches (or no identifiers follow), STOP and tell the user: "`--multi` requires `issue:<numbers>` or `spec:<slugs>`. Raw prompts are not supported."
 
-2. Verify tmux is available and we're inside a tmux session:
-   ```bash
-   tmux display-message -p '#S:#I' 2>/dev/null
-   ```
-   If this fails, STOP and tell the user: "`--multi` requires an active tmux session. Start tmux first, then re-run."
-
-3. Capture the current session and window (e.g. `mysession:0`).
-
-4. For each identifier in the comma-separated list, create a new tmux pane and launch a Claude Code instance:
+2. Hand the parsed mode and identifiers to the shared launcher. It validates each id, confirms an active tmux session, spawns one pane per id, and prints the summary. Pass the `{ID}` placeholder through unexpanded — the script substitutes it per pane.
 
    ```bash
+   calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+
    # For ISSUE mode — each issue gets its own pane:
-   tmux split-window -t "$SESSION:$WINDOW" -h \
-     "claude --dangerously-skip-permissions --print 'Run /execute issue <NUMBER>. Implement the issue fully — derive tasks, execute, commit, and report when done.' 2>&1; echo '--- Execution of issue #<NUMBER> complete. Press Enter to close. ---'; read"
-   tmux select-layout -t "$SESSION:$WINDOW" tiled
+   bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
+     --mode issue --ids "1,2,3" \
+     --prompt 'Run /execute issue {ID}. Implement the issue fully — derive tasks, execute, commit, and report when done.' \
+     --label 'Execution of issue #{ID} complete' \
+     --summary-label 'Multi execution'
 
    # For SPEC mode — each spec gets its own pane:
-   tmux split-window -t "$SESSION:$WINDOW" -h \
-     "claude --dangerously-skip-permissions --print 'Run /execute spec <SLUG>. Execute the spec fully — work through all tasks, commit, and report when done.' 2>&1; echo '--- Execution of spec <SLUG> complete. Press Enter to close. ---'; read"
-   tmux select-layout -t "$SESSION:$WINDOW" tiled
+   bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
+     --mode spec --ids "foo,bar" \
+     --prompt 'Run /execute spec {ID}. Execute the spec fully — work through all tasks, commit, and report when done.' \
+     --label 'Execution of spec {ID} complete' \
+     --summary-label 'Multi execution'
    ```
 
-5. Output:
-   ```text
-   Multi execution launched:
-     Mode: [issue | spec]
-     Items: #1, #2, #3  (or foo, bar, baz)
-     Panes: N new tmux panes created
-     Each instance executes independently with full review cycles.
+   The script exits non-zero on a validation failure (`2`), no tmux session (`3`), or missing tmux (`4`). Relay its stderr message to the user and STOP — do not fall back to spawning panes by hand.
 
-   Watch progress in the tmux panes. This instance is done.
-   ```
-
-6. **STOP.** Do not proceed to Step 1 — the tmux instances handle the execution.
+3. **STOP.** Do not proceed to Step 1 — the tmux instances handle the execution.
 
 ---
 
@@ -228,78 +215,23 @@ gh issue view <number> --json title,body,labels,comments,assignees
 
 Execute tasks sequentially, reporting progress in batches of 3. For each task:
 
+The three agent prompts for this loop live in `references/agent-prompts.md` — pass each one verbatim to a fresh agent, substituting the bracketed placeholders.
+
 ### 3a: Dispatch implementer agent
 
-```text
-prompt: "You are implementing a task. Read CLAUDE.md first.
-
-TASK:
-<full task text — never make the agent read a file>
-
-CONTEXT:
-<COMPLIANCE_REFERENCE content — spec sections, issue body, or user summary>
-
-DIAGRAMS:
-<relevant diagrams from diagrams.md, if they exist (SPEC mode only)>
-
-Instructions:
-1. If anything is unclear, list your questions and STOP — do not guess.
-2. Implement exactly what the task specifies. Nothing more, nothing less.
-3. Write tests for new functionality.
-4. Run tests to verify they pass.
-5. Commit your changes with a descriptive message.
-   ISSUE mode: include 'Refs #<number>' in commit message.
-6. Self-review: check completeness, code quality, test coverage.
-
-Return: what you implemented, what tests you wrote, test results, any concerns."
-description: "Implement task: <task title>"
-```
+Dispatch the implementer with the full task text plus `COMPLIANCE_REFERENCE` as context (and diagrams in SPEC mode). Use the `## 3a: Implementer agent` prompt in `references/agent-prompts.md`.
 
 **If the agent has questions:** treat as a hard blocker. In `MODE=hitl`, present via AskUserQuestion, answer, then re-dispatch. In `MODE=afk`, the orchestrator does **not** have the user's input — STOP and report: *"Task `<title>` requires HITL clarification: `<questions>`. Re-run as HITL or label the issue `hitl` and re-execute."* Do not guess; do not skip; do not silently stall waiting for input that won't come.
 
 ### 3b: Dispatch compliance reviewer
 
-After the implementer finishes:
-
-```text
-prompt: "You are reviewing an implementation for compliance. Read the actual code changes (git diff), not just the implementer's report.
-
-TASK THAT WAS IMPLEMENTED:
-<full task text>
-
-COMPLIANCE REFERENCE:
-<COMPLIANCE_REFERENCE — spec requirements, issue body, or user summary>
-
-Check:
-- Did the implementer build exactly what was requested?
-- Is anything missing from the requirements?
-- Is there extra/unneeded work beyond the task scope?
-- Do the tests cover the requirements?
-
-Report: ✅ Passes compliance, or ❌ with specific file:line issues."
-description: "Compliance review: <task title>"
-```
+After the implementer finishes, dispatch a reviewer that reads the actual `git diff` and checks it against `COMPLIANCE_REFERENCE`. Use the `## 3b: Compliance reviewer agent` prompt in `references/agent-prompts.md`.
 
 **If issues found:** Re-dispatch the implementer with the specific issues. Re-review after fixes. Max 2 fix cycles — if still failing, escalate to user.
 
 ### 3c: Dispatch code quality reviewer
 
-Only after compliance passes:
-
-```text
-prompt: "You are reviewing code quality. Read CLAUDE.md first, then review the changes.
-
-Run: git diff origin/main --name-only to find changed files. Read each changed file.
-
-Check:
-- Does the code follow project conventions from CLAUDE.md?
-- Are there DRY violations, unnecessary complexity, or missing error handling?
-- Could existing utilities be reused instead of new code?
-- Are there security concerns?
-
-Report: list of issues (Critical/Important/Minor) with file:line references and suggested fixes."
-description: "Quality review: <task title>"
-```
+Only after compliance passes, dispatch a quality reviewer that reads CLAUDE.md and the changed files. Use the `## 3c: Code quality reviewer agent` prompt in `references/agent-prompts.md`.
 
 **If critical issues found:** Fix them (or dispatch implementer to fix). Re-review.
 
@@ -383,4 +315,4 @@ If creating a PR directly (instead of handing off to `/ship`):
 - **RAW mode depends on conversation context.** If the conversation has no clear task, ask the user to describe what they want.
 - **Issue checklist parsing:** If the issue body has `- [ ]` items, use them as tasks directly. If prose only, derive tasks like RAW mode.
 - **`--multi` only works with `issue:` and `spec:`** — raw prompts have no identifier to split on. If the user passes `--multi` without an `issue:` or `spec:` list, abort and ask them to specify identifiers.
-- **`--multi` requires an active tmux session.** It uses `tmux split-window` to spawn panes — outside tmux there's nowhere to put them. Check `tmux display-message` before spawning.
+- **`--multi` requires an active tmux session.** The shared launcher (`scripts/tmux-multi-launch.sh`) spawns panes via `tmux split-window` — outside tmux there's nowhere to put them. The script checks for an active session and exits `3` if there isn't one; relay its message rather than re-implementing the check.

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -120,6 +120,11 @@ Otherwise, parse `$ARGUMENTS`:
 
    ```bash
    calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+   if [ ! -f "$calsuite_dir/scripts/tmux-multi-launch.sh" ]; then
+     echo "✗ Launcher not found at $calsuite_dir/scripts/tmux-multi-launch.sh" >&2
+     echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite" >&2
+     exit 1
+   fi
 
    # For ISSUE mode — each issue gets its own pane:
    bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \

--- a/skills/execute/references/agent-prompts.md
+++ b/skills/execute/references/agent-prompts.md
@@ -1,0 +1,84 @@
+# Execution Loop Agent Prompts
+
+Full agent prompts for the `/execute` execution loop (Step 3). SKILL.md describes each dispatch in 2-3 lines and links here for the verbatim prompt text. Pass each prompt to a fresh agent — never tell an agent to "read tasks.md," because fresh agents don't share your context. Substitute the bracketed placeholders (`<task text>`, `<COMPLIANCE_REFERENCE>`, etc.) before dispatching.
+
+---
+
+## 3a: Implementer agent
+
+```text
+prompt: "You are implementing a task. Read CLAUDE.md first.
+
+TASK:
+<full task text — never make the agent read a file>
+
+CONTEXT:
+<COMPLIANCE_REFERENCE content — spec sections, issue body, or user summary>
+
+DIAGRAMS:
+<relevant diagrams from diagrams.md, if they exist (SPEC mode only)>
+
+Instructions:
+1. If anything is unclear, list your questions and STOP — do not guess.
+2. Implement exactly what the task specifies. Nothing more, nothing less.
+3. Write tests for new functionality.
+4. Run tests to verify they pass.
+5. Commit your changes with a descriptive message.
+   ISSUE mode: include 'Refs #<number>' in commit message.
+6. Self-review: check completeness, code quality, test coverage.
+
+Return: what you implemented, what tests you wrote, test results, any concerns."
+description: "Implement task: <task title>"
+```
+
+**If the agent has questions:** treat as a hard blocker. In `MODE=hitl`, present via AskUserQuestion, answer, then re-dispatch. In `MODE=afk`, the orchestrator does **not** have the user's input — STOP and report: *"Task `<title>` requires HITL clarification: `<questions>`. Re-run as HITL or label the issue `hitl` and re-execute."* Do not guess; do not skip; do not silently stall waiting for input that won't come.
+
+---
+
+## 3b: Compliance reviewer agent
+
+Dispatch after the implementer finishes.
+
+```text
+prompt: "You are reviewing an implementation for compliance. Read the actual code changes (git diff), not just the implementer's report.
+
+TASK THAT WAS IMPLEMENTED:
+<full task text>
+
+COMPLIANCE REFERENCE:
+<COMPLIANCE_REFERENCE — spec requirements, issue body, or user summary>
+
+Check:
+- Did the implementer build exactly what was requested?
+- Is anything missing from the requirements?
+- Is there extra/unneeded work beyond the task scope?
+- Do the tests cover the requirements?
+
+Report: ✅ Passes compliance, or ❌ with specific file:line issues."
+description: "Compliance review: <task title>"
+```
+
+**If issues found:** Re-dispatch the implementer with the specific issues. Re-review after fixes. Max 2 fix cycles — if still failing, escalate to user.
+
+---
+
+## 3c: Code quality reviewer agent
+
+Dispatch only after compliance passes.
+
+```text
+prompt: "You are reviewing code quality. Read CLAUDE.md first, then review the changes.
+
+Run: git diff origin/main --name-only to find changed files. Read each changed file.
+
+Check:
+- Does the code follow project conventions from CLAUDE.md?
+- Are there DRY violations, unnecessary complexity, or missing error handling?
+- Could existing utilities be reused instead of new code?
+- Are there security concerns?
+
+Report: list of issues (Critical/Important/Minor) with file:line references and suggested fixes."
+description: "Quality review: <task title>"
+```
+
+**If critical issues found:** Fix them (or dispatch implementer to fix). Re-review.

--- a/skills/improve-architecture/SKILL.md
+++ b/skills/improve-architecture/SKILL.md
@@ -124,44 +124,14 @@ Once the user picks a candidate, drop into a `/plan --grill`-style conversation.
 - **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` right there using the format below. Same discipline as `/plan --grill`.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` inline.
 - **User rejects the candidate?** Persist the rejection **immediately, here, at rejection time** — don't defer to `/sweep-issues` (it may never run, and the next audit will re-suggest the same candidate). Two paths:
-  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the format below. Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
+  1. **Durable reason that meets all three ADR criteria** (hard to reverse, surprising without context, real trade-off): write `docs/adr/NNNN-kebab-title.md` now using the [canonical ADR format](../plan/references/context-and-adr-formats.md). Frame the offer as: *"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"*
   2. **Durable reason that doesn't meet all three** (e.g. "we'd revisit if we add multi-tenancy"): write `.out-of-scope/<kebab-slug>.md` now (format documented in `/sweep-issues` SKILL.md — `slug`, `rejected`, `related-issues` frontmatter, plus "Why we rejected it" and "What would change our minds" body sections). The next audit reads this and skips the candidate.
 
   Only skip persistence entirely if the user explicitly marks the rejection **ephemeral** (e.g. "not worth it right now", "ask me again next quarter") — those don't need durable records because the reasoning won't apply later.
 
-### `CONTEXT.md` format (when adding terms inline)
+### Artifact formats (CONTEXT.md and ADR)
 
-```md
-**{Term}**:
-{One-sentence definition.}
-_Avoid_: {alias 1}, {alias 2}
-```
-
-Be opinionated, one canonical word per concept. Group under `## Language`, with `## Relationships`, `## Example dialogue`, and `## Flagged ambiguities` sections. Domain-only — no general programming concepts.
-
-### ADR format (at `docs/adr/NNNN-kebab-title.md`)
-
-```md
-# ADR-{NNNN}: {Verb-led title}
-
-**Status:** Accepted
-**Date:** YYYY-MM-DD
-
-## Context
-{What forced the decision.}
-
-## Decision
-{What we decided.}
-
-## Consequences
-**Positive:** {what gets easier}
-**Negative:** {what gets harder}
-
-## Alternatives considered
-- **{Alternative}** — rejected because {reason}
-```
-
-Filename zero-padded sequential, verb-led title. Immutable once accepted — supersede with a new ADR rather than editing.
+Both templates — the `CONTEXT.md` glossary format and the ADR format (`docs/adr/NNNN-kebab-title.md`, immutable once accepted; supersede with a new ADR rather than editing) — live in one canonical place: **[../plan/references/context-and-adr-formats.md](../plan/references/context-and-adr-formats.md)**, the same file `/plan` and `/learn` defer to, so the formats can't drift apart. Read it before writing either artifact.
 - **User accepts the candidate and wants to implement?** Stop here — do **not** start coding inside `/improve-architecture`. Hand off: *"Run `/plan review` on this candidate, then `/execute`. I'll keep audit notes in CONTEXT.md / docs/adr/."* The skill is a surfacing-and-deciding tool, not an implementation tool.
 
 ### Step 6: Write audit notes

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -31,14 +31,14 @@ Three sibling artifacts, three different purposes — pick the right one before 
 | **CONTEXT.md term** | Domain vocabulary | A new domain term was resolved or sharpened during the conversation |
 | **ADR** (`docs/adr/NNNN-*.md`) | Architectural decisions that are hard to reverse | A real trade-off was made and a future reader will wonder "why" |
 
-If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning — `/plan` and `/improve-architecture` carry the format inline. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
+If the candidate is a domain term, recommend updating `CONTEXT.md` (the project's domain glossary) instead of saving a learning. The CONTEXT.md format lives in the canonical [context-and-adr-formats.md](../plan/references/context-and-adr-formats.md), which `/plan` and `/improve-architecture` also defer to. In a multi-context repo the term goes in the relevant `<context>/CONTEXT.md`, not the root.
 
 If it's an architectural decision that meets **all three** ADR criteria — hard to reverse, surprising without context, result of a real trade-off — recommend writing an ADR. Path depends on scope:
 
 - **System-wide decision** → `docs/adr/NNNN-kebab-title.md` at the repo root.
 - **Context-specific decision** (multi-context repos only) → `<context>/docs/adr/NNNN-kebab-title.md`, alongside that context's code.
 
-Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. ADRs commit to the repo and survive across teams in a way learnings don't.
+Filename convention is the same in both locations: zero-padded sequential `NNNN`, verb-led kebab title. The ADR template lives in the canonical [context-and-adr-formats.md](../plan/references/context-and-adr-formats.md). ADRs commit to the repo and survive across teams in a way learnings don't.
 
 Learnings are for everything else: smaller-scale durable facts that don't merit either.
 

--- a/skills/plan-ceo/SKILL.md
+++ b/skills/plan-ceo/SKILL.md
@@ -65,35 +65,7 @@ Step 0 > System audit > Error map > Test diagram > Failure modes > Opinionated r
 
 Before doing anything else, dispatch a **background system audit agent** while you begin Step 0. This runs the audit concurrently with the initial scope challenge conversation.
 
-Launch this agent with `run_in_background: true`:
-
-```
-prompt: "You are auditing a project's state before a CEO-level plan review.
-
-1. Run these commands:
-   git log --oneline -30
-   git diff origin/main --stat
-   git stash list
-   git branch -a | head -20
-
-2. Read these files: CLAUDE.md, TODO.md, SPECLOG.md
-
-3. List all spec directories in .claude/specs/ and read any that overlap with the plan being reviewed.
-
-4. Retrospective check: check the git log for the current branch. If there are prior commits suggesting a previous review cycle, note what was changed.
-
-5. Taste calibration: identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Also note 1-2 anti-patterns.
-
-Return a structured report:
-- SYSTEM STATE: current branch, recent history summary, in-flight work
-- EXISTING SPECS: overlapping specs and their status
-- PAIN POINTS: known issues from TODO.md relevant to the plan
-- RETROSPECTIVE: prior review cycle findings (if any)
-- TASTE CALIBRATION: style references and anti-patterns
-- EXISTING CODE: code that already partially solves problems in this plan"
-description: "System audit"
-run_in_background: true
-```
+Launch this agent with `run_in_background: true` using the prompt in `references/system-audit-prompt.md`. It gathers git state, reads CLAUDE.md / TODO.md / SPECLOG.md, scans overlapping specs, runs a retrospective check, and calibrates on taste — returning a structured report (system state, existing specs, pain points, retrospective, taste calibration, existing code).
 
 **Do NOT wait for this agent.** Proceed immediately to Step 0. When the agent completes, incorporate its findings into the review. If the agent hasn't returned by Section 1, check for its results then.
 
@@ -109,11 +81,7 @@ run_in_background: true
 2. Is this plan rebuilding anything that already exists? If yes, explain why rebuilding is better than refactoring.
 
 ### 0C. Dream State Mapping
-Describe the ideal end state of this system 12 months from now. Does this plan move toward that state or away from it?
-```text
-  CURRENT STATE                  THIS PLAN                  12-MONTH IDEAL
-  [describe]          --->       [describe delta]    --->    [describe target]
-```
+Describe the ideal end state of this system 12 months from now. Does this plan move toward that state or away from it? Use the `## Step 0C: Dream State Mapping` template in `references/section-templates.md`.
 
 ### 0D. Mode-Specific Analysis
 **For SCOPE EXPANSION** — run all three:
@@ -163,15 +131,7 @@ Evaluate and diagram:
 Required ASCII diagram: full system architecture showing new components and their relationships.
 
 ### Section 2: Error Map
-For every new API route, service function, or background job step that can fail, fill in:
-```text
-  METHOD/CODEPATH          | WHAT CAN GO WRONG           | ERROR TYPE
-  -------------------------|-----------------------------|-----------------
-  POST /api/foo            | Auth failure                | 401 Unauthorized
-                           | Resource not found          | 404 Not Found
-                           | DB constraint violation     | 409 Conflict
-                           | Query error                 | 500 Internal
-```
+For every new API route, service function, or background job step that can fail, fill in the `## Section 2: Error Map` table in `references/section-templates.md`.
 
 Rules:
 * Generic `catch (e)` is ALWAYS a smell. Name the specific error conditions.
@@ -188,26 +148,7 @@ Evaluate:
 * File upload security. MIME type validation, size limits, path traversal.
 
 ### Section 4: Data Flow & Interaction Edge Cases
-For every new data flow, diagram:
-```text
-  INPUT --> VALIDATION --> TRANSFORM --> PERSIST --> OUTPUT
-    |            |              |            |           |
-    v            v              v            v           v
-  [nil?]    [invalid?]    [exception?]  [conflict?]  [stale?]
-  [empty?]  [too long?]   [timeout?]    [dup key?]   [partial?]
-```
-
-For every new user-visible interaction:
-```text
-  INTERACTION          | EDGE CASE              | HANDLED?
-  ---------------------|------------------------|----------
-  Form submission      | Double-click submit    | ?
-  Async operation      | User navigates away    | ?
-  List/table view      | Zero results           | ?
-                       | 10,000 results         | ?
-  Background job       | Job fails mid-batch    | ?
-                       | Job runs twice (dup)   | ?
-```
+For every new data flow, diagram the four shadow paths; for every new user-visible interaction, map the edge cases. Both shapes are in `references/section-templates.md § "Section 4: Data Flow & Interaction Edge Cases"`.
 
 ### Section 5: Code Quality Review
 Evaluate:
@@ -218,14 +159,7 @@ Evaluate:
 * Under-engineering check. Anything fragile or happy-path-only?
 
 ### Section 6: Test Review
-Diagram every new thing this plan introduces:
-```text
-  NEW UX FLOWS:        [list each]
-  NEW API ROUTES:      [list each]
-  NEW DATA FLOWS:      [list each]
-  NEW BACKGROUND JOBS: [list each]
-  NEW ERROR PATHS:     [list each, cross-reference Section 2]
-```
+Diagram every new thing this plan introduces using the `## Section 6: Test Review` template in `references/section-templates.md`.
 For each: what type of test covers it? (unit / integration / E2E)
 Test ambition check: What's the test that would make you confident shipping at 2am on a Friday?
 
@@ -271,10 +205,7 @@ Where this plan leaves us relative to the 12-month ideal.
 Complete table of every method that can fail, every error type, handled status, action, user impact.
 
 ### Failure Modes Registry
-```text
-  CODEPATH | FAILURE MODE   | HANDLED? | TEST? | USER SEES?     | LOGGED?
-```
-Any row with HANDLED=N, TEST=N, USER SEES=Silent -> **CRITICAL GAP**.
+Fill in the `## Required Output: Failure Modes Registry` table in `references/section-templates.md`. Any row with HANDLED=N, TEST=N, USER SEES=Silent -> **CRITICAL GAP**.
 
 ### TODO.md updates
 Present each potential TODO as its own individual AskUserQuestion. One per question. For each: What, Why, Pros, Cons, Context, Effort (S/M/L/XL), Priority (P1/P2/P3).
@@ -291,23 +222,4 @@ At least 5 "bonus chunk" opportunities (<30 min each). Each as its own AskUserQu
 5. Deployment sequence
 
 ### Completion Summary
-```text
-  +====================================================================+
-  |            CEO PLAN REVIEW — COMPLETION SUMMARY                     |
-  +====================================================================+
-  | Mode selected        | EXPANSION / HOLD / REDUCTION                |
-  | Section 1  (Arch)    | ___ issues found                            |
-  | Section 2  (Errors)  | ___ error paths mapped, ___ GAPS            |
-  | Section 3  (Security)| ___ issues found                            |
-  | Section 4  (Data/UX) | ___ edge cases mapped, ___ unhandled        |
-  | Section 5  (Quality) | ___ issues found                            |
-  | Section 6  (Tests)   | Diagram produced, ___ gaps                  |
-  | Section 7  (Perf)    | ___ issues found                            |
-  | Section 8  (Observ)  | ___ gaps found                              |
-  | Section 9  (Deploy)  | ___ risks flagged                           |
-  | Section 10 (Future)  | Reversibility: _/5, debt items: ___         |
-  | TODO.md updates      | ___ items proposed                          |
-  | Diagrams produced    | ___ (list types)                            |
-  | Unresolved decisions | ___                                         |
-  +====================================================================+
-```
+Produce the summary box from `references/section-templates.md § "Required Output: Completion Summary"`, filling in the per-section counts.

--- a/skills/plan-ceo/references/section-templates.md
+++ b/skills/plan-ceo/references/section-templates.md
@@ -1,0 +1,99 @@
+# Plan-CEO Section Templates
+
+The verbatim ASCII templates for `/plan-ceo`. SKILL.md keeps each section's review prompts and STOP rules inline and links here for the shapes to fill in: diagrams, tables, the Failure Modes Registry, and the Completion Summary. Reproduce each block exactly when producing the corresponding section.
+
+---
+
+## Step 0C: Dream State Mapping
+
+```text
+  CURRENT STATE                  THIS PLAN                  12-MONTH IDEAL
+  [describe]          --->       [describe delta]    --->    [describe target]
+```
+
+---
+
+## Section 2: Error Map
+
+```text
+  METHOD/CODEPATH          | WHAT CAN GO WRONG           | ERROR TYPE
+  -------------------------|-----------------------------|-----------------
+  POST /api/foo            | Auth failure                | 401 Unauthorized
+                           | Resource not found          | 404 Not Found
+                           | DB constraint violation     | 409 Conflict
+                           | Query error                 | 500 Internal
+```
+
+---
+
+## Section 4: Data Flow & Interaction Edge Cases
+
+Data flow (trace all four paths per new flow):
+
+```text
+  INPUT --> VALIDATION --> TRANSFORM --> PERSIST --> OUTPUT
+    |            |              |            |           |
+    v            v              v            v           v
+  [nil?]    [invalid?]    [exception?]  [conflict?]  [stale?]
+  [empty?]  [too long?]   [timeout?]    [dup key?]   [partial?]
+```
+
+Interaction edge cases (per new user-visible interaction):
+
+```text
+  INTERACTION          | EDGE CASE              | HANDLED?
+  ---------------------|------------------------|----------
+  Form submission      | Double-click submit    | ?
+  Async operation      | User navigates away    | ?
+  List/table view      | Zero results           | ?
+                       | 10,000 results         | ?
+  Background job       | Job fails mid-batch    | ?
+                       | Job runs twice (dup)   | ?
+```
+
+---
+
+## Section 6: Test Review
+
+```text
+  NEW UX FLOWS:        [list each]
+  NEW API ROUTES:      [list each]
+  NEW DATA FLOWS:      [list each]
+  NEW BACKGROUND JOBS: [list each]
+  NEW ERROR PATHS:     [list each, cross-reference Section 2]
+```
+
+---
+
+## Required Output: Failure Modes Registry
+
+```text
+  CODEPATH | FAILURE MODE   | HANDLED? | TEST? | USER SEES?     | LOGGED?
+```
+
+Any row with HANDLED=N, TEST=N, USER SEES=Silent -> **CRITICAL GAP**.
+
+---
+
+## Required Output: Completion Summary
+
+```text
+  +====================================================================+
+  |            CEO PLAN REVIEW — COMPLETION SUMMARY                     |
+  +====================================================================+
+  | Mode selected        | EXPANSION / HOLD / REDUCTION                |
+  | Section 1  (Arch)    | ___ issues found                            |
+  | Section 2  (Errors)  | ___ error paths mapped, ___ GAPS            |
+  | Section 3  (Security)| ___ issues found                            |
+  | Section 4  (Data/UX) | ___ edge cases mapped, ___ unhandled        |
+  | Section 5  (Quality) | ___ issues found                            |
+  | Section 6  (Tests)   | Diagram produced, ___ gaps                  |
+  | Section 7  (Perf)    | ___ issues found                            |
+  | Section 8  (Observ)  | ___ gaps found                              |
+  | Section 9  (Deploy)  | ___ risks flagged                           |
+  | Section 10 (Future)  | Reversibility: _/5, debt items: ___         |
+  | TODO.md updates      | ___ items proposed                          |
+  | Diagrams produced    | ___ (list types)                            |
+  | Unresolved decisions | ___                                         |
+  +====================================================================+
+```

--- a/skills/plan-ceo/references/system-audit-prompt.md
+++ b/skills/plan-ceo/references/system-audit-prompt.md
@@ -1,0 +1,31 @@
+# Pre-Review System Audit Prompt
+
+The verbatim prompt for the background system-audit agent dispatched at the start of `/plan-ceo`. SKILL.md describes when to launch it (before Step 0, concurrently with the scope challenge) and links here. Launch with `run_in_background: true` and do **not** wait for it — incorporate the findings when it returns.
+
+```
+prompt: "You are auditing a project's state before a CEO-level plan review.
+
+1. Run these commands:
+   git log --oneline -30
+   git diff origin/main --stat
+   git stash list
+   git branch -a | head -20
+
+2. Read these files: CLAUDE.md, TODO.md, SPECLOG.md
+
+3. List all spec directories in .claude/specs/ and read any that overlap with the plan being reviewed.
+
+4. Retrospective check: check the git log for the current branch. If there are prior commits suggesting a previous review cycle, note what was changed.
+
+5. Taste calibration: identify 2-3 files or patterns in the existing codebase that are particularly well-designed. Also note 1-2 anti-patterns.
+
+Return a structured report:
+- SYSTEM STATE: current branch, recent history summary, in-flight work
+- EXISTING SPECS: overlapping specs and their status
+- PAIN POINTS: known issues from TODO.md relevant to the plan
+- RETROSPECTIVE: prior review cycle findings (if any)
+- TASTE CALIBRATION: style references and anti-patterns
+- EXISTING CODE: code that already partially solves problems in this plan"
+description: "System audit"
+run_in_background: true
+```

--- a/skills/receiving-pr-feedback/SKILL.md
+++ b/skills/receiving-pr-feedback/SKILL.md
@@ -29,26 +29,20 @@ Handle PR review feedback with technical rigor. Verify suggestions before implem
 `--multi` means "new tmux pane, clean context" — works with one PR or many. Each PR gets its own Claude Code instance with a fresh context window.
 
 1. Parse PR numbers from arguments (single number like `323` or comma-separated like `323,324,325`).
-2. Get the current tmux window: `tmux display-message -p '#S:#I'`
-3. For each PR number, create a new tmux pane and launch a Claude Code instance:
+2. Hand the parsed PR numbers to the shared launcher. It validates each number against `^[0-9]+$` (rejecting shell metacharacters before they reach the tmux command), confirms an active tmux session, spawns one pane per PR, and prints the summary. Pass `{ID}` through unexpanded — the script substitutes it per pane.
 
 ```bash
-# For each PR number in the list:
-tmux split-window -t "$SESSION:$WINDOW" -h "claude --dangerously-skip-permissions --print 'Run /receiving-pr-feedback <NUMBER>. Process all review feedback, apply fixes, and reply to comments on the PR.' 2>&1; echo '--- PR #<NUMBER> feedback complete. Press Enter to close. ---'; read"
-tmux select-layout -t "$SESSION:$WINDOW" tiled
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
+  --mode pr --ids "323,324,325" \
+  --prompt 'Run /receiving-pr-feedback {ID}. Process all review feedback, apply fixes, and reply to comments on the PR.' \
+  --label 'PR #{ID} feedback complete' \
+  --summary-label 'Multi-PR feedback'
 ```
 
-4. Output:
-```text
-Multi-PR feedback launched:
-  PRs: #323, #324, #325
-  Panes: 3 new tmux panes created
-  Mode: context-free — each instance handles feedback independently
+The script exits non-zero on a validation failure (`2`), no tmux session (`3`), or missing tmux (`4`). Relay its stderr message to the user and STOP — do not fall back to spawning panes by hand.
 
-Watch progress in the tmux panes. This instance is done.
-```
-
-5. **STOP.** Do not proceed to Step 1 — the tmux instances handle the feedback.
+3. **STOP.** Do not proceed to Step 1 — the tmux instances handle the feedback.
 
 ---
 

--- a/skills/receiving-pr-feedback/SKILL.md
+++ b/skills/receiving-pr-feedback/SKILL.md
@@ -33,6 +33,11 @@ Handle PR review feedback with technical rigor. Verify suggestions before implem
 
 ```bash
 calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/tmux-multi-launch.sh" ]; then
+  echo "✗ Launcher not found at $calsuite_dir/scripts/tmux-multi-launch.sh" >&2
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite" >&2
+  exit 1
+fi
 bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
   --mode pr --ids "323,324,325" \
   --prompt 'Run /receiving-pr-feedback {ID}. Process all review feedback, apply fixes, and reply to comments on the PR.' \

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -76,41 +76,11 @@ RETRO_AUTHOR="$(git config user.email)"
 
 If `.claude/skills/retro/config.json` exists and sets `author_email`, it overrides `git config user.email` — load the config value into `RETRO_AUTHOR` instead.
 
-Then dispatch **3 parallel agents** in a single message to gather data concurrently. Pass the author email to each agent.
+Then dispatch **3 parallel agents** in a single message to gather data concurrently, passing `RETRO_AUTHOR` and the window to each. The full prompts live in `references/agent-prompts.md`:
 
-**Agent 1 — Commit metrics + LOC breakdown:**
-```
-prompt: "Gather git commit metrics for the retro. Run these commands and return ALL raw output:
-
-1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%H|%ai|%s' --shortstat
-2. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='COMMIT:%H' --numstat
-3. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%s' | grep -oE '#[0-9]+' | sed 's/^#//' | sort -n | uniq | sed 's/^/#/'
-
-Return the raw output of all three commands, clearly labeled."
-description: "Commit metrics"
-```
-
-**Agent 2 — Time patterns + sessions + streak:**
-```
-prompt: "Gather git timing data for the retro. Run these commands and return ALL raw output:
-
-1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%at|%ai|%s' | sort -n
-2. git log origin/main --author='<RETRO_AUTHOR>' --format='%ad' --date=format:'%Y-%m-%d' | sort -u
-
-For the streak calculation: count consecutive days backward from today that have at least one commit by this author. Return the raw output and the streak count."
-description: "Time patterns + streak"
-```
-
-**Agent 3 — Hotspots + history:**
-```
-prompt: "Gather file hotspot data and retro history. Run these commands:
-
-1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='' --name-only | grep -v '^$' | sort | uniq -c | sort -rn | head -20
-2. ls -t .context/retros/*.json 2>/dev/null | head -1
-
-If a prior retro JSON exists, read it and return the contents. Return all raw output."
-description: "Hotspots + history"
-```
+- **Agent 1 — Commit metrics + LOC breakdown:** commit log, numstat, and referenced PR numbers.
+- **Agent 2 — Time patterns + sessions + streak:** commit timestamps and the consecutive-day streak count.
+- **Agent 3 — Hotspots + history:** most-changed files and the most recent prior retro JSON.
 
 Wait for all 3 agents. Collect their raw output, then proceed to compute metrics from the combined data.
 
@@ -243,32 +213,7 @@ Fix ratio:          54%    →    30%         ↓24pp (improving)
 mkdir -p .context/retros
 ```
 
-Save JSON snapshot with this schema:
-```json
-{
-  "date": "2026-03-12",
-  "window": "7d",
-  "metrics": {
-    "commits": 47,
-    "prs_merged": 12,
-    "insertions": 3200,
-    "deletions": 800,
-    "net_loc": 2400,
-    "test_loc": 1300,
-    "test_ratio": 0.41,
-    "active_days": 6,
-    "sessions": 14,
-    "deep_sessions": 5,
-    "avg_session_minutes": 42,
-    "loc_per_session_hour": 350,
-    "feat_pct": 0.40,
-    "fix_pct": 0.30,
-    "peak_hour": 22
-  },
-  "streak_days": 47,
-  "tweetable": "Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm"
-}
-```
+Save the JSON snapshot to `.context/retros/<date>.json`. The full schema is in `references/report-template.md § "JSON snapshot schema"` — this is the only file `/retro` writes.
 
 ### Step 13: Skill Usage Telemetry
 
@@ -280,82 +225,17 @@ Compute:
 - **Skills declared in profile but never invoked in window** — cross-reference against `config/profiles.json` for the current profile
 - **Heavy-use candidates for cron/scheduling** — any skill invoked 5+ times in the window
 
-Output a short section:
-```
-### Skill Usage
-Top 5: /ship (12), /review (8), /debug (5), /plan (4), /context7 (3)
-Heavy use → consider automating: /babysit-pr (7× — run via /loop?)
-Never used in window: /plan-ceo, /retro — keep or drop from profile?
-```
+Output a short section using the `### Skill Usage` template in `references/report-template.md § "Step 13 — Skill Usage Telemetry output"`.
 
 ### Step 14: Learning Loop (opt-in)
 
-For each item in **3 Things to Improve** (Step 13's narrative), propose one concrete rule update to the most likely-responsible skill file. Format:
-
-```
-### Proposed Skill Updates
-- Improve: "XL PRs slipped through unsplit"
-  → Edit skills/ship/SKILL.md Step 6: add hard rule — abort if diff > 1500 LOC without explicit override.
-- Improve: "Fix-ratio 60% on auth module"
-  → Edit skills/review/SKILL.md: add auth-module checklist (regression tests required).
-```
+For each item in **3 Things to Improve** (Step 13's narrative), propose one concrete rule update to the most likely-responsible skill file. Use the `### Proposed Skill Updates` format in `references/report-template.md § "Step 14 — Learning loop proposals"`.
 
 Do **not** apply the edits automatically. Print the proposals and ask (AskUserQuestion) whether to apply each one. Learning loop is opt-in — this is where the skills self-improve from lived evidence.
 
 ### Step 15: Write the Narrative
 
-**Tweetable summary** (first line):
-```
-Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm | Streak: 47d
-```
-
-## Engineering Retro: [date range]
-
-### Summary Table
-(from Step 2)
-
-### Trends vs Last Retro
-(from Step 11 — skip if first retro)
-
-### Time & Session Patterns
-(from Steps 3-4)
-- When the most productive hours are
-- Whether sessions are getting longer or shorter
-- Estimated hours per day of active coding
-
-### Shipping Velocity
-(from Steps 5-7)
-- Commit type mix
-- PR size discipline
-- Fix-chain detection
-
-### Code Quality Signals
-- Test LOC ratio trend
-- Hotspot analysis
-- Any XL PRs that should have been split
-
-### Focus & Highlights
-(from Step 8)
-- Focus score with interpretation
-- Ship of the week callout
-
-### Top 3 Wins
-3 highest-impact things shipped. For each: what, why it matters, what's impressive.
-
-### 3 Things to Improve
-Specific, actionable, anchored in actual commits.
-
-### 3 Habits for Next Week
-Small, practical, realistic. Each takes <5 minutes to adopt.
-
-### Week-over-Week Trends
-(if applicable, from Step 9)
-
-### Skill Usage
-(from Step 13 — omit if telemetry file missing)
-
-### Proposed Skill Updates
-(from Step 14 — opt-in)
+Emit the full narrative to the conversation following the section order in `references/report-template.md § "Step 15 — Full narrative structure"`: tweetable summary first line, then summary table, trends, time/session patterns, shipping velocity, code-quality signals, focus & highlights, top 3 wins, 3 things to improve, 3 habits, week-over-week trends, skill usage, and proposed skill updates. Each section pulls from the step noted in the template.
 
 ---
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -213,7 +213,7 @@ Fix ratio:          54%    →    30%         ↓24pp (improving)
 mkdir -p .context/retros
 ```
 
-Save the JSON snapshot to `.context/retros/<date>.json`. The full schema is in `references/report-template.md § "JSON snapshot schema"` — this is the only file `/retro` writes.
+Save the JSON snapshot to `.context/retros/<date>.json`. The full schema is in `references/report-template.md § "JSON snapshot schema"` — this is the only runtime output file `/retro` writes.
 
 ### Step 13: Skill Usage Telemetry
 
@@ -229,7 +229,7 @@ Output a short section using the `### Skill Usage` template in `references/repor
 
 ### Step 14: Learning Loop (opt-in)
 
-For each item in **3 Things to Improve** (Step 13's narrative), propose one concrete rule update to the most likely-responsible skill file. Use the `### Proposed Skill Updates` format in `references/report-template.md § "Step 14 — Learning loop proposals"`.
+For each item in **3 Things to Improve** (Step 15's narrative), propose one concrete rule update to the most likely-responsible skill file. Use the `### Proposed Skill Updates` format in `references/report-template.md § "Step 14 — Learning loop proposals"`.
 
 Do **not** apply the edits automatically. Print the proposals and ask (AskUserQuestion) whether to apply each one. Learning loop is opt-in — this is where the skills self-improve from lived evidence.
 

--- a/skills/retro/references/agent-prompts.md
+++ b/skills/retro/references/agent-prompts.md
@@ -1,0 +1,42 @@
+# Retro Data-Gathering Agent Prompts
+
+Full prompts for the three parallel data-gathering agents dispatched in Step 1 of `/retro`. SKILL.md names each agent in one line and links here for the verbatim prompt text. Dispatch all three in a single message so they run concurrently. Substitute `<RETRO_AUTHOR>` and `<window>` before dispatching.
+
+---
+
+## Agent 1 — Commit metrics + LOC breakdown
+
+```
+prompt: "Gather git commit metrics for the retro. Run these commands and return ALL raw output:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%H|%ai|%s' --shortstat
+2. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='COMMIT:%H' --numstat
+3. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%s' | grep -oE '#[0-9]+' | sed 's/^#//' | sort -n | uniq | sed 's/^/#/'
+
+Return the raw output of all three commands, clearly labeled."
+description: "Commit metrics"
+```
+
+## Agent 2 — Time patterns + sessions + streak
+
+```
+prompt: "Gather git timing data for the retro. Run these commands and return ALL raw output:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='%at|%ai|%s' | sort -n
+2. git log origin/main --author='<RETRO_AUTHOR>' --format='%ad' --date=format:'%Y-%m-%d' | sort -u
+
+For the streak calculation: count consecutive days backward from today that have at least one commit by this author. Return the raw output and the streak count."
+description: "Time patterns + streak"
+```
+
+## Agent 3 — Hotspots + history
+
+```
+prompt: "Gather file hotspot data and retro history. Run these commands:
+
+1. git log origin/main --author='<RETRO_AUTHOR>' --since='<window>' --format='' --name-only | grep -v '^$' | sort | uniq -c | sort -rn | head -20
+2. ls -t .context/retros/*.json 2>/dev/null | head -1
+
+If a prior retro JSON exists, read it and return the contents. Return all raw output."
+description: "Hotspots + history"
+```

--- a/skills/retro/references/report-template.md
+++ b/skills/retro/references/report-template.md
@@ -46,7 +46,7 @@ Telemetry (Step 13) and the learning loop (Step 14) feed into the narrative writ
 ### Skill Usage
 Top 5: /ship (12), /review (8), /debug (5), /plan (4), /context7 (3)
 Heavy use → consider automating: /babysit-pr (7× — run via /loop?)
-Never used in window: /plan-ceo, /retro — keep or drop from profile?
+Never used in window (excluding the current /retro run): /plan-ceo — keep or drop from profile?
 ```
 
 ### Step 14 — Learning loop proposals

--- a/skills/retro/references/report-template.md
+++ b/skills/retro/references/report-template.md
@@ -1,0 +1,117 @@
+# Retro Output Templates
+
+The JSON snapshot schema (Step 12) and the narrative report structure (Steps 12-15) for `/retro`. SKILL.md keeps the control flow inline and points here for the verbatim shapes. The JSON snapshot is the only file `/retro` writes; everything else in this file is emitted to the conversation.
+
+---
+
+## JSON snapshot schema (Step 12)
+
+Save to `.context/retros/<date>.json` after `mkdir -p .context/retros`:
+
+```json
+{
+  "date": "2026-03-12",
+  "window": "7d",
+  "metrics": {
+    "commits": 47,
+    "prs_merged": 12,
+    "insertions": 3200,
+    "deletions": 800,
+    "net_loc": 2400,
+    "test_loc": 1300,
+    "test_ratio": 0.41,
+    "active_days": 6,
+    "sessions": 14,
+    "deep_sessions": 5,
+    "avg_session_minutes": 42,
+    "loc_per_session_hour": 350,
+    "feat_pct": 0.40,
+    "fix_pct": 0.30,
+    "peak_hour": 22
+  },
+  "streak_days": 47,
+  "tweetable": "Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm"
+}
+```
+
+---
+
+## Narrative report template (Steps 13-15)
+
+Telemetry (Step 13) and the learning loop (Step 14) feed into the narrative written in Step 15. Emit the full report to the conversation in this order.
+
+### Step 13 — Skill Usage Telemetry output
+
+```
+### Skill Usage
+Top 5: /ship (12), /review (8), /debug (5), /plan (4), /context7 (3)
+Heavy use → consider automating: /babysit-pr (7× — run via /loop?)
+Never used in window: /plan-ceo, /retro — keep or drop from profile?
+```
+
+### Step 14 — Learning loop proposals
+
+```
+### Proposed Skill Updates
+- Improve: "XL PRs slipped through unsplit"
+  → Edit skills/ship/SKILL.md Step 6: add hard rule — abort if diff > 1500 LOC without explicit override.
+- Improve: "Fix-ratio 60% on auth module"
+  → Edit skills/review/SKILL.md: add auth-module checklist (regression tests required).
+```
+
+Do **not** apply the edits automatically. Print the proposals and ask (AskUserQuestion) whether to apply each one.
+
+### Step 15 — Full narrative structure
+
+**Tweetable summary** (first line):
+```
+Week of Mar 8: 47 commits, 3.2k LOC, 38% tests, 12 PRs, peak: 10pm | Streak: 47d
+```
+
+## Engineering Retro: [date range]
+
+### Summary Table
+(from Step 2)
+
+### Trends vs Last Retro
+(from Step 11 — skip if first retro)
+
+### Time & Session Patterns
+(from Steps 3-4)
+- When the most productive hours are
+- Whether sessions are getting longer or shorter
+- Estimated hours per day of active coding
+
+### Shipping Velocity
+(from Steps 5-7)
+- Commit type mix
+- PR size discipline
+- Fix-chain detection
+
+### Code Quality Signals
+- Test LOC ratio trend
+- Hotspot analysis
+- Any XL PRs that should have been split
+
+### Focus & Highlights
+(from Step 8)
+- Focus score with interpretation
+- Ship of the week callout
+
+### Top 3 Wins
+3 highest-impact things shipped. For each: what, why it matters, what's impressive.
+
+### 3 Things to Improve
+Specific, actionable, anchored in actual commits.
+
+### 3 Habits for Next Week
+Small, practical, realistic. Each takes <5 minutes to adopt.
+
+### Week-over-Week Trends
+(if applicable, from Step 9)
+
+### Skill Usage
+(from Step 13 — omit if telemetry file missing)
+
+### Proposed Skill Updates
+(from Step 14 — opt-in)

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -54,6 +54,11 @@ If `docs/adr/` exists and the diff touches an area covered by an ADR, include "r
 
 ```bash
 calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+if [ ! -f "$calsuite_dir/scripts/tmux-multi-launch.sh" ]; then
+  echo "✗ Launcher not found at $calsuite_dir/scripts/tmux-multi-launch.sh" >&2
+  echo "  Set \$CALSUITE_DIR to your calsuite checkout, or clone it to ~/Projects/calsuite" >&2
+  exit 1
+fi
 bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
   --mode pr --ids "123,124,125" \
   --prompt 'Run /review pr {ID}. Post your full findings as a PR comment. Do not make any code changes.' \

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -50,33 +50,20 @@ If `docs/adr/` exists and the diff touches an area covered by an ADR, include "r
 `--multi` means "new tmux pane, clean context" — works with one PR or many. Each PR gets its own Claude Code instance for unbiased review.
 
 1. Parse PR numbers from arguments (single number like `123` or comma-separated like `123,124,125`).
-2. **Validate each parsed value matches `^[0-9]+$`.** Reject anything else before touching tmux — a value containing `$(...)`, backticks, or other shell metacharacters would fire command substitution inside the double-quoted tmux command in step 4.
-   ```bash
-   for pr in "${PRS[@]}"; do
-     [[ "$pr" =~ ^[0-9]+$ ]] || { echo "Invalid PR number: $pr"; exit 1; }
-   done
-   ```
-3. Get the current tmux window: `tmux display-message -p '#S:#I'`
-4. For each validated PR number, create a new tmux pane and launch a Claude Code instance:
+2. Hand the parsed PR numbers to the shared launcher. It validates each value against `^[0-9]+$` before touching tmux — a value containing `$(...)`, backticks, or other shell metacharacters would otherwise fire command substitution inside the double-quoted tmux command. It then confirms an active tmux session, spawns one pane per PR, and prints the summary. Pass `{ID}` through unexpanded — the script substitutes it per pane.
 
 ```bash
-# For each validated PR number in the list:
-tmux split-window -t "$SESSION:$WINDOW" -h "claude --dangerously-skip-permissions --print 'Run /review pr <NUMBER>. Post your full findings as a PR comment. Do not make any code changes.' 2>&1; echo '--- Review of PR #<NUMBER> complete. Press Enter to close. ---'; read"
-tmux select-layout -t "$SESSION:$WINDOW" tiled
+calsuite_dir="${CALSUITE_DIR:-$HOME/Projects/calsuite}"
+bash "$calsuite_dir/scripts/tmux-multi-launch.sh" \
+  --mode pr --ids "123,124,125" \
+  --prompt 'Run /review pr {ID}. Post your full findings as a PR comment. Do not make any code changes.' \
+  --label 'Review of PR #{ID} complete' \
+  --summary-label 'Multi-PR review'
 ```
 
-4. Output:
-```text
-Multi-PR review launched:
-  PRs: #123, #124, #125
-  Panes: 3 new tmux panes created
-  Mode: context-free — each instance reviews independently
+The script exits non-zero on a validation failure (`2`), no tmux session (`3`), or missing tmux (`4`). Relay its stderr message to the user and STOP — do not fall back to spawning panes by hand. Each pane posts its findings as a comment on the respective PR.
 
-Each instance will post its findings as a comment on the respective PR.
-Watch progress in the tmux panes. This instance is done.
-```
-
-5. **STOP.** Do not proceed to Step 1 — the tmux instances handle the reviews.
+3. **STOP.** Do not proceed to Step 1 — the tmux instances handle the reviews.
 
 ---
 

--- a/skills/review/checklist.md
+++ b/skills/review/checklist.md
@@ -75,6 +75,10 @@ Not unified here: the ordering / atomicity family (TOCTOU re-reads under *SQL & 
 
 ### Pass 2 — INFORMATIONAL
 
+#### Distributability & Fresh-Clone
+- **Maintainer-path fallbacks must be guarded.** A `${CALSUITE_DIR:-$HOME/Projects/calsuite}` fallback — or any `~/<dir>` / `$HOME/<dir>` default — in a skill body or shell script is only safe when the **next lines** check the target exists and fail with actionable guidance (the `customise` / `sync` pattern). Read the surrounding lines, not just the matched line: flag any such fallback that's invoked directly (e.g. `bash "$calsuite_dir/scripts/x.sh"`) with no intervening existence guard — on a fresh clone without the env var it silently points at a nonexistent path. Distributed skills (those that ship to target repos) should prefer resolving via the env var only.
+- **Resolver/installer code must not hardcode the maintainer's layout.** New path resolution should use `git rev-parse --git-common-dir`, `__dirname`, or an explicit env var — not `path.join(HOME_DIR, 'Projects', 'calsuite')`. Reviewers are historically blind to distributability (PR #95, PR #103 both slipped through internal review); check it explicitly when a diff touches path resolution or shells out to another repo.
+
 #### React 19 State Patterns
 - **Derive-during-render must also sync state**: When a component computes an `effectiveX` during render to mask a stale `x` state (e.g., "filter falls back to a default if the selected option disappears from the props"), the derivation alone hides the bug — it doesn't fix it. The underlying `x` state stays stale and can snap back to the displayed-but-not-stored value when that value reappears in the props. Look for the pattern `const effectiveX = condition ? fallback : x` and check whether `setX(effectiveX)` is also called (via prev-prop tracking) so the stored state matches what the user sees.
 - **`useEffect(() => setX(...), [prop])` is forbidden**: The `react-hooks/set-state-in-effect` rule catches this, but new instances can slip through. When state needs to reset because a prop changed, use prev-prop tracking with `useState` and adjust during render — not an effect.


### PR DESCRIPTION
## Summary

Consolidates four skill-audit follow-up issues into a single PR. They were originally four separate PRs (#119, #120, #121, #118), but each bumped the version and CHANGELOG, so every merge re-conflicted the rest. Folding them into one branch removes that ladder — this PR plus #129 are the only two left.

All four are markdown/skill refactors from the PR #99 audit pass:

- **#100** — `/learn` and `/improve-architecture` now defer to the canonical `skills/plan/references/context-and-adr-formats.md` for the CONTEXT.md and ADR templates instead of carrying their own copies. The bulk of this already landed when `/plan` was split out (#127); this closes the remaining duplication without introducing a second canonical file.
- **#103** — the tmux multi-pane launch logic moves to `scripts/tmux-multi-launch.sh`; `/execute`, `/receiving-pr-feedback`, and `/review` shell out to it instead of re-implementing the parse-validate-spawn block.
- **#104** — progressive-disclosure pass on `/execute`, `/retro`, and `/plan-ceo`: long agent prompts and section templates move to `references/`, with each skill linking to them.
- **#107** — `/execute` links to `/guardian` for the authoritative AFK/HITL definitions instead of redefining them, keeping only its own `MODE` compute.

## How it was built

Each issue's content was 3-way merged onto current main independently, then verified byte-identical to its original branch (single-source files) or, for `skills/execute/SKILL.md` — which #103, #104, and #107 each edit in non-overlapping regions — confirmed to contain all three changes. The `/plan-ceo` Section 4 conflict (#104's reference extraction vs #127's per-section `**STOP.**` removal) was resolved in favour of both: the reference link stays, the redundant STOP line is dropped. One version bump (2.52) and one CHANGELOG entry cover all four.

## Note for review

The launcher path fallback (`${CALSUITE_DIR:-$HOME/Projects/calsuite}`) is now guarded in all three skill bodies: if the script isn't found it fails with an actionable error instead of silently pointing at a nonexistent path. This matches the `customise` skill's existing contract and CLAUDE.md's documented `~/Projects/calsuite` default. (Resolved from CodeRabbit review.)

Closes #100
Closes #103
Closes #104
Closes #107

## Revision History

**Round 1** (2026-06-12):
- Accepted: 6 — tmux `--prompt`/`--label` shell-escaped (`printf %q`); launcher path guarded in execute/receiving-pr-feedback/review; CHANGELOG 2.52 date corrected; retro "runtime output file" wording + Step 15 cross-ref + "never used" example fixed
- Pushed back: 1 — AFK/HITL vs Step 5 unconditional `gh issue comment` is pre-existing in main and outside this PR's hunks (out of scope; better as its own issue)
- Skipped: 1 — plan-ceo canonical mode names would overflow the fixed-width ASCII box (disproportionate reflow for a cosmetic nit)

**Round 2** (2026-06-12):
- Folded in `/prevent` follow-up: a "Distributability & Fresh-Clone" `/review` checklist item + CLAUDE.md clarification of the guarded-`$CALSUITE_DIR`-fallback house pattern, so the unguarded-fallback class is caught in review going forward.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 2.52
  * Consolidated skill documentation templates and reference materials into dedicated sources for improved maintainability
  * Extracted shared utility script for multi-pane workflow orchestration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

