### PR TITLE
chore(skills): make /execute AFK/HITL gating self-consistent for completion comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to this repository.
 
-Current version: **2.52**
+Current version: **2.53**
+
+## [2.53] — 2026-06-12
+
+### Fixed
+
+- **`/execute` AFK/HITL gating is now self-consistent for ISSUE-mode completion comments.** The gating-rule table listed "post comment" as a user-owned, always-ask action, but Step 5 posted the ISSUE-mode completion status comment unconditionally — a contradiction flagged in PR #130 review. Scoped the rule to *discretionary* comments and classified the completion note as **delegated output** (posted in both AFK and HITL; running `/execute issue <n>` explicitly delegates the issue). No change to execution behavior — the inconsistency was in the documented rule, not the action.
 
 ## [2.52] — 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.52** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.53** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.52**
+**Version: 2.53**
 
 ## Getting started
 

--- a/skills/execute/SKILL.md
+++ b/skills/execute/SKILL.md
@@ -72,7 +72,7 @@ Every AskUserQuestion call below falls into one of two categories:
 | Category | AFK behavior | HITL behavior |
 |---|---|---|
 | **Phase confirmation** — "proceed?", "continue?", "raise concerns?" between phases | **Skip** the prompt; proceed automatically and log the auto-decision in the batch report | Ask normally |
-| **User-owned decision** — actions that change shared state outside this run (close issue, post comment, push to remote, send notification) | **Always ask** regardless of mode — AFK does not authorize state changes the user hasn't explicitly delegated | Ask normally |
+| **User-owned decision** — actions that change shared state outside this run (close issue, post a discretionary comment, push to remote, send notification) | **Always ask** regardless of mode — AFK does not authorize state changes the user hasn't explicitly delegated | Ask normally |
 
 Each AskUserQuestion call site below explicitly states which category it belongs to. The default for ambiguous calls is **phase confirmation** (skippable in AFK) — be conservative about marking a call user-owned, but never auto-execute issue-close, force-push, or external-system writes without explicit user confirmation.
 
@@ -279,6 +279,7 @@ After all tasks are done:
      ```bash
      gh issue comment <number> --body "Implementation complete on branch \`$(git branch --show-current)\`. Changes: <summary of files changed and tests written>"
      ```
+     **Delegated output** — post this completion comment in both modes (no prompt): running `/execute issue <n>` explicitly delegates this issue, so the end-of-run status note is the expected output, not a discretionary external write. (A *discretionary* comment would be user-owned per the gating rule.)
      **User-owned decision** — always ask via AskUserQuestion regardless of `MODE`: "Close this issue? (A) Yes (B) No, keep open until PR merges". Closing an issue is a state change visible outside this run; AFK does not authorize it.
    - **RAW:** No external updates.
 3. Report final status:


### PR DESCRIPTION
Follow-up to #130 review. The `/execute` gating-rule table listed "post comment" as a user-owned/always-ask action, but Step 5 posted the ISSUE-mode completion status comment unconditionally — a contradiction.

**Fix (doc-consistency only, no execution-behavior change):**
- Scoped the gating rule to *discretionary* comments.
- Classified the ISSUE-mode completion note as **delegated output** — posted in both AFK and HITL, since running `/execute issue <n>` explicitly delegates the issue.

Markdown-only. Version 2.53.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected documentation of AFK/HITL gating behavior for issue executions.

* **Documentation**
  * Clarified when interactive prompts are required for user-owned decisions.
  * Clarified expected behavior for delegated issue execution outputs.

* **Chores**
  * Version updated to 2.53.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->