### PR TITLE
feat(skills): add /next-task + /roadmap and global-behaviours mechanism (v2.56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,24 @@
 
 All notable changes to this repository.
 
-Current version: **2.53**
+Current version: **2.54**
+
+## [2.54] — 2026-06-26
+
+### Added
+
+- **`/next-task` skill — prep and hand off the next piece of work.** Reads what just happened (git log, working tree, spec task state), picks the next task off the active spec using the dependency tree (critical path first), recommends whether to **carry on / compact / start a new session** from explicit signals (coupling to current context, context pressure, tree cleanliness, phase boundary), and writes a ready-to-paste execution prompt to Claude Code prompting best practice (explicit, motivated, files + finish line; standalone when it recommends a fresh session). Then invokes `/roadmap` for the "what we did / where next" visual. Distributed to `base` + `monorepo-root`.
+- **`/roadmap` skill — render where we are and what's next.** Creates or updates a self-contained `docs/roadmap/*.html` from the project's spec(s): finished work, ready-to-start tasks, and the dependency tree (critical path, sequential, parallelisable). Multi-spec aware — one spec → `roadmap.html`; many → a cross-spec `spec_roadmap.html` portfolio plus a per-spec `{spec_name}_roadmap.html` and an index. Output is dependency-free, dark-mode-aware HTML that opens offline; optional inline preview via `show_widget`. Reads status from `tasks.md` only; never edits the spec. Distributed to `base` + `monorepo-root`.
+- **Global behaviours mechanism (`behaviors/` → `~/.claude/CLAUDE.md`).** New `behaviors/*.md` directory holding personal, cross-project guidance. `installGlobalBehaviors()` in the installer merges them (filename order, `README.md` excluded) into a marker-delimited block in user-global `~/.claude/CLAUDE.md`, preserving content outside the markers. Idempotent (unchanged block = no write, no log); a hand-corrupted marker is detected and repaired rather than duplicated. Installs from the single-target path (shown in the global-settings summary), from `--sync` (silent in git-hook context, silent on no-op so `/sync` parsing is unaffected), and from a standalone `--install-global-behaviors` flag. Post-commit hook now watches `behaviors/`; the `setup.cjs` smoke test sandboxes `HOME` so it never touches the real `~/.claude/CLAUDE.md`.
+- **Two starter behaviours.** `visualise-over-verbose.md` — render structure (flows, graphs, layouts) as a visual instead of a wall of describing prose, scoped to skip terse answers and code. `code-comments.md` — functional, present-tense comments stating the contract/invariant/constraint that still governs the code; explicitly **not** debugging war-stories (those belong in commits/PRs/ADRs); favours scannable bullets over dense multi-line paragraphs; grounded in PEP 257 / Google style / a sharpened "why, not what".
+
+### Changed
+
+- **`templates/specs/tasks.md` gains an optional dependency convention.** Tasks may carry a bold `**ID**` and a trailing `— deps: A, B`; `/roadmap` reads these to draw cross-task edges and the critical path. Backward compatible — un-annotated tasks still parse, with dependencies inferred from phase order.
+
+### Why
+
+Maintainer wanted two recurring moves codified as harness primitives — "what's the next task and how should I start it" (`/next-task`) and "show me the plan as a picture, not text" (`/roadmap`) — plus two standing preferences made global: prefer visuals over verbose structural prose, and keep code comments functional rather than forensic. The behaviours needed a home that is truly global (every project) without polluting team-shared repo files, so the installer now manages a section in user-global `~/.claude/CLAUDE.md` — the same "personal config stays out of committed target files" discipline as the hooks-in-`settings.local.json` rule.
 
 ## [2.53] — 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.53** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.54** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 
@@ -16,6 +16,7 @@ When the user's intent matches, read the pointed file *before* doing anything el
 | Add/change an agent | `agents/<name>.md` (YAML frontmatter) |
 | MCP server changes | `config/global-settings.json` (empty placeholder keys only) + `~/.mcp.json` (real keys, never committed) |
 | Spec/doc templates | `templates/` — never overwritten on re-install |
+| Add/change a global behaviour | `behaviors/<topic>.md` — installer merges them into user-global `~/.claude/CLAUDE.md` (see Global behaviours below) |
 
 ## Codify on repeat
 
@@ -55,6 +56,7 @@ Record durable learnings (patterns, pitfalls, preferences) via `/learn save` —
 | `/learn` | Durable per-project learnings across sessions |
 | `/lint-rule-gen` | Generate lint rules from review-feedback patterns |
 | `/new-spec` | Scaffold a spec directory (requirements / design / tasks) |
+| `/next-task` | Pick the next task, recommend session strategy, write its prompt + roadmap |
 | `/plan` | Interview / brainstorm / review / visualize before building |
 | `/plan-ceo` | Founder-mode plan review: scope expansion / hold / reduction |
 | `/prevent` | Add the most deterministic guardrail for a mistake |
@@ -62,6 +64,7 @@ Record durable learnings (patterns, pitfalls, preferences) via `/learn save` —
 | `/receiving-pr-feedback` | Rigorously handle PR review feedback |
 | `/retro` | Weekly engineering retrospective |
 | `/review` | Multi-agent pre-landing code review |
+| `/roadmap` | Render a self-contained HTML roadmap (done / next / dependency tree) from the spec(s) |
 | `/session-start` | Load full project-context briefing |
 | `/ship` | Merge main, test, review, push, open PR |
 | `/strategic-compact` | Suggest `/compact` at logical session breakpoints |
@@ -131,6 +134,7 @@ config/      # global-settings.json (manifest), profiles.json (profile→plugin 
 plugins/     # Claude Code plugins
 skills/      # parameterized slash-commands (SKILL.md each)
 agents/      # agent .md files with YAML frontmatter
+behaviors/   # global behaviour sections merged into user-global ~/.claude/CLAUDE.md
 templates/   # spec / doc / changelog templates
 ```
 
@@ -145,7 +149,9 @@ templates/   # spec / doc / changelog templates
 - `<target>/.claude/settings.json` — **team-shared** (committed). Installer writes `enabledPlugins` and `permissions` here. Never hooks, never paths.
 - `<target>/.claude/settings.local.json` — **per-user** (gitignored by the installer). Installer writes calsuite hook wiring here with literal resolved `$CALSUITE_DIR` paths.
 - `config/targets.json` — repos that `--sync` installs to. Each entry: `{ path, workspaces?, skills? }`. `workspaces: "skip"` restricts monorepo targets to root-only install. `skills: { exclude: ["a", "b"] }` drops the named skills from the profile-resolved install set; unmatched names surface as a ⚠ drift warning. See `config/targets.example.json`.
-- `.git/hooks/post-commit` — auto-syncs on commit when hooks/skills/agents/scripts/config change
+- `.git/hooks/post-commit` — auto-syncs on commit when hooks/skills/agents/scripts/config/behaviors change
+- `~/.claude/CLAUDE.md` — user-global memory loaded for every project. Installer merges a marker-delimited block here from `behaviors/*.md`; content outside the markers is preserved.
+- `behaviors/*.md` — global behaviour sections (one concern per file, `README.md` excluded). Concatenated in filename order into the `~/.claude/CLAUDE.md` managed block.
 - `<target>/.claude/verify-config.json` — **optional** per-project config for `/verify` (dev command, ports, log path, DB shell, auth bypass, seed script). Without it the skill auto-discovers from `package.json` / `Makefile` / `docker-compose.yml`; schema lives at `skills/verify/references/config-schema.md`.
 
 ## Gotchas
@@ -177,6 +183,13 @@ templates/   # spec / doc / changelog templates
 - Claude Code's skill hierarchy is enterprise > personal (`~/.claude/`) > project (CWD's `.claude/`) > plugin. Parent-directory `.claude/skills/` is **not** discovered automatically.
 - Review gate blocks commits without `@code-reviewer` approval — bypass with `[skip-review]`, `docs:`/`chore:`/`style:` prefix, or md-only changes.
 
+### Global behaviours
+- `behaviors/*.md` are personal, **cross-project** preferences merged into user-global `~/.claude/CLAUDE.md` — never into a target repo's committed files. (A code-comment convention is arguably team-shared; this mechanism deliberately keeps it personal-global, like the "never write hooks into committed `settings.json`" rule.)
+- The merge is marker-delimited (`installGlobalBehaviors()` in `scripts/configure-claude.js`) and **idempotent**: an unchanged block writes nothing and logs nothing, so the post-commit `--sync` stays silent. Content outside the markers is preserved. A hand-corrupted marker (lone or misordered) is detected and **repaired** — every marker line is stripped and one clean block re-appended — rather than duplicated or used to silently delete surrounding prose.
+- Installs from three callers — single-target install (`announceNoop: true`, shown in the global-settings summary), `--sync` (`quiet: inGitHook`, silent on no-op so `/sync`'s output parsing stays stable), and the standalone `--install-global-behaviors` flag. A normal single-target install writes the block to your real `~/.claude/CLAUDE.md` (same as the existing `~/.mcp.json` write); the `setup.cjs` smoke test runs against a **sandboxed `HOME`**, so it never touches your real home.
+- Behaviour text is injected into **every** session's context — keep each file short and scoped both ways (when it applies *and* when it doesn't). `README.md` in `behaviors/` is documentation and is excluded from the merge.
+- Editing `behaviors/*.md` and committing refreshes `~/.claude/CLAUDE.md` via the post-commit hook (it watches `behaviors/`). Existing installs whose `.git/hooks/post-commit` predates that watch need `node scripts/setup.cjs --hook-only` once to pick up the new path filter.
+
 ### Divergence resolution
 
 When `--sync` reports files skipped pending reconciliation, three commands resolve them:
@@ -188,7 +201,9 @@ When `--sync` reports files skipped pending reconciliation, three commands resol
 
 - `node scripts/configure-claude.js /tmp/test-project` — full integration test
 - `--install-ccstatusline` flag for standalone ccstatusline install
+- `--install-global-behaviors` flag for standalone `~/.claude/CLAUDE.md` behaviour merge (idempotent)
 - Always `rm -rf /tmp/test-project` after testing
+- A full integration test touches the real `~/.claude/CLAUDE.md` (behaviours block) and `~/.mcp.json` — both idempotent and additive. The `setup.cjs` smoke test sandboxes `HOME`, so it touches neither.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.53**
+**Version: 2.54**
 
 ## Getting started
 
@@ -50,6 +50,7 @@ config/      # global-settings.json (manifest), profiles.json, targets.example.j
 plugins/     # Claude Code plugins
 skills/      # Markdown skills (invoked as /skill-name)
 agents/      # Agent definitions (invoked as @agent-name)
+behaviors/   # Global cross-project behaviour sections merged into ~/.claude/CLAUDE.md
 templates/   # Spec, doc, and changelog templates (for target projects)
 specs/       # Calsuite's own spec docs
 ```
@@ -168,6 +169,8 @@ Skills are invoked as `/<name>`. Bucketed by how often you'll reach for them.
 - **`/session-start`** — load full project context: CLAUDE.md, specs, changelog, git history.
 - **`/strategic-compact`** — hook-driven compaction suggestions at logical session breakpoints.
 - **`/learn`** — durable per-project learnings that compound across sessions.
+- **`/next-task`** — figure out what just shipped, pick the next task off the spec (critical path first), recommend carry-on / compact / new session, and write a ready-to-paste execution prompt. Renders the roadmap visual via `/roadmap`.
+- **`/roadmap`** — create or update a self-contained `docs/roadmap/*.html` from the spec(s): done vs next, plus the dependency tree (critical path, sequential, parallelisable). Multi-spec aware.
 - **`/babysit-pr`**, **`/receiving-pr-feedback`** — PR lifecycle helpers.
 
 ### Occasional
@@ -219,6 +222,16 @@ The installer auto-configures MCP servers defined in `config/global-settings.jso
 - **context7** — current, version-specific library documentation via [Context7](https://github.com/upstash/context7) (used by `/context7` skill, no API key required)
 
 Servers are written to `~/.mcp.json` and enabled in `~/.claude/settings.local.json` automatically.
+
+## Global behaviours
+
+`behaviors/*.md` hold personal, cross-project guidance. The installer merges them (filename order; `README.md` excluded) into a marker-delimited block in your user-global `~/.claude/CLAUDE.md`, which Claude Code loads for **every** project. Content outside the markers is preserved, and the merge is idempotent.
+
+- Installs during a normal `configure-claude.js <target>` run, during `--sync` (silent in the post-commit hook), or standalone via `--install-global-behaviors`.
+- These are personal preferences, not team conventions — they live in your home directory, never in a target repo's committed files (same discipline as hooks-in-`settings.local.json`).
+- Ships with two: **visualise-over-verbose** (render structure as a diagram instead of describing it in prose) and **code-comments** (functional, present-tense comments — contracts and constraints, not debugging war-stories).
+
+Add one by dropping a short `behaviors/<topic>.md` and re-running the installer. See `behaviors/README.md`.
 
 ## Changelog
 

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -7,7 +7,7 @@ Each `*.md` file here is one behaviour — a short, high-signal section. The ins
 marker-delimited block in your user-global `~/.claude/CLAUDE.md`, which Claude Code loads
 for every project. Content outside the markers is never touched.
 
-```
+```text
 <!-- BEGIN calsuite global behaviours … -->
   …concatenated behaviour sections…
 <!-- END calsuite global behaviours -->

--- a/behaviors/README.md
+++ b/behaviors/README.md
@@ -1,0 +1,34 @@
+# behaviors/
+
+Global behavioural guidance that applies across **all** of your projects.
+
+Each `*.md` file here is one behaviour — a short, high-signal section. The installer
+(`scripts/configure-claude.js`) concatenates them (sorted by filename) into a single
+marker-delimited block in your user-global `~/.claude/CLAUDE.md`, which Claude Code loads
+for every project. Content outside the markers is never touched.
+
+```
+<!-- BEGIN calsuite global behaviours … -->
+  …concatenated behaviour sections…
+<!-- END calsuite global behaviours -->
+```
+
+## How it installs
+
+- During a normal `node scripts/configure-claude.js <target>` (the global-settings step).
+- During `--sync` (so committing a behaviour change refreshes `~/.claude/CLAUDE.md`; the
+  post-commit hook watches `behaviors/`). Silent in git-hook context.
+- Standalone: `node scripts/configure-claude.js --install-global-behaviors`.
+
+It is idempotent — re-running writes nothing when the block already matches.
+
+## Writing a behaviour
+
+- Keep it short. This text is injected into **every** session's context — pay for the tokens.
+- One concern per file. Name files by topic (`code-comments.md`, `visualise-over-verbose.md`).
+- Scope it both ways: say when the behaviour applies *and* when it doesn't. A blanket rule
+  with no off-switch is worse than none.
+- These are personal, cross-project preferences — not team conventions. They install to your
+  home directory, never into a target repo's committed files.
+
+`README.md` is ignored by the installer (it is not a behaviour).

--- a/behaviors/code-comments.md
+++ b/behaviors/code-comments.md
@@ -1,0 +1,14 @@
+## Comments and docstrings: functional, not forensic
+
+Write commentary that states what a reader cannot infer from the code itself — the contract, the invariant, the unit, the constraint that still governs the code today. Cut everything else.
+
+- **No debugging war-stories.** Don't narrate the investigation that produced the line ("we tried X, but under load Y happened, so now we…"). That history belongs in the commit message, the PR, or an ADR — not inline, where it rots and buries the signal. A comment describes the code as it is now, in the present tense, not how it got here or why a past attempt failed.
+- **No restating the code.** `// increment i` over `i++` is noise. If a name or structure makes a comment redundant, fix the name and delete the comment. Self-documenting code beats a comment that re-narrates it.
+- **Bullets over dense paragraphs.** When a comment or docstring runs past one sentence, format it as a short scannable list, not a multi-line block of prose — several short lines read faster than a wall of text. Docstrings likewise use fields (params, returns, raises) rather than burying them in a paragraph.
+- **Do document** the genuinely non-obvious: why a bound exists ("API caps at 100 per page"), units and ranges, ordering or concurrency assumptions, an edge case that looks like a bug, why the tempting simpler approach is wrong, and anything a caller must not violate.
+- **Docstrings describe the contract, not the implementation:** what it does, parameters, return, what it raises, units. Public API earns a docstring; trivial internals usually don't. Match prose density to the surrounding code — terse modules get terse docs.
+- **Comments are load-bearing claims.** When you change the code, update or delete the comments that referenced the old shape. A stale comment is worse than no comment.
+
+Default to fewer, sharper comments. If you can't say why a line of commentary earns its place, cut it.
+
+_Grounding: PEP 257, Google style guides, and the "why, not what" lineage — sharpened so "why" means the constraint that still binds the code, not the story of how it was written._

--- a/behaviors/visualise-over-verbose.md
+++ b/behaviors/visualise-over-verbose.md
@@ -1,0 +1,10 @@
+## Visualise instead of describing
+
+When the answer is structure — a flow, hierarchy, dependency graph, state machine, timeline, comparison, or system layout — render it, don't narrate it. A diagram or small interactive view is read faster and held in mind better than three paragraphs reconstructing the same shape in prose. LLM prose tends to over-describe structure; a picture ends the verbosity.
+
+- **Reach for a visual when** you'd otherwise write a long descriptive block to convey relationships, sequence, or layout: architectures, data and control flow, before/after, decision trees, schedules, option trade-offs, roadmaps.
+- **Prefer**, in order of what's available: an inline HTML/SVG widget (`show_widget`) for something to glance at in chat; an Excalidraw diagram (`excalidraw` MCP) for hand-drawn architecture; a written `.html` artifact for something the user will reopen later. Fall back to a compact Mermaid or ASCII diagram when no render tool is connected.
+- **The visual replaces the wall of text — it doesn't get bolted onto one.** Label nodes in ≤5 words; keep detail in the short prose around the diagram, not stuffed inside every box.
+- **Don't visualise** terse answers, status updates, single facts, or plain linear narrative. Two boxes and an arrow is worse than a sentence. Code stays code.
+
+The test: if you're about to emit a dense paragraph that is really describing a shape, draw the shape instead.

--- a/config/profiles.json
+++ b/config/profiles.json
@@ -23,7 +23,7 @@
         "code-simplifier@claude-plugins-official",
         "security-guidance@claude-plugins-official"
       ],
-      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "verify", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize", "layman", "improve-prompt", "grok"],
+      "skills": ["strategic-compact", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "verify", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize", "layman", "improve-prompt", "grok", "next-task", "roadmap"],
       "agents": ["code-reviewer"]
     },
     "typescript": {
@@ -45,7 +45,7 @@
     },
     "monorepo-root": {
       "extends": "base",
-      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "verify", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize", "layman", "improve-prompt", "grok"],
+      "skills": ["strategic-compact", "update-docs", "session-start", "context7", "guardian", "plan", "plan-ceo", "ship", "retro", "review", "qa", "verify", "babysit-pr", "receiving-pr-feedback", "execute", "worktrees", "debug", "lint-rule-gen", "prevent", "new-spec", "sweep-issues", "flow", "learn", "customise", "zoom-out", "improve-architecture", "humanize", "layman", "improve-prompt", "grok", "next-task", "roadmap"],
       "agents": ["context-loader", "doc-updater", "browser", "code-reviewer"],
       "templates": ["specs"]
     }

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -14,6 +14,7 @@
  *   --only skill1,skill2,...     Install only specific skills (skips hooks/plugins/settings)
  *   --agents agent1,agent2,...   Install only specific agents (use with --only)
  *   --install-ccstatusline       Install ccstatusline config only
+ *   --install-global-behaviors   Merge behaviors/*.md into ~/.claude/CLAUDE.md only
  *   --sync                       Re-run install against all targets in config/targets.json.
  *                                Each target may set `workspaces: "skip"` to install the
  *                                harness only at the repo root — workspace subdirs
@@ -63,6 +64,10 @@ const HOME_SETTINGS = path.join(HOME_DIR, '.claude', 'settings.json');
 const HOME_SETTINGS_LOCAL = path.join(HOME_DIR, '.claude', 'settings.local.json');
 const HOME_MCP_JSON = path.join(HOME_DIR, '.mcp.json');
 const KNOWN_MARKETPLACES = path.join(HOME_DIR, '.claude', 'plugins', 'known_marketplaces.json');
+const BEHAVIORS_DIR = path.join(CONFIG_REPO, 'behaviors');
+const HOME_CLAUDE_MD = path.join(HOME_DIR, '.claude', 'CLAUDE.md');
+const BEHAVIORS_BEGIN = '<!-- BEGIN calsuite global behaviours (managed by configure-claude.js — edit behaviors/*.md in calsuite, not here) -->';
+const BEHAVIORS_END = '<!-- END calsuite global behaviours -->';
 // Skills that only make sense in the config repo itself — never export to target repos.
 // These orchestrate calsuite's own workflow (installer, sync, cross-target reconciliation)
 // and read files that only exist here (config/targets.json, scripts/configure-claude.js).
@@ -1070,6 +1075,75 @@ function installCcstatuslineConfig(manifest) {
   console.log(`  ✓ Installed ccstatusline config (v${manifest.ccstatusline.version}) → ${ccstatuslinePath}`);
 }
 
+function buildBehaviorsBlock() {
+  if (!fs.existsSync(BEHAVIORS_DIR)) return null;
+  const files = fs.readdirSync(BEHAVIORS_DIR)
+    .filter(f => f.endsWith('.md') && f.toLowerCase() !== 'readme.md')
+    .sort();
+  if (!files.length) return null;
+  const sections = files.map(f => fs.readFileSync(path.join(BEHAVIORS_DIR, f), 'utf8').trim());
+  return `${BEHAVIORS_BEGIN}\n\n${sections.join('\n\n')}\n\n${BEHAVIORS_END}`;
+}
+
+/**
+ * Merge the global-behaviours block into the user-global ~/.claude/CLAUDE.md,
+ * which Claude Code loads for every project. Marker-delimited and idempotent:
+ * content outside the markers is preserved, and an unchanged block is a no-op
+ * (no write, no log) so the post-commit --sync hook stays silent.
+ *
+ * `quiet` suppresses all output (git-hook context). `announceNoop` prints a ✓
+ * even when nothing changed — used by the single-target install where the
+ * global-settings summary expects a line per check.
+ */
+function installGlobalBehaviors({ quiet = false, announceNoop = false } = {}) {
+  const block = buildBehaviorsBlock();
+  if (!block) return;
+
+  const existing = fs.existsSync(HOME_CLAUDE_MD) ? fs.readFileSync(HOME_CLAUDE_MD, 'utf8') : '';
+  const beginIdx = existing.indexOf(BEHAVIORS_BEGIN);
+  const endIdx = existing.indexOf(BEHAVIORS_END);
+  const wellFormed = beginIdx !== -1 && endIdx !== -1 && endIdx > beginIdx;
+  // A lone or misordered marker (BEGIN with no END, or END before BEGIN) means
+  // the managed region was hand-edited or a write was interrupted. Treating it
+  // as "no block" and appending would:
+  //   - duplicate the block now, and
+  //   - on the next run, silently delete text between the orphan marker and the
+  //     new block.
+  // Instead: strip every marker line (keeping surrounding prose) and re-append
+  // one clean block — convergent and lossless.
+  const corrupted = !wellFormed && (beginIdx !== -1 || endIdx !== -1);
+
+  let next;
+  let verb;
+  if (wellFormed) {
+    next = existing.slice(0, beginIdx) + block + existing.slice(endIdx + BEHAVIORS_END.length);
+    verb = 'updated';
+  } else if (corrupted) {
+    const cleaned = existing
+      .split('\n')
+      .filter(line => line.trim() !== BEHAVIORS_BEGIN && line.trim() !== BEHAVIORS_END)
+      .join('\n')
+      .replace(/\s*$/, '');
+    next = (cleaned ? cleaned + '\n\n' : '') + block + '\n';
+    verb = 'repaired';
+  } else if (existing.trim() === '') {
+    next = block + '\n';
+    verb = 'installed';
+  } else {
+    next = existing.replace(/\s*$/, '') + '\n\n' + block + '\n';
+    verb = 'installed';
+  }
+
+  if (next === existing) {
+    if (!quiet && announceNoop) console.log('  ✓ Global behaviours: ~/.claude/CLAUDE.md already current');
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(HOME_CLAUDE_MD), { recursive: true });
+  fs.writeFileSync(HOME_CLAUDE_MD, next);
+  if (!quiet) console.log(`  ✓ Global behaviours ${verb} → ~/.claude/CLAUDE.md`);
+}
+
 /**
  * --only mode: Install specific skills/agents only, without touching hooks or settings.
  * Usage: node configure-claude.js <target> --only review,qa,ship
@@ -1933,6 +2007,8 @@ function parseArgv() {
       flags.agents = args[++i].split(',').map(s => s.trim()).filter(Boolean);
     } else if (args[i] === '--install-ccstatusline') {
       flags.installCcstatusline = true;
+    } else if (args[i] === '--install-global-behaviors') {
+      flags.installGlobalBehaviors = true;
     } else if (args[i] === '--sync') {
       flags.sync = true;
     } else if (args[i] === '--yes' || args[i] === '-y') {
@@ -2016,6 +2092,12 @@ function main() {
     return;
   }
 
+  // Handle --install-global-behaviors flag (standalone refresh of ~/.claude/CLAUDE.md)
+  if (flags.installGlobalBehaviors) {
+    installGlobalBehaviors({ announceNoop: true });
+    return;
+  }
+
   // Handle --sync mode: re-run install against all targets in config/targets.json.
   //
   // Loudness depends on invocation context:
@@ -2042,6 +2124,11 @@ function main() {
   if (flags.sync) {
     const targets = readJsonSync(TARGETS_JSON);
     const inGitHook = !!process.env.GIT_DIR;
+    // Refresh global behaviours so committing a behaviors/*.md change (or any
+    // sync) flows into ~/.claude/CLAUDE.md. Runs before the no-targets early
+    // return so it works even when no targets are configured. Quiet in hook
+    // context; silent on no-op so /sync's output parsing stays stable.
+    installGlobalBehaviors({ quiet: inGitHook });
     if (!targets) {
       if (inGitHook) return;
       console.error('  ✗ config/targets.json not found.');
@@ -2148,6 +2235,9 @@ function main() {
     }
     checkGlobalSettings(manifest, settingsPaths);
   }
+
+  // Global behaviours → ~/.claude/CLAUDE.md (home-level, applies to every project).
+  installGlobalBehaviors({ announceNoop: true });
 
   console.log('\nDone!\n');
   printDivergenceSummary(divergences);

--- a/scripts/configure-claude.js
+++ b/scripts/configure-claude.js
@@ -1066,10 +1066,15 @@ function buildBehaviorsBlock() {
 }
 
 /**
- * Merge the global-behaviours block into the user-global ~/.claude/CLAUDE.md,
+ * Sync the global-behaviours block into the user-global ~/.claude/CLAUDE.md,
  * which Claude Code loads for every project. Marker-delimited and idempotent:
  * content outside the markers is preserved, and an unchanged block is a no-op
  * (no write, no log) so the post-commit --sync hook stays silent.
+ *
+ * The block mirrors behaviors/ exactly: install/update when behaviours exist,
+ * and REMOVE it when behaviors/ is present but empty (so deleting the last
+ * behaviour propagates). A missing behaviors/ dir is left alone — that's an
+ * unknown/partial checkout, not a deliberate removal.
  *
  * `quiet` suppresses all output (git-hook context). `announceNoop` prints a ✓
  * even when nothing changed — used by the single-target install where the
@@ -1077,7 +1082,6 @@ function buildBehaviorsBlock() {
  */
 function installGlobalBehaviors({ quiet = false, announceNoop = false } = {}) {
   const block = buildBehaviorsBlock();
-  if (!block) return;
 
   const existing = fs.existsSync(HOME_CLAUDE_MD) ? fs.readFileSync(HOME_CLAUDE_MD, 'utf8') : '';
   const beginIdx = existing.indexOf(BEHAVIORS_BEGIN);
@@ -1095,7 +1099,21 @@ function installGlobalBehaviors({ quiet = false, announceNoop = false } = {}) {
 
   let next;
   let verb;
-  if (wellFormed) {
+  if (!block) {
+    // No behaviours defined. If behaviors/ exists but is empty, this is a
+    // deliberate removal — strip the managed block so it propagates. If the dir
+    // is absent (unknown/partial checkout), leave the file untouched.
+    if (!fs.existsSync(BEHAVIORS_DIR) || (!wellFormed && !corrupted)) {
+      if (!quiet && announceNoop) console.log('  ✓ Global behaviours: none defined, ~/.claude/CLAUDE.md untouched');
+      return;
+    }
+    const body = wellFormed
+      ? existing.slice(0, beginIdx) + existing.slice(endIdx + BEHAVIORS_END.length)
+      : existing.split('\n').filter(l => l.trim() !== BEHAVIORS_BEGIN && l.trim() !== BEHAVIORS_END).join('\n');
+    const trimmed = body.replace(/\n{3,}/g, '\n\n').replace(/\s*$/, '');
+    next = trimmed ? trimmed + '\n' : '';
+    verb = 'removed';
+  } else if (wellFormed) {
     next = existing.slice(0, beginIdx) + block + existing.slice(endIdx + BEHAVIORS_END.length);
     verb = 'updated';
   } else if (corrupted) {

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Calsuite post-commit hook — auto-syncs config to target repos after commits
-# that touch shipped content (hooks/, skills/, agents/, scripts/, config/).
+# that touch shipped content (hooks/, skills/, agents/, scripts/, config/,
+# behaviors/). A behaviors/ change refreshes the global ~/.claude/CLAUDE.md via
+# --sync's installGlobalBehaviors() step.
 #
 # Installed by `node scripts/setup.cjs` from the tracked template at
 # scripts/git-hooks/post-commit. Re-run setup.cjs to reinstall after a fresh
@@ -11,7 +13,7 @@
 # called from a git hook (GIT_DIR is set) and there's no config/targets.json,
 # so a fresh user without targets configured won't see spam on every commit.
 
-CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -E '^(hooks/|skills/|agents/|scripts/|config/)' | head -1)
+CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -E '^(hooks/|skills/|agents/|scripts/|config/|behaviors/)' | head -1)
 
 if [ -n "$CHANGED" ]; then
   echo "[post-commit] Syncing calsuite to targets..."

--- a/scripts/git-hooks/post-commit
+++ b/scripts/git-hooks/post-commit
@@ -13,7 +13,7 @@
 # called from a git hook (GIT_DIR is set) and there's no config/targets.json,
 # so a fresh user without targets configured won't see spam on every commit.
 
-CHANGED=$(git diff-tree --no-commit-id --name-only -r HEAD | grep -E '^(hooks/|skills/|agents/|scripts/|config/|behaviors/)' | head -1)
+CHANGED=$(git diff-tree --root --no-commit-id --name-only -r HEAD | grep -E '^(hooks/|skills/|agents/|scripts/|config/|behaviors/)' | head -1)
 
 if [ -n "$CHANGED" ]; then
   echo "[post-commit] Syncing calsuite to targets..."

--- a/scripts/setup.cjs
+++ b/scripts/setup.cjs
@@ -216,10 +216,11 @@ function printNextSteps() {
     log('  Next: copy config/targets.example.json to config/targets.json and list your target repos.');
     log('        Then `node scripts/configure-claude.js --sync` will fan out to them.');
   }
-  log('  A real install (per-target or --sync) also seeds the calsuite global');
-  log('  behaviours from behaviors/*.md into ~/.claude/CLAUDE.md; the smoke test');
-  log('  above does not (it runs against a sandboxed HOME). To seed them now');
-  log('  without a target, run `node scripts/configure-claude.js --install-global-behaviors`.');
+  log('  A real install (per-target or --sync) seeds the calsuite global behaviours');
+  log('  from behaviors/*.md into your ~/.claude/CLAUDE.md. The smoke test above seeds');
+  log('  into a throwaway sandboxed HOME instead, so your real ~/.claude/CLAUDE.md is');
+  log('  untouched. To seed it now without a target, run');
+  log('  `node scripts/configure-claude.js --install-global-behaviors`.');
   log('');
 }
 

--- a/scripts/setup.cjs
+++ b/scripts/setup.cjs
@@ -158,10 +158,24 @@ function smokeTest() {
   const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'calsuite-setup-'));
   try {
     spawnSync('git', ['init', '-q'], { cwd: tmpRoot, stdio: 'ignore' });
+    // Sandbox HOME for the run. The single-target install path writes to the
+    // real home in three places:
+    //   - MCP servers → ~/.mcp.json
+    //   - enabled servers → ~/.claude/settings.local.json
+    //   - global-behaviours block → ~/.claude/CLAUDE.md
+    // Pointing HOME/USERPROFILE under tmpRoot keeps this throwaway run from
+    // mutating the user's real home, and from failing on a read-only HOME in CI
+    // (those writes would throw). Everything lands in tmpRoot, removed in the finally.
+    const tmpHome = path.join(tmpRoot, 'home');
+    fs.mkdirSync(tmpHome, { recursive: true });
     const result = spawnSync(
       'node',
       [path.join(CONFIG_REPO, 'scripts', 'configure-claude.js'), tmpRoot],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+      }
     );
     if (result.status !== 0) {
       fail(`Smoke test failed (exit ${result.status}).`);
@@ -202,6 +216,10 @@ function printNextSteps() {
     log('  Next: copy config/targets.example.json to config/targets.json and list your target repos.');
     log('        Then `node scripts/configure-claude.js --sync` will fan out to them.');
   }
+  log('  A real install (per-target or --sync) also seeds the calsuite global');
+  log('  behaviours from behaviors/*.md into ~/.claude/CLAUDE.md; the smoke test');
+  log('  above does not (it runs against a sandboxed HOME). To seed them now');
+  log('  without a target, run `node scripts/configure-claude.js --install-global-behaviors`.');
   log('');
 }
 

--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: next-task
+version: 1.0.0
+description: |
+  next task, what's next, what should I do next, generate the next prompt,
+  hand off to the next task, kick off the next piece, should I start a new
+  session or compact, prep the next task, where do I go from here.
+  Figures out what was just done, picks the next task off the spec (respecting
+  the dependency tree), recommends whether to carry on / compact / start a new
+  session, writes a ready-to-paste execution prompt for it, and renders the
+  roadmap showing what's done and where the next task sits.
+argument-hint: "[spec-slug]"
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Skill
+  - AskUserQuestion
+---
+
+# Next-task: prep and hand off the next piece of work
+
+You've just finished something. This skill produces the **three things you need to start the
+next piece cleanly**:
+
+1. A **session recommendation** — carry on, compact, or start fresh.
+2. A **copy-paste execution prompt** for the next task, written to Claude Code prompting best practice.
+3. A **roadmap visual** (via `/roadmap`) showing what you just did and where the next task lands.
+
+Don't over-explain. The output is a recommendation, a prompt, and a link — not an essay.
+
+## Arguments
+
+- `/next-task` — infer the next task from the active spec (or the conversation if there's no spec).
+- `/next-task <spec-slug>` — pull the next task from that specific spec.
+
+## Step 1 — Establish what just happened
+
+Read the situation from facts, not vibes:
+
+```bash
+git log --oneline -8
+git status --short
+git diff --stat
+```
+
+- What did the recent commits / working tree actually change? Which files, which feature?
+- Find the active spec: `ls -d .claude/specs/*/ docs/specs/*/ specs/*/ 2>/dev/null` and check `SPECLOG.md`. Which tasks in `tasks.md` are now `[x]` or in `## Completed`? **Remember the directory you find** — Step 4 and the `/roadmap` call in Step 5 both reference it. (Same three locations `/roadmap` searches, so the two skills agree.)
+- Is the tree clean (work committed/shipped) or dirty (mid-task)? This drives the session call in Step 3.
+
+## Step 2 — Pick the next task
+
+From the active spec's `tasks.md`, choose the next task using the **dependency tree**:
+
+- The next task is an **open** task whose dependencies are all **done** (ready to start). Parse the optional `**ID** … — deps: …` annotations; without them, infer from phase order (finish phase N before phase N+1; tasks within a phase are parallel).
+- If several are ready, prefer the one on the **critical path** (the longest dependency chain to the end). Surface up to 2 alternates the user could parallelise instead.
+- **No spec?** Derive the next task from open GitHub issues, `TODO`/`FIXME`, or the conversation's stated direction. Say where it came from.
+- If the next task is genuinely ambiguous, use `AskUserQuestion` to confirm which to tee up — don't guess silently.
+
+## Step 3 — Recommend a session strategy
+
+Weigh these signals, then make **one** call with a one-line reason:
+
+| Signal | Pushes toward |
+|---|---|
+| Next task shares files / feature / mental model with what you just did | **Carry on** |
+| Context still has headroom (early-ish session, modest tool-call count) | **Carry on** |
+| Same thread continues, but the session is long / tool-call-heavy and most loaded context is now stale exploration | **Compact** |
+| Durable state lives in committed code + spec, not the conversation | **Compact** or **New session** |
+| Next task is a distinct unit — new phase, different subsystem, independent graph node | **New session** |
+| Current work is committed and the tree is clean | **New session** |
+
+The three outcomes:
+
+- **Carry on** — keep going in this session. Restarting would re-pay the cost of rebuilding context you still hold. Output the tighter prompt from Step 4 and just proceed.
+- **Compact** — `/compact` (or accept the `/strategic-compact` suggestion if it's pending) to shed stale context while keeping the thread, then continue. Use when the next task continues this work but the transcript is bloated.
+- **New session** — start clean with the standalone prompt from Step 4 (optionally `/session-start` first to load project context). Use when the next task is independent and current work is banked.
+
+If a `/strategic-compact` suggestion has already surfaced earlier in this session, treat it as concrete evidence of context pressure when deciding between Carry on and Compact. There's no live counter you can query mid-session — react only to a suggestion that actually appeared in the transcript.
+
+## Step 4 — Write the execution prompt
+
+Generate a prompt the user can paste to start the next task. Follow Claude Code prompting best practice: **explicit, specific, motivated, with files and a finish line.** Structure:
+
+```text
+**Task:** <one-line imperative — what to build>
+
+**Why / context:** <1–2 lines: what this builds on, why it matters now>
+
+**Relevant files & spec:**
+- <spec-dir>/{requirements,design,tasks}.md  (Task <ID>) — substitute the real spec directory located in Step 1 (`.claude/specs/`, `docs/specs/`, or `specs/`); never emit a hardcoded path that may not exist
+- <key source paths the task touches>
+
+**Do:**
+- <concrete steps, or: "Run /execute spec <slug>" to work the next task with full compliance review>
+- Respect docs/adr/ and CONTEXT.md vocabulary if present.
+
+**Constraints:** <what NOT to touch; invariants; scope edges>
+
+**Done when:** <acceptance criteria> — then /verify, then /ship.
+```
+
+Tailor it to the Step 3 call:
+- **New session** → make it **fully standalone**. The new session has no memory of this one: spell out the context, paths, and acceptance criteria so it stands alone.
+- **Carry on / Compact** → tighter is fine; reference what's already loaded, but still name the task, files, and finish line.
+
+Lean on existing skills rather than re-deriving: `/execute` to implement, `/verify` before PR, `/ship` to land. Don't pad the prompt with motivational filler — best-practice prompts are concrete, not verbose.
+
+## Step 5 — Render the roadmap visual
+
+Invoke the `/roadmap` skill (pass the spec slug if you have one) to (re)generate `docs/roadmap/`. It shows the just-finished work and where the next task sits in the dependency tree (critical path, what's parallelisable). Reference the produced file in your output; if `roadmap` renders an inline preview, let it.
+
+## Step 6 — Present
+
+Output, in this order, nothing more:
+
+1. **Recommendation:** `Carry on` / `Compact` / `New session` — one-line reason.
+2. **Next task:** the chosen task (+ alternates if any), and its place on the critical path.
+3. **Prompt:** the Step 4 prompt in a fenced block, ready to copy.
+4. **Roadmap:** path to `docs/roadmap/roadmap.html` (and the inline preview if shown).
+
+## Gotchas
+
+- **One recommendation, not a menu.** Make the call and give the reason. Offer the other options only if it's genuinely a coin-flip.
+- **Don't start coding.** This skill preps the next task; it doesn't execute it. The prompt is the handoff. (Exception: on a clear "carry on", you may proceed straight into the work after presenting.)
+- **Standalone prompts must actually stand alone.** The most common failure is a "new session" prompt that references "the bug we just fixed" — the new session can't see it. Inline the context.
+- **Status is read, never written.** Don't tick tasks in `tasks.md` here. Pull state; let `/execute` and `@doc-updater` record progress.

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: roadmap
+version: 1.0.0
+description: |
+  roadmap, show the roadmap, update the roadmap, where are we, project map,
+  what's done and what's next, dependency tree, critical path, spec roadmap,
+  visualise the plan, render the roadmap, generate roadmap.html.
+  Creates or updates a self-contained docs/roadmap/*.html from the project's
+  spec(s): what's finished, what's next, and the dependency tree — critical
+  path, sequential, and parallelisable work. Multi-spec aware.
+argument-hint: "[spec-slug]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - mcp__visualize__show_widget
+  - mcp__visualize__read_me
+---
+
+# Roadmap: render where we are and what's next
+
+Build (or refresh) a **self-contained HTML roadmap** at `docs/roadmap/` from the project's
+spec(s). It shows finished work, the next actionable tasks, and the dependency tree —
+**critical path**, **sequential** chains, and **parallelisable** work — so the plan is
+something you glance at, not a wall of task text.
+
+This skill is invoked two ways:
+- **Ad-hoc** — "show me the roadmap", "where are we" → parse the current spec state and re-render.
+- **From `/next-task`** — to produce the "what we just did / where the next task lies" visual.
+
+## Arguments
+
+- `/roadmap` — render every spec found. Single spec → `docs/roadmap/roadmap.html`. Multiple specs → a cross-spec `spec_roadmap.html` plus one `{spec_name}_roadmap.html` each, and `roadmap.html` as the index.
+- `/roadmap <spec-slug>` — render (or refresh) just that spec's `{spec_name}_roadmap.html`.
+
+## Output files (`docs/roadmap/`)
+
+| Situation | Files written |
+|---|---|
+| One spec (or none) | `roadmap.html` — the roadmap itself |
+| Multiple specs | `spec_roadmap.html` (portfolio: specs as nodes, inter-spec deps, which spec is on the critical path) · `{spec_name}_roadmap.html` per spec (in-spec phase/task tree) · `roadmap.html` (thin index linking to all of them) |
+
+Always create `docs/roadmap/` if it's missing. Never delete a `{spec_name}_roadmap.html` for a spec that still exists.
+
+## Step 1 — Locate the spec(s)
+
+Spec paths vary by project. Look in this order and use the first that has specs:
+
+```bash
+ls -d .claude/specs/*/ docs/specs/*/ specs/*/ 2>/dev/null
+```
+
+Also read `SPECLOG.md` if present — it indexes specs and their status. If `$ARGUMENTS` names a slug, target only that spec. **If no specs exist anywhere**, fall back to a freeform roadmap built from open GitHub issues / `TODO`s / the conversation, and tell the user there's no spec to anchor to (offer `/new-spec <slug>`).
+
+## Step 2 — Parse `tasks.md` into a task graph
+
+For each spec, read `tasks.md` and extract every task as a node:
+
+- **Phase** — the `## Phase N: …` header the task sits under.
+- **Status** — `[x]` or under `## Completed` → **done**; under `## Blocked` → **blocked**; `[ ]` otherwise → **open**.
+- **ID + deps** — the optional convention: a bold `**ID**` and a trailing `— deps: A, B`. (See the `tasks.md` template.) If a task has no `**ID**`, assign `P{phase}.{n}`.
+- **Label** — the task text with the ID/deps stripped.
+
+Also read `requirements.md` / `design.md` only if you need a one-line spec summary for the header — don't dump them.
+
+## Step 3 — Build the dependency tree (hybrid model)
+
+- **Explicit deps win.** If a task declares `deps:`, draw an edge from each dependency to it.
+- **Otherwise infer from phases.** Phases run in sequence; tasks within a phase run in parallel. So an un-annotated phase is a band of parallel siblings, gated by the previous phase completing. Don't draw N×M edges for this — represent it as the phase ordering (bands top-to-bottom), not a hairball.
+- **Derive the three classes:**
+  - **Critical path** — the longest dependency chain to the final task(s). Highlight its nodes and edges in the accent colour. With only phase inference, it's one representative task per phase, chained.
+  - **Parallelisable** — open tasks with no dependency path between them and all deps satisfied. These are the ones that could be picked up concurrently *right now*; badge them.
+  - **Sequential** — a chain where each task waits on the previous.
+- **Resolve "you are here":** the **next** tasks are open tasks whose deps are all done (ready to start). Mark them distinctly from blocked/not-yet-ready tasks.
+
+## Step 4 — Render the HTML
+
+Write a **single self-contained file** — no external scripts, fonts, or CDNs, so it opens offline and survives in the repo. Inline CSS + inline SVG for the dependency graph. It must adapt to light/dark via `prefers-color-scheme`. Use this skeleton (fill the marked regions; keep the token palette):
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{Project} — Roadmap</title>
+<style>
+  :root{
+    --bg:#fff; --panel:#f6f7f9; --text:#1a1a1a; --muted:#6b7280; --border:#e5e7eb;
+    --done:#16a34a; --next:#2563eb; --blocked:#dc2626; --todo:#9ca3af; --crit:#f59e0b;
+  }
+  @media (prefers-color-scheme:dark){
+    :root{ --bg:#0d1117; --panel:#161b22; --text:#e6edf3; --muted:#8b949e; --border:#30363d;
+           --done:#3fb950; --next:#58a6ff; --blocked:#f85149; --todo:#6e7681; --crit:#d29922; }
+  }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);
+    font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;padding:32px}
+  h1{font-size:22px;margin:0 0 4px} .sub{color:var(--muted);margin:0 0 20px}
+  .bar{height:10px;border-radius:6px;background:var(--border);overflow:hidden;margin:8px 0 24px}
+  .bar > i{display:block;height:100%;background:var(--done)}
+  .legend{display:flex;gap:16px;flex-wrap:wrap;color:var(--muted);font-size:13px;margin-bottom:20px}
+  .legend b{display:inline-block;width:10px;height:10px;border-radius:3px;margin-right:6px;vertical-align:middle}
+  .phase{margin:0 0 18px;padding:16px;background:var(--panel);border:1px solid var(--border);border-radius:12px}
+  .phase h2{font-size:14px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted);margin:0 0 12px}
+  .cards{display:flex;gap:12px;flex-wrap:wrap}
+  .card{flex:1 1 220px;min-width:200px;border:1px solid var(--border);border-left:4px solid var(--todo);
+    border-radius:10px;padding:12px;background:var(--bg)}
+  .card.done{border-left-color:var(--done)} .card.next{border-left-color:var(--next)}
+  .card.blocked{border-left-color:var(--blocked)} .card.crit{box-shadow:0 0 0 2px var(--crit) inset}
+  .card .id{font:12px ui-monospace,monospace;color:var(--muted)}
+  .card .t{margin:4px 0} .badge{font-size:11px;color:var(--muted)}
+  svg .edge{stroke:var(--border);stroke-width:2;fill:none;marker-end:url(#a)}
+  svg .edge.crit{stroke:var(--crit)} svg text{fill:var(--text);font-size:12px}
+</style>
+</head>
+<body>
+  <h1>{Project} — Roadmap</h1>
+  <p class="sub">{spec summary} · updated {YYYY-MM-DD} · {done}/{total} tasks complete</p>
+  <div class="bar"><i style="width:{pct}%"></i></div>
+  <div class="legend">
+    <span><b style="background:var(--done)"></b>Done</span>
+    <span><b style="background:var(--next)"></b>Next (ready)</span>
+    <span><b style="background:var(--todo)"></b>Not yet</span>
+    <span><b style="background:var(--blocked)"></b>Blocked</span>
+    <span><b style="background:var(--crit)"></b>Critical path</span>
+  </div>
+
+  <!-- DEPENDENCY GRAPH: inline SVG, viewBox sized to content. Nodes positioned
+       by phase (left→right or top→bottom). Critical-path nodes/edges use class="crit".
+       Include <defs><marker id="a">…</marker></defs> for arrowheads. Omit the SVG
+       entirely if the only structure is phase order with no explicit deps — the
+       phase cards below already convey it. -->
+  {svg-or-omit}
+
+  <!-- PHASE CARDS: one .phase per phase, .card per task with the right status class.
+       Add class="crit" to critical-path tasks. Show **next** tasks first within a phase. -->
+  {phase-sections}
+</body>
+</html>
+```
+
+Render rules:
+- Pass the date in (don't call `date` from a sandbox that forbids it — read it from `git log -1 --format=%cd --date=short` or the latest commit).
+- Keep node labels ≤6 words; the full task text lives in the card, not the SVG node.
+- If a spec has only phase-order structure (no explicit deps), **skip the SVG** — the phase cards already show the sequence. The graph earns its place only when there are real cross-task edges.
+- For the **multi-spec `spec_roadmap.html`**, nodes are specs (status = % complete), edges are inter-spec deps (from `design.md` "Dependencies" or SPECLOG), and the critical path is the longest spec chain.
+
+## Step 5 — Show it and report
+
+1. Write the file(s) and print the path(s): `docs/roadmap/roadmap.html`.
+2. Offer to open it: `open docs/roadmap/roadmap.html` (macOS) — don't run it unprompted.
+3. If `show_widget` is available and the user is in an interactive chat, render a **compact inline preview** (progress bar + the next-up tasks + critical path) so they see it without leaving the terminal. Follow the widget theming rules (CSS variables, transparent background) — call `mcp__visualize__read_me` first if unsure.
+4. End with a two-line summary: **Done** (last finished phase/tasks) and **Next** (the ready tasks, critical-path one first). Keep it short — the visual is the deliverable.
+
+## Gotchas
+
+- **Self-contained only.** No `<script src>`, no web fonts, no CDN. The file lives in the repo and must open with a double-click, offline, years later.
+- **Idempotent.** Re-rendering overwrites the roadmap file in place. Preserve any sibling files the user added to `docs/roadmap/`.
+- **Don't invent tasks or dates.** Status comes from `tasks.md` checkboxes and the Completed/Blocked sections, nothing else. If `tasks.md` is empty or all-template, say so rather than rendering a fake roadmap.
+- **Don't modify the spec.** This skill reads specs and writes HTML; it never edits `tasks.md`. (That's `/execute` and `@doc-updater`.)
+- **Naming is load-bearing.** Single spec → `roadmap.html`. Multiple → `spec_roadmap.html` + `{spec_name}_roadmap.html` + index. Match exactly so `/next-task` and links stay stable.

--- a/templates/specs/tasks.md
+++ b/templates/specs/tasks.md
@@ -1,5 +1,21 @@
 # Tasks: [Spec Name]
 
+<!--
+OPTIONAL dependency annotations — read by `/roadmap` to draw the dependency
+tree (critical path, sequential vs parallelisable). Plain `- [ ] ...` tasks
+still work; without annotations, /roadmap infers deps from phase order (phases
+run in sequence, tasks within a phase run in parallel).
+
+To annotate, give a task a bold **ID** and an optional trailing `— deps: …`:
+
+  - [ ] **T1** Scaffold the data model
+  - [ ] **T2** Build the API client — deps: T1
+  - [ ] **T3** Wire the UI — deps: T1, T2
+
+IDs are short and unique across the file (T1, API-1, whatever). `deps:` lists
+the IDs this task waits on. Mix annotated and plain tasks freely.
+-->
+
 ## Phase 1: [Phase Name]
 - [ ] Task description
 - [ ] Task description


### PR DESCRIPTION
## Summary

- **`/next-task`** — reads what just shipped (git log, working tree, spec task state), picks the next task off the active spec by dependency tree (critical path first), recommends **carry-on / compact / new session** from explicit signals, and writes a paste-ready execution prompt to Claude Code prompting best practice. Then renders the roadmap via `/roadmap`.
- **`/roadmap`** — creates/updates a self-contained `docs/roadmap/*.html` from the spec(s): finished work, ready-to-start tasks, and the dependency tree (critical path, sequential, parallelisable). Multi-spec aware (one spec → `roadmap.html`; many → a cross-spec `spec_roadmap.html` + per-spec files).
- **Global-behaviours mechanism** — `behaviors/*.md` merged by `installGlobalBehaviors()` into the user-global `~/.claude/CLAUDE.md` (marker-delimited, idempotent, with corrupted-marker repair and removal-on-empty). Installs from the single-target path, `--sync` (quiet in git-hook), and a standalone `--install-global-behaviors` flag. The `setup.cjs` smoke test sandboxes `HOME` so it never touches real home; the post-commit hook now watches `behaviors/`.
- **Two starter behaviours** — `visualise-over-verbose.md` (render structure as a diagram, not prose) and `code-comments.md` (functional present-tense comments — contracts, not debugging war-stories; bullets over dense paragraphs).
- Both skills registered in `base` + `monorepo-root`; `templates/specs/tasks.md` gains an optional `**ID** — deps:` convention that `/roadmap` reads.

## Pre-PR Gates

- ⚠ **PR size:** 530 insertions. Mostly additive — 292 lines are the two new `SKILL.md` docs, 90 the installer mechanism. One cohesive feature; not meaningfully splittable.
- **Test-presence:** calsuite has no unit-test harness — the installer smoke test is the test. It ran clean against a sandboxed HOME (target install + behaviours seed + idempotency + corrupted-marker repair all verified).
- **Spec-contract:** no matching spec for this branch — skipped.

## How It Works

```mermaid
flowchart TD
    B["behaviors/*.md<br/>(visualise-over-verbose, code-comments)"] --> IGB["installGlobalBehaviors()<br/>marker-delimited · idempotent · self-repairing"]
    C1["single-target install<br/>(announceNoop)"] --> IGB
    C2["--sync<br/>(quiet in git-hook)"] --> IGB
    C3["--install-global-behaviors"] --> IGB
    IGB --> HCM["~/.claude/CLAUDE.md<br/>loaded for every project"]
    SM["setup.cjs smoke test"] -.->|sandboxed HOME| NT["never touches real home"]
```

## Important Files

| File | Change |
|------|--------|
| `scripts/configure-claude.js` | `buildBehaviorsBlock()` + `installGlobalBehaviors()` (install / update / repair / remove); `--install-global-behaviors` flag; calls from single-target, `--sync`, and standalone |
| `scripts/setup.cjs` | Smoke test runs the installer under a sandboxed `HOME` so home-level writes (MCP, behaviours) stay disposable |
| `scripts/git-hooks/post-commit` | Watch `behaviors/` (and `--root` so a fresh repo's first commit syncs too) |
| `skills/next-task/SKILL.md` | New skill (128 lines) |
| `skills/roadmap/SKILL.md` | New skill (164 lines) |
| `behaviors/*.md` | Two behaviours + a `README.md` (excluded from the merge) |
| `config/profiles.json` | Register `next-task` + `roadmap` in `base` and `monorepo-root` |
| `templates/specs/tasks.md` | Optional `**ID** — deps:` dependency convention |
| `CLAUDE.md`, `README.md`, `CHANGELOG.md` | v2.56 + docs for the mechanism and skills |

## Test Results

| Suite | Result |
|-------|--------|
| `node -c` syntax (configure-claude.js, setup.cjs) | ✅ Clean |
| Installer smoke test (sandboxed HOME) | ✅ Target install + behaviours seed + idempotent no-op |
| Corrupted-marker repair (lone-BEGIN, END-before-BEGIN) | ✅ Converges to one block, prose preserved |
| Removal-on-empty (empty `behaviors/`) | ✅ Managed block stripped, user prose preserved, idempotent |
| Live activation (real post-commit `--sync`) | ✅ `~/.claude/CLAUDE.md` seeded with both behaviours |

## Pre-Landing Review

PASS (`@code-reviewer`). Verified the `installGlobalBehaviors` merge logic (all paths idempotent; corrupted-marker repair convergent), the four-caller survey (single-target / `--sync` / standalone flag / smoke test) for output-contract consistency, fresh-clone distributability (no hardcoded paths), and code↔docs consistency. No blocking findings. A prior 14-agent adversarial review surfaced 6 findings (smoke-test HOME sandboxing, marker-merge hardening, next-task spec-glob + non-hardcoded path, strategic-compact wording, README layout) — all fixed before this PR.

## Doc Completeness
- [x] CHANGELOG.md updated
- [x] CLAUDE.md updated (routing, structure, gotchas, skills inventory)
- [ ] tasks.md updated (no active spec for this work)

## Revision History

**Round 1** (2026-06-30):
- Accepted: 4 CodeRabbit comments —
  - `behaviors/README.md`: tagged the fenced marker example `text` (MD040 lint fix).
  - `installGlobalBehaviors()`: now removes the managed block when `behaviors/` is present-but-empty, so deleting the last behaviour propagates (an *absent* dir is left untouched — partial checkout, not a removal). Prose-preserving and idempotent.
  - `post-commit`: `git diff-tree --root` so a fresh repo's initial commit triggers the sync too.
  - `setup.cjs`: corrected next-steps wording — the smoke test seeds into a sandboxed HOME, not "does not seed".
- Pushed back: 0
- Questions answered: 0
- Also merged `origin/main` (resolved 3 doc-only conflicts from #132; renumbered 2.54 → **2.56** since 2.54/2.55 were taken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `/next-task` workflow to pick the next item from a spec’s task tree and generate a ready-to-use execution prompt.
  * Added a `/roadmap` workflow that creates offline, dark-mode-friendly HTML roadmaps from task files.
  * Introduced support for global behavior snippets that are merged into the local Claude configuration.

* **Documentation**
  * Updated setup and usage docs to cover the new workflows and global behavior installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
