### PR TITLE
test: verify afk-enroll fires (throwaway — do not merge)

### DIFF
--- a/AFK_ENROLL_SMOKE.md
+++ b/AFK_ENROLL_SMOKE.md
@@ -1,0 +1,3 @@
+# afk-enroll smoke test
+
+Throwaway PR to confirm the afk-enroll Action auto-labels new PRs `auto:needs-review`. Close, do not merge.


### PR DESCRIPTION
Throwaway to confirm afk-enroll labels new PRs auto:needs-review. Will close once verified.