### PR TITLE
fix(skills): dogfood-hardening for /roadmap + /next-task (v2.57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to this repository.
 
-Current version: **2.56**
+Current version: **2.57**
+
+## [2.57] — 2026-07-14
+
+### Fixed
+
+- **`/roadmap` and `/next-task` spec discovery aborted under zsh.** Both located specs with `ls -d .claude/specs/*/ docs/specs/*/ specs/*/` — but zsh's `nomatch` aborts the whole line (printing a "no matches found" error that `2>/dev/null` can't suppress, since it fires during word-expansion before the redirect applies) whenever any of the three paths is absent. So on any project without all three spec dirs (nearly all of them) both skills found **zero** specs and fell into their no-spec fallback. Replaced with `find … -type d`, which handles absent *and* existing-but-empty spec dirs cleanly in both shells. Found by dogfooding the skills for #135; reproduced live in zsh.
+
+### Changed
+
+- **`/roadmap` → v1.1.0: the SVG dependency-graph path is now actually specified.** The skeleton couldn't render a node (only `.edge`/`text` were styled); added node CSS, the status-dot + amber-critical-border encoding, and `fill="context-stroke"` arrowheads so critical-path edges get amber heads. Added a **Graph layout** rules block (bands by phase, ≤12-node cap with card fallback, "no arrow through a non-endpoint node", ID-only labels, viewBox/`role`), handling for design-only spec dirs (no `tasks.md`), and completed the body CSS (max-width, links, inline `code`).
+- **`/next-task` → v1.0.1:** the shared glob fix, plus a rule for picking the active spec when several exist and no `SPECLOG`/slug disambiguates.
 
 ## [2.56] — 2026-06-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration repo (dotfiles-style). Hooks, commands, scripts, plugins, skills, and agents that bootstrap new projects.
 
-**Version: 2.56** — full history in [CHANGELOG.md](./CHANGELOG.md).
+**Version: 2.57** — full history in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Routing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Personal Claude Code configuration — hooks, commands, scripts, plugins, skills, and agents.
 
-**Version: 2.56**
+**Version: 2.57**
 
 ## Getting started
 

--- a/skills/next-task/SKILL.md
+++ b/skills/next-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: next-task
-version: 1.0.0
+version: 1.0.1
 description: |
   next task, what's next, what should I do next, generate the next prompt,
   hand off to the next task, kick off the next piece, should I start a new
@@ -46,7 +46,8 @@ git diff --stat
 ```
 
 - What did the recent commits / working tree actually change? Which files, which feature?
-- Find the active spec: `ls -d .claude/specs/*/ docs/specs/*/ specs/*/ 2>/dev/null` and check `SPECLOG.md`. Which tasks in `tasks.md` are now `[x]` or in `## Completed`? **Remember the directory you find** — Step 4 and the `/roadmap` call in Step 5 both reference it. (Same three locations `/roadmap` searches, so the two skills agree.)
+- Find the active spec with `find .claude/specs docs/specs specs -mindepth 1 -maxdepth 1 -type d 2>/dev/null`, then check `SPECLOG.md`. (A bare `ls -d .claude/specs/*/ docs/specs/*/ specs/*/` aborts the whole line under zsh when any path is missing, and a per-dir glob still leaks a nomatch error on an empty spec dir — `find` avoids both.) Which tasks in `tasks.md` are now `[x]` or in `## Completed`? **Remember the directory you find** — Step 4 and the `/roadmap` call in Step 5 both reference it. (Same locations `/roadmap` searches, so the two skills agree.)
+- **Multiple specs, no slug?** If discovery finds several and neither `SPECLOG.md` nor a `$ARGUMENTS` slug singles one out, pick the spec whose open tasks line up with the recent commits (else the most-recently-touched `tasks.md`); if it's still a toss-up, `AskUserQuestion` rather than guess silently.
 - Is the tree clean (work committed/shipped) or dirty (mid-task)? This drives the session call in Step 3.
 
 ## Step 2 — Pick the next task

--- a/skills/roadmap/SKILL.md
+++ b/skills/roadmap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: roadmap
-version: 1.0.0
+version: 1.1.0
 description: |
   roadmap, show the roadmap, update the roadmap, where are we, project map,
   what's done and what's next, dependency tree, critical path, spec roadmap,
@@ -50,14 +50,18 @@ Always create `docs/roadmap/` if it's missing. Never delete a `{spec_name}_roadm
 Spec paths vary by project. Look in this order and use the first that has specs:
 
 ```bash
-ls -d .claude/specs/*/ docs/specs/*/ specs/*/ 2>/dev/null
+# `find` sidesteps the zsh nomatch trap: a bare `ls -d a/*/ b/*/ c/*/` aborts the whole
+# line (finding nothing) when any path is missing, and a per-dir glob still leaks a
+# "no matches found" error on an existing-but-empty spec dir. find handles absent AND
+# empty dirs cleanly in both bash and zsh.
+find .claude/specs docs/specs specs -mindepth 1 -maxdepth 1 -type d 2>/dev/null
 ```
 
 Also read `SPECLOG.md` if present — it indexes specs and their status. If `$ARGUMENTS` names a slug, target only that spec. **If no specs exist anywhere**, fall back to a freeform roadmap built from open GitHub issues / `TODO`s / the conversation, and tell the user there's no spec to anchor to (offer `/new-spec <slug>`).
 
 ## Step 2 — Parse `tasks.md` into a task graph
 
-For each spec, read `tasks.md` and extract every task as a node:
+For each spec, read `tasks.md` and extract every task as a node. **A spec dir with no `tasks.md` (design-only) isn't renderable** — in multi-spec mode list it in `spec_roadmap.html` as "design only (no tasks yet)"; in single-spec mode say so and offer `/plan` to add tasks. In both cases, skip it from the node extraction below. For each renderable spec:
 
 - **Phase** — the `## Phase N: …` header the task sits under.
 - **Status** — `[x]` or under `## Completed` → **done**; under `## Blocked` → **blocked**; `[ ]` otherwise → **open**.
@@ -96,9 +100,9 @@ Write a **single self-contained file** — no external scripts, fonts, or CDNs, 
     :root{ --bg:#0d1117; --panel:#161b22; --text:#e6edf3; --muted:#8b949e; --border:#30363d;
            --done:#3fb950; --next:#58a6ff; --blocked:#f85149; --todo:#6e7681; --crit:#d29922; }
   }
-  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--text);
+  *{box-sizing:border-box} body{margin:0 auto;max-width:1000px;background:var(--bg);color:var(--text);
     font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;padding:32px}
-  h1{font-size:22px;margin:0 0 4px} .sub{color:var(--muted);margin:0 0 20px}
+  h1{font-size:22px;margin:0 0 4px} .sub{color:var(--muted);margin:0 0 20px} a{color:var(--next)}
   .bar{height:10px;border-radius:6px;background:var(--border);overflow:hidden;margin:8px 0 24px}
   .bar > i{display:block;height:100%;background:var(--done)}
   .legend{display:flex;gap:16px;flex-wrap:wrap;color:var(--muted);font-size:13px;margin-bottom:20px}
@@ -111,9 +115,14 @@ Write a **single self-contained file** — no external scripts, fonts, or CDNs, 
   .card.done{border-left-color:var(--done)} .card.next{border-left-color:var(--next)}
   .card.blocked{border-left-color:var(--blocked)} .card.crit{box-shadow:0 0 0 2px var(--crit) inset}
   .card .id{font:12px ui-monospace,monospace;color:var(--muted)}
-  .card .t{margin:4px 0} .badge{font-size:11px;color:var(--muted)}
+  .card .t{margin:4px 0} .card .t code{font:12px ui-monospace,monospace;background:var(--panel);padding:1px 4px;border-radius:4px}
+  .badge{font-size:11px;color:var(--muted)}
+  svg{width:100%;height:auto;display:block}
   svg .edge{stroke:var(--border);stroke-width:2;fill:none;marker-end:url(#a)}
-  svg .edge.crit{stroke:var(--crit)} svg text{fill:var(--text);font-size:12px}
+  svg .edge.crit{stroke:var(--crit);stroke-width:2.5}
+  svg .node rect{fill:var(--bg);stroke:var(--border);stroke-width:1.5}
+  svg .node.crit rect{stroke:var(--crit);stroke-width:2.5}
+  svg .node text{fill:var(--text);font:12px ui-monospace,monospace;text-anchor:middle;dominant-baseline:middle}
 </style>
 </head>
 <body>
@@ -128,11 +137,18 @@ Write a **single self-contained file** — no external scripts, fonts, or CDNs, 
     <span><b style="background:var(--crit)"></b>Critical path</span>
   </div>
 
-  <!-- DEPENDENCY GRAPH: inline SVG, viewBox sized to content. Nodes positioned
-       by phase (left→right or top→bottom). Critical-path nodes/edges use class="crit".
-       Include <defs><marker id="a">…</marker></defs> for arrowheads. Omit the SVG
-       entirely if the only structure is phase order with no explicit deps — the
-       phase cards below already convey it. -->
+  <!-- DEPENDENCY GRAPH — draw ONLY when there are explicit cross-task deps; omit for
+       phase-order-only specs (the cards already convey those). viewBox sized to content;
+       positioning is in "Graph layout" below. Markup pattern:
+         <defs><marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7"
+           markerHeight="7" orient="auto"><path d="M0,0 L10,5 L0,10 z" fill="context-stroke"/></marker></defs>
+         edge:  <line class="edge" .../>          <line class="edge crit" .../>   (crit = on critical path)
+         node:  <g class="node[ crit]"><rect x y width height rx="7"/>
+                  <circle cx cy r="4" fill="var(--STATUS)"/>   STATUS = done|next|blocked|todo
+                  <text x y>ID</text></g>
+       Encoding: the node OUTLINE marks the critical path (amber via .crit); the status
+       DOT marks done/next/blocked/todo — so a ready critical task shows an amber border
+       AND a blue dot. fill="context-stroke" makes each arrowhead match its edge colour. -->
   {svg-or-omit}
 
   <!-- PHASE CARDS: one .phase per phase, .card per task with the right status class.
@@ -147,6 +163,13 @@ Render rules:
 - Keep node labels ≤6 words; the full task text lives in the card, not the SVG node.
 - If a spec has only phase-order structure (no explicit deps), **skip the SVG** — the phase cards already show the sequence. The graph earns its place only when there are real cross-task edges.
 - For the **multi-spec `spec_roadmap.html`**, nodes are specs (status = % complete), edges are inter-spec deps (from `design.md` "Dependencies" or SPECLOG), and the critical path is the longest spec chain.
+
+**Graph layout (when you draw the SVG):**
+- **Bands by phase.** One horizontal band per phase, top→bottom in phase order; give each node in a band an evenly-spaced x-slot (~140px apart, first at x≈110). Push blocked/side tasks to an outer x-slot so their edges don't cut through the main columns.
+- **Keep it small — ≤ ~12 nodes.** Past that the hand-layout gets unreliable; render phase cards only and skip the SVG.
+- **No arrow through a non-endpoint node.** After placing nodes, walk each edge: if the straight segment would cross another node's box, move a node rather than let the arrow pass through. Favour short vertical edges within a column and gentle diagonals between bands.
+- **ID-only node labels** (`T1`, `P2.1`); the task text lives in the card.
+- **viewBox** width ~600 — but widen it if any band has more than ~4 nodes rather than compressing the x-spacing; height = the last band's bottom + ~30; `svg{width:100%;height:auto}` scales it. Give the `<svg>` `role="img"` + an `aria-label` naming the critical path.
 
 ## Step 5 — Show it and report
 


### PR DESCRIPTION
## Summary

Two skill fixes surfaced by **dogfooding `/roadmap` and `/next-task` end-to-end** (issue #135):

- **🔴 Spec discovery aborted under zsh.** Both skills located specs with `ls -d .claude/specs/*/ docs/specs/*/ specs/*/`. Under zsh, `nomatch` aborts the *entire* line when any of the three paths is absent (with a visible error `2>/dev/null` can't suppress — it fires during word-expansion). So on any project lacking all three spec dirs — nearly all of them — **both skills found zero specs and silently fell into their no-spec fallback.** Replaced with `find … -mindepth 1 -maxdepth 1 -type d`, which is clean for absent *and* existing-but-empty spec dirs in both bash and zsh. Reproduced live in zsh; static review had missed it.
- **`/roadmap` → v1.1.0:** the SVG dependency-graph path is now actually specified — node CSS (the skeleton couldn't render a node), status-dot + amber-critical-border encoding, `context-stroke` arrowheads, a **Graph layout** rules block (bands by phase, ≤12-node cap with card fallback, no-arrow-through-a-box, viewBox-widen fallback), design-only spec handling, completed body CSS.
- **`/next-task` → v1.0.1:** the shared glob fix plus an active-spec disambiguation rule for when several specs exist and no `SPECLOG`/slug picks one.

## Important Files

| File | Change |
|------|--------|
| `skills/roadmap/SKILL.md` | `find`-based discovery; complete SVG graph spec (node CSS, encoding, layout rules); design-only handling |
| `skills/next-task/SKILL.md` | `find`-based discovery; multi-spec disambiguation |
| `CHANGELOG.md`, `CLAUDE.md`, `README.md` | v2.57 |

## Test Results

| Check | Result |
|-------|--------|
| zsh repro of the discovery bug + `find` fix (absent / empty / populated) | ✅ `find` clean in bash + zsh; old glob leaked/aborted |
| Installer smoke test (sandboxed HOME) — changed skills still distribute | ✅ exit 0, both skills copied |
| `/roadmap` render dogfood (multi-spec + deps-graph synthetic spec) | ✅ valid self-contained HTML, all edges routed clean |
| `/next-task` dogfood (partial spec) | ✅ picks critical-path task + parallel alternates |

## Pre-Landing Review

PASS (`@code-reviewer`). Notably **caught a residual bug in the first fix** — the initial per-dir loop still leaked a zsh `no matches found` on an existing-but-empty spec dir — which is why this ships the `find` form instead. Also fixed on its feedback: a viewBox-width fallback for wide bands, a dangling "Otherwise" in the design-only rule, and inaccurate changelog wording about `2>/dev/null`. Remaining notes were cosmetic (`context-stroke` degrades to a default-colour arrowhead on old Safari) and left as-is.

## Doc Completeness
- [x] CHANGELOG.md updated (v2.57)
- [x] CLAUDE.md / README.md version bumped
- [x] Skill `version:` frontmatter bumped (roadmap 1.1.0, next-task 1.0.1)

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)